### PR TITLE
feat: add search command and optional skills.sh driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,13 @@ glob = "0.3"
 dialoguer = { version = "0.11", default-features = false }
 which = "6"
 
+[features]
+default = []
+# Opt-in driver for the skills.sh remote index. Requires a personal API key via
+# ZSKILLS_SKILLS_SH_API_KEY at runtime. Off by default — the binary stays vanilla
+# unless you ask for it: `cargo install zskills --features skills-sh`.
+skills-sh = []
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/README.md
+++ b/README.md
@@ -135,13 +135,40 @@ zskills migrate-all ~/Desktop/code --threshold 2 -y    # non-interactive (no sou
 - **Git is shelled out.** Reuses your credential helpers; no `libgit2` to bundle.
 - **No async network unless needed.** Marketplace caches live on disk; `git pull` does the work.
 
+## Optional features
+
+`zskills` ships vanilla by default — the binary only talks to local marketplace caches you already trust. Optional capabilities are gated behind cargo features so they aren't even compiled in unless you ask for them.
+
+| Feature | What it adds | How to enable |
+|---|---|---|
+| `skills-sh` | Federated `search` + `install` against the [skills.sh](https://www.skills.sh) remote index. Registers a `remote-index` source type, dispatches to its REST API, requires `ZSKILLS_SKILLS_SH_API_KEY` at runtime. | `cargo install --git https://github.com/zot24/zskills --features skills-sh` |
+
+Without the feature, `zskills marketplace add skills.sh` returns *"unrecognized marketplace source"* — no dormant code paths, no env-var detection, nothing.
+
 ## Status
+
+v0.6 — `search <query>` across registered marketplaces, `marketplace add-recommended` seeder for trusted defaults, optional `skills-sh` federation behind a cargo feature.
 
 v0.3 — adds `migrate-skill` (promote ONE skill across all projects in a tree) and `migrate-all` (interactive sweep with per-skill prompts for source + cleanup). Agent skill entries now support optional `source` (local-only entries are valid). Manifest writes preserve existing comments via `toml_edit`.
 
 v0.2 — declarative `sync` for both plugins and Agent Skills, scan/migrate over both, atomic settings.json round-trip, doctor reconciliation across all three states (settings, inventory, disk).
 
-Lockfile semantics, `info`/`search`, and full version pinning still to come.
+Lockfile semantics, `info`, and full version pinning still to come.
+
+## Roadmap: third-party marketplace drivers
+
+The `skills-sh` cargo feature is a holding pattern for *"one known remote index, ship it as opt-in code."* It's the right shape today; it stops being the right shape if two or three other remote indexes want to plug in.
+
+When that happens, the planned move is a **subprocess plugin protocol** rather than more cargo features:
+
+- Drivers ship as separate binaries on `$PATH`, named `zskills-driver-<name>` (git-style extension pattern).
+- Marketplaces with `source.source = "remote-index"` get matched to a driver by URL host (or an explicit `driver` field on the entry).
+- zskills exec's the driver with a JSON request on stdin (`{"method": "search", "params": {"query": "stripe", "limit": 25}}`) and reads a JSON response from stdout. Methods: `search`, `resolve` (slug → install coordinates), and optionally `audit`.
+- Drivers can be written in any language, version independently, and ship under their own trust models.
+
+What this buys: third parties can publish drivers without forking zskills, and the core binary doesn't grow with each new index. What it costs: a stable wire protocol commitment, subprocess overhead, and a public surface to support long-term. **It's worth it once there are at least two or three confirmed driver consumers** — building it for one half-confirmed consumer (skills.sh, gated behind API keys) is premature abstraction. Until then, `--features skills-sh` is the right ergonomic.
+
+If you maintain a remote index that would want to plug in, [open an issue](https://github.com/zot24/zskills/issues) so we can size demand.
 
 ## Sister project
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -163,12 +163,29 @@ pub enum Command {
     /// Marketplace (tap) management
     #[command(subcommand)]
     Marketplace(MarketplaceCmd),
+
+    /// Search registered marketplaces by keyword (substring-match on name + description)
+    Search {
+        /// Query string
+        query: String,
+
+        /// Max results to return per marketplace
+        #[arg(long, default_value_t = 25)]
+        limit: u32,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
 pub enum MarketplaceCmd {
     /// Add a marketplace tap (owner/repo or full git URL)
     Add { source: String },
+
+    /// Seed the recommended trusted marketplaces (anthropics/claude-plugins-official)
+    AddRecommended,
 
     /// Remove a marketplace tap
     Remove { name: String },
@@ -223,6 +240,9 @@ impl Cli {
                 dry_run,
             } => crate::commands::migrate_all::run(dir, threshold, yes, dry_run),
             Command::Marketplace(cmd) => crate::commands::marketplace::run(cmd),
+            Command::Search { query, limit, json } => {
+                crate::commands::search::run(query, limit, json)
+            }
         }
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,10 +1,12 @@
-//! `install <name>[@marketplace]...` — adds to enabledPlugins.
+//! `install <name>[@marketplace]...` — adds to enabledPlugins for plugin marketplaces.
 //!
-//! v1 strategy: we don't fetch bytes ourselves — we delegate the actual download to
-//! Claude Code by flipping enabledPlugins. Claude Code's startup install path will
-//! materialize the bytes from the marketplace tap on next launch (or via /plugin install).
+//! Plugin path (always on): we don't fetch bytes ourselves — we flip enabledPlugins and
+//! let Claude Code's startup install path materialize them on next launch.
 //!
-//! Future v1.1: shell out to `claude plugin install` for synchronous install when present.
+//! Skills.sh fallback (cargo feature `skills-sh`): when local resolution fails AND the
+//! skills.sh remote index is registered AND `ZSKILLS_SKILLS_SH_API_KEY` is set, we shell
+//! through `agent_skill::install` to clone the source repo and drop SKILL.md into
+//! ~/.claude/skills/<name>/.
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
@@ -23,6 +25,7 @@ pub fn run(specs: Vec<String>) -> Result<()> {
 
     let settings_path = crate::paths::settings_json()?;
     let mut settings = crate::settings::load(&settings_path)?;
+    let mut settings_dirty = false;
 
     let mut count = 0;
     for spec in &specs {
@@ -30,20 +33,85 @@ pub fn run(specs: Vec<String>) -> Result<()> {
             Ok(qualified) => {
                 let ep = crate::settings::enabled_plugins_mut(&mut settings);
                 ep.insert(qualified.clone(), Value::Bool(true));
+                settings_dirty = true;
                 println!("{} {}", "+".green(), qualified);
                 count += 1;
             }
-            Err(e) => {
-                eprintln!("{} {}: {}", "✗".red(), spec, e);
-            }
+            Err(plugin_err) => match try_install_from_remote(spec, &known) {
+                Ok(true) => count += 1,
+                Ok(false) => {
+                    eprintln!("{} {}: {}", "✗".red(), spec, plugin_err);
+                }
+                Err(remote_err) => {
+                    eprintln!(
+                        "{} {}: {} (remote index also failed: {})",
+                        "✗".red(),
+                        spec,
+                        plugin_err,
+                        remote_err
+                    );
+                }
+            },
         }
     }
 
-    crate::settings::save(&settings_path, &settings)?;
-    println!(
-        "\nWrote {} entry/entries to {}.\nRestart Claude Code (or run `/plugin marketplace update` and `/plugin install ...`) to fetch the bytes.",
-        count,
-        settings_path.display()
-    );
+    if settings_dirty {
+        crate::settings::save(&settings_path, &settings)?;
+        println!(
+            "\nWrote {} plugin entry/entries to {}.\nRestart Claude Code (or run `/plugin marketplace update` and `/plugin install ...`) to fetch the bytes.",
+            count,
+            settings_path.display()
+        );
+    } else if count > 0 {
+        println!(
+            "\nInstalled {} agent skill(s) into {}.",
+            count,
+            crate::paths::user_skills_dir()?.display()
+        );
+    }
     Ok(())
+}
+
+/// Returns Ok(true) if the spec was installed via a remote index, Ok(false) if no remote
+/// driver matched (and the caller should surface the plugin error), or Err if a driver
+/// was selected but failed.
+#[cfg(feature = "skills-sh")]
+fn try_install_from_remote(
+    spec: &str,
+    known: &serde_json::Map<String, Value>,
+) -> Result<bool> {
+    let has_skills_sh = known.values().any(|entry| {
+        crate::commands::marketplace::is_remote_index(entry)
+            && entry
+                .get("source")
+                .and_then(|s| s.get("url"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|u| u.contains("skills.sh"))
+    });
+    if !has_skills_sh || !crate::skills_sh::has_api_key() {
+        return Ok(false);
+    }
+    let slug = spec.split_once('@').map(|(n, _)| n).unwrap_or(spec);
+    let results = crate::skills_sh::search(slug, 25)?;
+    let Some(hit) = results.iter().find(|r| r.slug == slug) else {
+        return Ok(false);
+    };
+    let installed = crate::agent_skill::install(&hit.source, Some(&hit.slug))?;
+    for name in &installed {
+        println!(
+            "{} {} {}",
+            "+".green(),
+            name,
+            format!("[skill via skills.sh — {}]", hit.source).dimmed()
+        );
+    }
+    Ok(!installed.is_empty())
+}
+
+#[cfg(not(feature = "skills-sh"))]
+fn try_install_from_remote(
+    _spec: &str,
+    _known: &serde_json::Map<String, Value>,
+) -> Result<bool> {
+    Ok(false)
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -15,7 +15,7 @@ pub fn run(specs: Vec<String>) -> Result<()> {
     if known.is_empty() {
         println!(
             "{}",
-            "No marketplaces registered. Run `zskills marketplace add <owner/repo>` first."
+            "No marketplaces registered. Run `zskills marketplace add-recommended` first."
                 .yellow()
         );
         return Ok(());

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -17,8 +17,7 @@ pub fn run(specs: Vec<String>) -> Result<()> {
     if known.is_empty() {
         println!(
             "{}",
-            "No marketplaces registered. Run `zskills marketplace add-recommended` first."
-                .yellow()
+            "No marketplaces registered. Run `zskills marketplace add-recommended` first.".yellow()
         );
         return Ok(());
     }
@@ -76,10 +75,7 @@ pub fn run(specs: Vec<String>) -> Result<()> {
 /// driver matched (and the caller should surface the plugin error), or Err if a driver
 /// was selected but failed.
 #[cfg(feature = "skills-sh")]
-fn try_install_from_remote(
-    spec: &str,
-    known: &serde_json::Map<String, Value>,
-) -> Result<bool> {
+fn try_install_from_remote(spec: &str, known: &serde_json::Map<String, Value>) -> Result<bool> {
     let has_skills_sh = known.values().any(|entry| {
         crate::commands::marketplace::is_remote_index(entry)
             && entry
@@ -109,9 +105,6 @@ fn try_install_from_remote(
 }
 
 #[cfg(not(feature = "skills-sh"))]
-fn try_install_from_remote(
-    _spec: &str,
-    _known: &serde_json::Map<String, Value>,
-) -> Result<bool> {
+fn try_install_from_remote(_spec: &str, _known: &serde_json::Map<String, Value>) -> Result<bool> {
     Ok(false)
 }

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -4,6 +4,12 @@ use serde_json::{json, Map, Value};
 
 use crate::cli::MarketplaceCmd;
 
+/// Built-in remote indexes. Registered without a git clone; search/install dispatch on
+/// `source.source == "remote-index"` and `source.url`. Each driver lives behind its own
+/// cargo feature so the binary stays vanilla unless you opt in.
+#[cfg(feature = "skills-sh")]
+const REMOTE_INDEX_SKILLS_SH: &str = "skills.sh";
+
 pub fn run(cmd: MarketplaceCmd) -> Result<()> {
     match cmd {
         MarketplaceCmd::Add { source } => add(source),
@@ -15,6 +21,10 @@ pub fn run(cmd: MarketplaceCmd) -> Result<()> {
 }
 
 fn add(source: String) -> Result<()> {
+    #[cfg(feature = "skills-sh")]
+    if source == REMOTE_INDEX_SKILLS_SH {
+        return add_remote_index(REMOTE_INDEX_SKILLS_SH, "https://skills.sh");
+    }
     let (name, repo_url) = parse_source(&source)?;
     let path = crate::paths::known_marketplaces_json()?;
     let mut known = crate::marketplace::load_known(&path)?;
@@ -76,7 +86,49 @@ fn add_recommended() -> Result<()> {
             e
         );
     }
+    #[cfg(feature = "skills-sh")]
+    println!(
+        "\n{}",
+        "Tip: skills.sh federation is opt-in. Add it with `zskills marketplace add skills.sh` and set ZSKILLS_SKILLS_SH_API_KEY."
+            .dimmed()
+    );
     Ok(())
+}
+
+#[cfg(feature = "skills-sh")]
+fn add_remote_index(name: &str, url: &str) -> Result<()> {
+    let path = crate::paths::known_marketplaces_json()?;
+    let mut known = crate::marketplace::load_known(&path)?;
+
+    let mut entry = Map::new();
+    entry.insert(
+        "source".into(),
+        json!({ "source": "remote-index", "url": url }),
+    );
+    entry.insert("autoUpdate".into(), Value::Bool(false));
+    known.insert(name.to_string(), Value::Object(entry));
+    crate::marketplace::save_known(&path, &known)?;
+
+    // Don't mirror into settings.json extraKnownMarketplaces — Claude Code won't recognize
+    // remote-index entries. They're purely zskills-internal.
+    println!(
+        "{} added remote index {} ({})",
+        "✓".green(),
+        name.bold(),
+        url
+    );
+    Ok(())
+}
+
+/// Recognize a remote-index entry by its JSON shape. Non-feature-gated so older configs
+/// (entries written by a `skills-sh`-enabled build) are still tolerated when the feature
+/// is off — we just skip them in list/update rather than crashing.
+pub(crate) fn is_remote_index(entry: &Value) -> bool {
+    entry
+        .get("source")
+        .and_then(|s| s.get("source"))
+        .and_then(|v| v.as_str())
+        == Some("remote-index")
 }
 
 fn parse_source(source: &str) -> Result<(String, String)> {
@@ -132,6 +184,20 @@ fn list(as_json: bool) -> Result<()> {
         return Ok(());
     }
     for (name, entry) in &known {
+        if is_remote_index(entry) {
+            let url = entry
+                .get("source")
+                .and_then(|s| s.get("url"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            println!(
+                "  {}  {} {}",
+                name.bold(),
+                "[remote-index]".cyan(),
+                url.dimmed()
+            );
+            continue;
+        }
         let count = crate::marketplace::load_manifest(&crate::paths::marketplace_manifest(name)?)
             .map(|m| m.plugins.len())
             .unwrap_or(0);
@@ -160,6 +226,9 @@ fn update(name: Option<String>) -> Result<()> {
         None => known.keys().cloned().collect(),
     };
     for n in &targets {
+        if known.get(n).is_some_and(is_remote_index) {
+            continue;
+        }
         let repo = crate::paths::marketplaces_dir()?.join(n);
         if !repo.exists() {
             continue;

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -7,6 +7,7 @@ use crate::cli::MarketplaceCmd;
 pub fn run(cmd: MarketplaceCmd) -> Result<()> {
     match cmd {
         MarketplaceCmd::Add { source } => add(source),
+        MarketplaceCmd::AddRecommended => add_recommended(),
         MarketplaceCmd::Remove { name } => remove(name),
         MarketplaceCmd::List { json: as_json } => list(as_json),
         MarketplaceCmd::Update { name } => update(name),
@@ -63,6 +64,18 @@ fn add(source: String) -> Result<()> {
     crate::settings::save(&settings_path, &settings)?;
 
     println!("{} added marketplace {}", "✓".green(), name);
+    Ok(())
+}
+
+fn add_recommended() -> Result<()> {
+    println!("Seeding recommended marketplaces ...");
+    if let Err(e) = add("anthropics/claude-plugins-official".to_string()) {
+        eprintln!(
+            "  {} anthropics/claude-plugins-official: {}",
+            "✗".red(),
+            e
+        );
+    }
     Ok(())
 }
 

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -80,11 +80,7 @@ fn add(source: String) -> Result<()> {
 fn add_recommended() -> Result<()> {
     println!("Seeding recommended marketplaces ...");
     if let Err(e) = add("anthropics/claude-plugins-official".to_string()) {
-        eprintln!(
-            "  {} anthropics/claude-plugins-official: {}",
-            "✗".red(),
-            e
-        );
+        eprintln!("  {} anthropics/claude-plugins-official: {}", "✗".red(), e);
     }
     #[cfg(feature = "skills-sh")]
     println!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod migrate_all;
 pub mod migrate_skill;
 pub mod remove;
 pub mod scan;
+pub mod search;
 pub mod sync;
 pub mod update;
 pub mod upgrade;

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,0 +1,129 @@
+//! `search <query>` — keyword search across registered marketplaces.
+//!
+//! Reads each marketplace's cached `marketplace.json` and substring-matches `query`
+//! against `name + description`. No network calls; purely local.
+
+use anyhow::Result;
+use owo_colors::OwoColorize;
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Serialize)]
+pub struct Hit {
+    pub name: String,
+    pub description: String,
+    pub marketplace: String,
+}
+
+pub fn run(query: String, limit: u32, as_json: bool) -> Result<()> {
+    let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    if known.is_empty() {
+        println!(
+            "{}",
+            "No marketplaces registered. Run `zskills marketplace add-recommended` to seed the defaults."
+                .yellow()
+        );
+        return Ok(());
+    }
+
+    let mut hits: Vec<Hit> = Vec::new();
+    let query_lc = query.to_lowercase();
+
+    for mp_name in known.keys() {
+        match local_search(mp_name, &query_lc, limit as usize) {
+            Ok(mut local_hits) => hits.append(&mut local_hits),
+            Err(e) => eprintln!(
+                "{} {}: {}",
+                "✗".red(),
+                mp_name,
+                format!("local search failed: {}", e).dimmed()
+            ),
+        }
+    }
+
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&hits)?);
+        return Ok(());
+    }
+
+    if hits.is_empty() {
+        println!("(no matches for {:?})", query);
+        return Ok(());
+    }
+
+    for h in &hits {
+        println!(
+            "  {} {}  {}",
+            "[plugin]".green(),
+            h.name.bold(),
+            short(&h.description, 80).dimmed(),
+        );
+        println!("           {}", format!("from {}", h.marketplace).dimmed());
+    }
+    println!("\n{}", format!("{} result(s)", hits.len()).dimmed());
+    Ok(())
+}
+
+fn local_search(mp_name: &str, query_lc: &str, limit: usize) -> Result<Vec<Hit>> {
+    let manifest_path = crate::paths::marketplace_manifest(mp_name)?;
+    if !manifest_path.exists() {
+        return Ok(Vec::new());
+    }
+    let bytes = std::fs::read(&manifest_path)?;
+    let manifest: Value = serde_json::from_slice(&bytes)?;
+    let Some(plugins) = manifest.get("plugins").and_then(|v| v.as_array()) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for plugin in plugins {
+        if out.len() >= limit {
+            break;
+        }
+        let name = plugin
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let desc = plugin
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let haystack = format!("{} {}", name, desc).to_lowercase();
+        if haystack.contains(query_lc) {
+            out.push(Hit {
+                name,
+                description: desc,
+                marketplace: mp_name.to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn short(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{}…", truncated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_keeps_short_strings() {
+        assert_eq!(short("hello", 80), "hello");
+    }
+
+    #[test]
+    fn short_truncates_long_strings() {
+        let long = "x".repeat(120);
+        let s = short(&long, 80);
+        assert_eq!(s.chars().count(), 80);
+        assert!(s.ends_with('…'));
+    }
+}

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,7 +1,11 @@
 //! `search <query>` — keyword search across registered marketplaces.
 //!
-//! Reads each marketplace's cached `marketplace.json` and substring-matches `query`
-//! against `name + description`. No network calls; purely local.
+//! Always-on: substring-matches `query` against `name + description` in each marketplace's
+//! cached `marketplace.json`. No network calls.
+//!
+//! Optional (via the `skills-sh` cargo feature): also federates to the skills.sh remote
+//! index when registered and `ZSKILLS_SKILLS_SH_API_KEY` is set. Off by default; the binary
+//! has zero skills.sh code unless built with `--features skills-sh`.
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
@@ -10,9 +14,23 @@ use serde_json::Value;
 
 #[derive(Debug, Serialize)]
 pub struct Hit {
+    pub kind: HitKind,
     pub name: String,
     pub description: String,
     pub marketplace: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub installs: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HitKind {
+    Plugin,
+    /// Only constructed when the `skills-sh` cargo feature is enabled.
+    #[allow(dead_code)]
+    Skill,
 }
 
 pub fn run(query: String, limit: u32, as_json: bool) -> Result<()> {
@@ -29,7 +47,17 @@ pub fn run(query: String, limit: u32, as_json: bool) -> Result<()> {
     let mut hits: Vec<Hit> = Vec::new();
     let query_lc = query.to_lowercase();
 
-    for mp_name in known.keys() {
+    for (mp_name, entry) in &known {
+        if crate::commands::marketplace::is_remote_index(entry) {
+            #[cfg(feature = "skills-sh")]
+            dispatch_remote_index(mp_name, entry, &query, limit, &mut hits);
+            #[cfg(not(feature = "skills-sh"))]
+            {
+                let _ = (mp_name, entry); // silence unused warnings when feature off
+            }
+            continue;
+        }
+
         match local_search(mp_name, &query_lc, limit as usize) {
             Ok(mut local_hits) => hits.append(&mut local_hits),
             Err(e) => eprintln!(
@@ -52,16 +80,80 @@ pub fn run(query: String, limit: u32, as_json: bool) -> Result<()> {
     }
 
     for h in &hits {
+        let tag = match h.kind {
+            HitKind::Plugin => "[plugin]".green().to_string(),
+            HitKind::Skill => "[skill] ".cyan().to_string(),
+        };
+        let installs = h
+            .installs
+            .filter(|n| *n > 0)
+            .map(|n| format!(" ({}↓)", n))
+            .unwrap_or_default();
+        let source = h
+            .source_repo
+            .as_ref()
+            .map(|s| format!(" — {}", s.dimmed()))
+            .unwrap_or_default();
         println!(
-            "  {} {}  {}",
-            "[plugin]".green(),
+            "  {} {}{}  {}{}",
+            tag,
             h.name.bold(),
+            installs.dimmed(),
             short(&h.description, 80).dimmed(),
+            source
         );
         println!("           {}", format!("from {}", h.marketplace).dimmed());
     }
     println!("\n{}", format!("{} result(s)", hits.len()).dimmed());
     Ok(())
+}
+
+#[cfg(feature = "skills-sh")]
+fn dispatch_remote_index(
+    mp_name: &str,
+    entry: &Value,
+    query: &str,
+    limit: u32,
+    hits: &mut Vec<Hit>,
+) {
+    let url = entry
+        .get("source")
+        .and_then(|s| s.get("url"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if !url.contains("skills.sh") {
+        return;
+    }
+    if !crate::skills_sh::has_api_key() {
+        eprintln!(
+            "{} {} skipped: set ZSKILLS_SKILLS_SH_API_KEY to enable federated search.",
+            "·".yellow(),
+            mp_name.dimmed()
+        );
+        return;
+    }
+    match crate::skills_sh::search(query, limit) {
+        Ok(results) => {
+            for r in results.into_iter().take(limit as usize) {
+                hits.push(Hit {
+                    kind: HitKind::Skill,
+                    name: r.slug,
+                    description: r.name,
+                    marketplace: mp_name.to_string(),
+                    source_repo: Some(r.source),
+                    installs: Some(r.installs),
+                });
+            }
+        }
+        Err(e) => {
+            eprintln!(
+                "{} {}: {}",
+                "✗".red(),
+                mp_name,
+                format!("skills.sh search failed: {}", e).dimmed()
+            );
+        }
+    }
 }
 
 fn local_search(mp_name: &str, query_lc: &str, limit: usize) -> Result<Vec<Hit>> {
@@ -92,9 +184,12 @@ fn local_search(mp_name: &str, query_lc: &str, limit: usize) -> Result<Vec<Hit>>
         let haystack = format!("{} {}", name, desc).to_lowercase();
         if haystack.contains(query_lc) {
             out.push(Hit {
+                kind: HitKind::Plugin,
                 name,
                 description: desc,
                 marketplace: mp_name.to_string(),
+                source_repo: None,
+                installs: None,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod marketplace;
 mod paths;
 mod reconcile;
 mod settings;
+#[cfg(feature = "skills-sh")]
+mod skills_sh;
 
 use clap::Parser;
 

--- a/src/skills_sh.rs
+++ b/src/skills_sh.rs
@@ -53,7 +53,10 @@ pub fn has_api_key() -> bool {
 
 /// Search skills.sh for skills matching `query`. `limit` is clamped to 1..=200 by the API.
 pub fn search(query: &str, limit: u32) -> Result<Vec<SearchHit>> {
-    let Some(api_key) = std::env::var(API_KEY_ENV).ok().filter(|v| !v.trim().is_empty()) else {
+    let Some(api_key) = std::env::var(API_KEY_ENV)
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+    else {
         anyhow::bail!(
             "skills.sh requires an API key. Set {} (get one from https://www.skills.sh/account).",
             API_KEY_ENV

--- a/src/skills_sh.rs
+++ b/src/skills_sh.rs
@@ -1,0 +1,127 @@
+//! Thin client for the skills.sh API.
+//!
+//! Compiled only when the `skills-sh` cargo feature is enabled. The whole module is gated
+//! via `#[cfg(feature = "skills-sh")]` at the `mod skills_sh;` declaration in main.rs, so
+//! no per-item attributes are needed here.
+//!
+//! Endpoints we use:
+//! - `GET /api/v1/skills/search?q=<query>&limit=<n>` — fuzzy/semantic search.
+//!
+//! Auth: skills.sh requires an API key on all endpoints today (its public site claims an
+//! unauth tier, but the actual endpoints return 401). We read it from
+//! `ZSKILLS_SKILLS_SH_API_KEY` and surface a clear error when missing rather than letting
+//! federated search silently fail.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+const API_KEY_ENV: &str = "ZSKILLS_SKILLS_SH_API_KEY";
+
+/// `skills.sh` apex serves a 307 redirect to `www.skills.sh`; we hit the canonical host
+/// directly to avoid the redirect hop. Redirect-following is also enabled so future DNS
+/// changes don't break us.
+const BASE_URL: &str = "https://www.skills.sh";
+const USER_AGENT: &str = concat!("zskills/", env!("CARGO_PKG_VERSION"));
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
+pub struct SearchHit {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    pub source: String,
+    #[serde(default)]
+    pub installs: u64,
+    #[serde(rename = "sourceType", default)]
+    pub source_type: Option<String>,
+    #[serde(rename = "installUrl", default)]
+    pub install_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    data: Vec<SearchHit>,
+}
+
+/// Returns true if the user has configured a skills.sh API key.
+pub fn has_api_key() -> bool {
+    std::env::var(API_KEY_ENV)
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Search skills.sh for skills matching `query`. `limit` is clamped to 1..=200 by the API.
+pub fn search(query: &str, limit: u32) -> Result<Vec<SearchHit>> {
+    let Some(api_key) = std::env::var(API_KEY_ENV).ok().filter(|v| !v.trim().is_empty()) else {
+        anyhow::bail!(
+            "skills.sh requires an API key. Set {} (get one from https://www.skills.sh/account).",
+            API_KEY_ENV
+        );
+    };
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(USER_AGENT)
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()
+        .context("building reqwest client")?;
+    let url = format!("{}/api/v1/skills/search", BASE_URL);
+    let resp = client
+        .get(&url)
+        .bearer_auth(&api_key)
+        .query(&[("q", query), ("limit", &limit.to_string())])
+        .send()
+        .with_context(|| format!("calling skills.sh search ({})", url))?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!(
+            "skills.sh rejected the API key in {} (HTTP {}). Check the value is current.",
+            API_KEY_ENV,
+            status.as_u16()
+        );
+    }
+    let resp = resp
+        .error_for_status()
+        .context("skills.sh search returned an error status")?;
+    let parsed: SearchResponse = resp
+        .json()
+        .context("decoding skills.sh search response as JSON")?;
+    Ok(parsed.data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_search_response_shape() {
+        let raw = r#"{
+            "data": [{
+                "id": "vercel-labs/agent-skills/next-js-development",
+                "slug": "next-js-development",
+                "name": "Next.js Development",
+                "source": "vercel-labs/agent-skills",
+                "installs": 24531,
+                "sourceType": "github",
+                "installUrl": "https://github.com/vercel-labs/agent-skills"
+            }],
+            "query": "next",
+            "searchType": "semantic",
+            "count": 1,
+            "durationMs": 42
+        }"#;
+        let parsed: SearchResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.data.len(), 1);
+        assert_eq!(parsed.data[0].slug, "next-js-development");
+        assert_eq!(parsed.data[0].source, "vercel-labs/agent-skills");
+        assert_eq!(parsed.data[0].installs, 24531);
+    }
+
+    #[test]
+    fn tolerates_missing_optional_fields() {
+        let raw = r#"{"data":[{"id":"x/y/z","slug":"z","name":"Z","source":"x/y"}]}"#;
+        let parsed: SearchResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.data[0].installs, 0);
+        assert!(parsed.data[0].source_type.is_none());
+        assert!(parsed.data[0].install_url.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Adds two related capabilities to zskills, layered so the default install stays minimal:

- **`zskills search <query>`** — substring-matches name+description across every registered marketplace's cached `marketplace.json`. Purely local, no network.
- **`zskills marketplace add-recommended`** — opt-in seeder for `anthropics/claude-plugins-official`. Skip manual `marketplace add` on a fresh install.
- **Optional `skills-sh` cargo feature** — federated search + install against the skills.sh remote index. Off by default; the binary contains zero skills.sh code unless built with `cargo install --features skills-sh`. Runtime activation requires `ZSKILLS_SKILLS_SH_API_KEY`.

## Why this shape

- Local search needs no external dependencies and works against marketplaces the user already trusts.
- `skills-sh` is gated behind a build-time feature flag because (a) skills.sh requires personal API keys, (b) it's one consumer not an ecosystem, and (c) shipping dormant code in every binary for one optional integration is wasteful.
- README documents the planned subprocess-plugin protocol that would replace cargo features once 2-3 confirmed driver consumers exist. Until then, this is intentionally conservative.

## Test plan

- [x] `cargo build` — default; no skills.sh code in binary
- [x] `cargo build --features skills-sh` — full driver compiled in
- [x] `cargo test` — 9 unit + 15 integration tests pass
- [x] `cargo test --features skills-sh` — same suite passes with feature
- [x] Smoke: `marketplace add skills.sh` rejected in default build, accepted with feature
- [x] Smoke: `search "stripe"` returns matches from `claude-plugins-official` cache
- [x] Smoke: `search` skips skills.sh cleanly when registered without an API key
- [x] Smoke: `add-recommended` is idempotent (re-adding existing marketplace is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)