### PR TITLE
docs: document v0.6 search command and skills-sh optional feature

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,6 +139,26 @@ Marketplaces installed via Claude Code can be either git working trees or unpack
 
 The tarball path uses `reqwest` blocking + `flate2` + `tar`. Result: every marketplace recorded in `known_marketplaces.json` is updatable from one command regardless of how Claude Code originally installed it.
 
+## Remote-index marketplaces (cargo-feature-gated)
+
+A third marketplace shape lives behind cargo features: **remote indexes**. Their `known_marketplaces.json` entry has `source.source = "remote-index"` and a `source.url`, but no `installLocation` — there's no git clone. `search` and `install` dispatch to driver code that talks to the index's HTTP API.
+
+```
+known_marketplaces.json:
+{
+  "skills.sh": {
+    "source": { "source": "remote-index", "url": "https://skills.sh" },
+    "autoUpdate": false
+  }
+}
+```
+
+Each driver lives behind its own cargo feature (today: `skills-sh`). Default builds don't compile the driver in — `marketplace add skills.sh` errors with *"unrecognized marketplace source"*. With the feature, `add` accepts the special name, `search` federates to the API when `ZSKILLS_SKILLS_SH_API_KEY` is set, and `install` falls through to the index when local plugin resolution misses (routing through the existing agent-skill install path).
+
+The non-feature build still tolerates remote-index entries that might be in `known_marketplaces.json` from a feature-built version: `list` shows them with a `[remote-index]` tag, `update` skips them, `remove` works as expected. This is a forward-compatibility hedge, not a runtime dispatch path.
+
+See [README → Roadmap: third-party marketplace drivers](https://github.com/zot24/zskills#roadmap-third-party-marketplace-drivers) for when the cargo-feature pattern is the wrong shape and a subprocess plugin protocol takes over.
+
 ## Ownership tracking for agent skills
 
 Agent skill inventory entries carry a `source` field that's *typed* by prefix:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -231,9 +231,43 @@ Tap management — register, list, refresh, and remove Claude Code marketplaces.
 
 ```
 zskills marketplace add <owner/repo | git-url>
+zskills marketplace add-recommended
 zskills marketplace remove <name>
 zskills marketplace list [--json]
 zskills marketplace update [<name>]
 ```
 
 `add` clones the marketplace repo into `~/.claude/plugins/marketplaces/<name>/` and writes both `known_marketplaces.json` and `settings.json`'s `extraKnownMarketplaces`. Mirrors what `/plugin marketplace add` does inside Claude Code.
+
+`add-recommended` seeds the trusted defaults (currently just `anthropics/claude-plugins-official`). Idempotent — safe to re-run; existing marketplaces are left as-is.
+
+`add skills.sh` is recognized only when zskills was built with `--features skills-sh`. It registers skills.sh as a `remote-index` source type (no git clone) and is dispatched by `search` and `install` via the HTTP API. See [Optional features](#optional-features) below.
+
+## `search`
+
+Keyword search across every registered marketplace. Substring-matches `<query>` against `name + description` in each marketplace's cached `marketplace.json`. Purely local — no network calls.
+
+```
+zskills search <query> [--limit <n>] [--json]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--limit <n>` | 25 | Maximum results per marketplace |
+| `--json` | off | Emit results as a JSON array for scripting |
+
+With the `skills-sh` cargo feature compiled in AND `ZSKILLS_SKILLS_SH_API_KEY` set, `search` also federates to the skills.sh remote index and tags those results `[skill]`. Without the env var, the registered remote-index is skipped with a one-line hint and local search continues uninterrupted.
+
+## Optional features
+
+`zskills` ships vanilla by default. Optional capabilities are gated behind cargo features so they aren't even compiled into the binary unless you ask for them.
+
+| Feature | What it adds | How to enable |
+|---|---|---|
+| `skills-sh` | Federated `search` + `install` against the [skills.sh](https://www.skills.sh) remote index. Registers a new `remote-index` source type. Runtime activation requires `ZSKILLS_SKILLS_SH_API_KEY`. | `cargo install --git https://github.com/zot24/zskills --features skills-sh` |
+
+Without the feature, `zskills marketplace add skills.sh` returns *"unrecognized marketplace source"* — there's no dormant code, no env-var detection, nothing. The compiled binary is byte-identical to a feature-free build except for what you explicitly asked for.
+
+### `install` fallback (skills.sh feature only)
+
+When `skills-sh` is built in and a remote index is registered with a valid key, `install <name>` will fall through to skills.sh if the spec doesn't resolve in any local plugin marketplace. It performs an exact-slug match against the skills.sh search API and, on hit, routes through the existing Agent Skill install path (`git clone source/repo` → drop `SKILL.md` into `~/.claude/skills/<name>/`). No `enabledPlugins` flip — agent skills don't use that gate.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,9 @@ claims = ["gsd-*"]
 Then:
 
 ```bash
-zskills marketplace add zot24/skills    # register the marketplace
+zskills marketplace add-recommended     # seed trusted defaults (Anthropic-official marketplace)
+zskills marketplace add zot24/skills    # register additional taps as needed
+zskills search <query>                  # find skills across registered marketplaces
 zskills sync                            # apply the manifest
 zskills upgrade                         # refresh everything from origin
 zskills list                            # see what's installed
@@ -62,8 +64,12 @@ zskills scan [path]                     # find project-scope skills across a tre
 zskills migrate <project>               # promote project skills to user scope
 zskills migrate-skill <name>            # promote ONE skill across every project
 zskills migrate-all <dir>               # interactive sweep
+zskills search <query>                  # keyword search across registered marketplaces
 zskills marketplace add|remove|list|update
+zskills marketplace add-recommended     # seed trusted defaults (anthropics/claude-plugins-official)
 ```
+
+Optional capabilities live behind cargo features so the default binary stays minimal — see [Commands → Optional features](./commands.md#optional-features) for the `skills-sh` remote-index driver.
 
 Full reference: [Commands](./commands.md). Workflows and recipes: [Use cases](./use-cases.md). How it works internally: [Architecture](./architecture.md). Stuck? [Troubleshooting](./troubleshooting.md).
 
@@ -73,4 +79,4 @@ Existing skill managers are JavaScript shims with per-skill Node cold-start, no 
 
 ## Source
 
-[github.com/zot24/zskills](https://github.com/zot24/zskills) · MIT license · v0.5+
+[github.com/zot24/zskills](https://github.com/zot24/zskills) · MIT license · v0.6+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,6 +155,20 @@ zskills sync
 zskills doctor --fix
 ```
 
+## "unrecognized marketplace source: skills.sh"
+
+You ran `zskills marketplace add skills.sh` against a default build. The skills.sh driver is gated behind the `skills-sh` cargo feature and not compiled into vanilla binaries. Reinstall with the feature on:
+
+```bash
+cargo install --git https://github.com/zot24/zskills --features skills-sh --force
+```
+
+Then set `ZSKILLS_SKILLS_SH_API_KEY` (get one from [skills.sh/account](https://www.skills.sh/account)) and retry the `marketplace add`. Without the env var, `search` will skip skills.sh with a one-line hint and `install` will not fall through to it.
+
+## "skills.sh rejected the API key in ZSKILLS_SKILLS_SH_API_KEY (HTTP 401)"
+
+The key is wrong, revoked, or expired. Generate a fresh one at [skills.sh/account](https://www.skills.sh/account), update your shell rc, and re-source. The whole skills.sh API is gated — there's no unauthenticated fallback today.
+
 ## Cargo install fails with "edition2024 not stabilized"
 
 You're on Rust < 1.85. zskills requires Rust 1.85 or newer (transitive `idna_adapter` dep). Update:

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -11,10 +11,10 @@ cargo install --git https://github.com/zot24/zskills
 mkdir -p ~/.config/zskills
 scp old-machine:~/.config/zskills/skills.toml ~/.config/zskills/
 
-# Add the marketplaces named in the manifest
+# Seed the trusted defaults, then add any additional marketplaces named in the manifest
+zskills marketplace add-recommended       # anthropics/claude-plugins-official
 zskills marketplace add zot24/skills
 zskills marketplace add cloudflare/skills
-# (claude-plugins-official is registered automatically by Claude Code)
 
 # Apply
 zskills sync
@@ -172,3 +172,25 @@ Moves both `enabledPlugins` entries from the project's `.claude/settings.json` (
 ## 12. Vendor a global skill INTO a project (rare; manual)
 
 zskills doesn't push this direction yet (user-scope → project-scope). If you need a particular project to pin an exact version of a skill that diverges from the global one, copy `~/.claude/skills/<name>/` into the project's `.claude/skills/<name>/` and commit it. Claude Code resolves project scope before user scope, so the project's pinned copy wins.
+
+## 13. Find a skill before installing it
+
+You remember there's a Stripe integration somewhere but you don't know which marketplace ships it:
+
+```bash
+zskills search stripe                # substring-matches name + description across taps
+zskills search stripe --limit 5      # tighter output
+zskills search "data analytics"      # quoted multi-word queries work
+zskills search stripe --json | jq    # JSON for scripting
+```
+
+Search reads each marketplace's cached `marketplace.json` — purely local, no network. If you also have the `skills-sh` cargo feature compiled in and `ZSKILLS_SKILLS_SH_API_KEY` set, results from the skills.sh remote index are tagged `[skill]` and merged in:
+
+```bash
+cargo install --git https://github.com/zot24/zskills --features skills-sh --force
+export ZSKILLS_SKILLS_SH_API_KEY=sk_live_...
+zskills marketplace add skills.sh
+zskills search next-js                # now federates to skills.sh
+```
+
+Once you've found the name, `zskills install <name>` flips it on (or appends `[[skills]]` to `skills.toml` for the declarative path).


### PR DESCRIPTION
## Summary

Brings the mdBook docs and llms.txt mirror in line with the v0.6 surface that landed in #4.

- **`docs/commands.md`** — `search`, `marketplace add-recommended`, and a new "Optional features" section explaining `skills-sh` and its install fallback.
- **`docs/index.md`** — quickstart shows `add-recommended` + `search`, version bumped to v0.6+.
- **`docs/architecture.md`** — new "Remote-index marketplaces" section covering the cargo-feature-gated source type and the forward-compatibility shape (list/update tolerate remote-index entries even without the feature).
- **`docs/troubleshooting.md`** — two new entries: *"unrecognized marketplace source: skills.sh"* and *"skills.sh rejected the API key"*.
- **`docs/use-cases.md`** — bootstrap recipe updated to use `add-recommended`; new "Find a skill before installing it" recipe.

The deploy workflow handles `CHANGELOG.md → docs/changelog.md` sync and `llms.txt` regeneration automatically — no manual mirror commits needed.

## Test plan

- [x] All edits verified against the v0.6 code surface
- [x] `cargo fmt --check` passes (no code touched)
- [ ] CI: deploy-docs workflow runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)