### PR TITLE
feat: add -i interactive mode to install / search / remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console 0.15.11",
+ "fuzzy-matcher",
  "shell-words",
  "thiserror 1.0.69",
 ]
@@ -467,6 +468,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -1592,6 +1602,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3"
 sha2 = "0.10"
 walkdir = "2"
 glob = "0.3"
-dialoguer = { version = "0.11", default-features = false }
+dialoguer = { version = "0.11", default-features = false, features = ["fuzzy-select"] }
 which = "6"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Existing options are JavaScript shims that pay Node cold-start per skill (`bunx 
 ```
 zskills list [-v]                       # what's installed; agent skills grouped by source
 zskills install <name>                  # add to enabledPlugins
+zskills install -i                      # browse all marketplace plugins, fuzzy-pick one
 zskills remove  <name>                  # disable + drop inventory entry (keep bytes — apt style)
+zskills remove  -i                      # multi-select from enabled plugins to remove
 zskills purge   <name>                  # also delete bytes
 zskills enable  <name>                  # flip on without (un)installing
 zskills disable <name>
@@ -45,10 +47,13 @@ zskills scan [path]                     # find project-scope skills across a tre
 zskills migrate <project>               # promote one project's skills to user scope
 zskills migrate-skill <name>            # promote ONE skill across every project in a tree
 zskills migrate-all <dir>               # interactive: walk a tree, prompt per skill
+zskills search <query> [-i]             # -i picks a result and installs it
 zskills marketplace add|remove|list|update
 ```
 
 `<name>` accepts unqualified (`servarr`) when unambiguous, or `name@marketplace` (`servarr@zot24-skills`) to disambiguate.
+
+`-i` / `--interactive` is available on `install`, `remove`, and `search`.
 
 ## Declarative manifest (skills.toml)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,9 +29,14 @@ Flip a plugin's `enabledPlugins` entry on. Claude Code fetches bytes on next sta
 
 ```
 zskills install <name>...
+zskills install -i
 ```
 
 Accepts multiple names. Resolves unqualified names against your registered marketplaces; errors on ambiguity.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-i`, `--interactive` | off | When passed without any `<name>`, browse all plugins across registered marketplaces with a fuzzy picker and install the selection. |
 
 ## `remove` / `purge`
 
@@ -39,8 +44,13 @@ Accepts multiple names. Resolves unqualified names against your registered marke
 
 ```
 zskills remove <name>...
+zskills remove -i
 zskills purge  <name>...
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-i`, `--interactive` | off | (`remove` only) When passed without any `<name>`, browse enabled plugins with a multi-select picker and remove the selection. |
 
 ## `enable` / `disable`
 
@@ -248,13 +258,14 @@ zskills marketplace update [<name>]
 Keyword search across every registered marketplace. Substring-matches `<query>` against `name + description` in each marketplace's cached `marketplace.json`. Purely local — no network calls.
 
 ```
-zskills search <query> [--limit <n>] [--json]
+zskills search <query> [--limit <n>] [--json] [-i]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--limit <n>` | 25 | Maximum results per marketplace |
 | `--json` | off | Emit results as a JSON array for scripting |
+| `-i`, `--interactive` | off | After printing results, open a picker; selecting one installs it. |
 
 With the `skills-sh` cargo feature compiled in AND `ZSKILLS_SKILLS_SH_API_KEY` set, `search` also federates to the skills.sh remote index and tags those results `[skill]`. Without the env var, the registered remote-index is skipped with a one-line hint and local search continues uninterrupted.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,14 +29,20 @@ pub enum Command {
 
     /// Install + enable one or more skills (format: name or name@marketplace)
     Install {
+        /// Browse all marketplace plugins interactively and pick one to install
+        #[arg(short = 'i', long)]
+        interactive: bool,
+
         /// Skills to install
-        #[arg(required = true)]
         skills: Vec<String>,
     },
 
     /// Disable + drop from inventory (keeps bytes on disk)
     Remove {
-        #[arg(required = true)]
+        /// Browse enabled plugins interactively and pick which to remove
+        #[arg(short = 'i', long)]
+        interactive: bool,
+
         skills: Vec<String>,
     },
 
@@ -176,6 +182,10 @@ pub enum Command {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// After showing results, pick one interactively and install it
+        #[arg(short = 'i', long)]
+        interactive: bool,
     },
 }
 
@@ -207,9 +217,15 @@ impl Cli {
     pub fn run(self) -> anyhow::Result<()> {
         match self.command {
             Command::List { json, verbose } => crate::commands::list::run(json, verbose),
-            Command::Install { skills } => crate::commands::install::run(skills),
-            Command::Remove { skills } => crate::commands::remove::run(skills, false),
-            Command::Purge { skills } => crate::commands::remove::run(skills, true),
+            Command::Install {
+                skills,
+                interactive,
+            } => crate::commands::install::run(skills, interactive),
+            Command::Remove {
+                skills,
+                interactive,
+            } => crate::commands::remove::run(skills, interactive, false),
+            Command::Purge { skills } => crate::commands::remove::run(skills, false, true),
             Command::Enable { skills } => crate::commands::enable::run(skills, true),
             Command::Disable { skills } => crate::commands::enable::run(skills, false),
             Command::Update { skills } => crate::commands::update::run(skills),
@@ -240,9 +256,12 @@ impl Cli {
                 dry_run,
             } => crate::commands::migrate_all::run(dir, threshold, yes, dry_run),
             Command::Marketplace(cmd) => crate::commands::marketplace::run(cmd),
-            Command::Search { query, limit, json } => {
-                crate::commands::search::run(query, limit, json)
-            }
+            Command::Search {
+                query,
+                limit,
+                json,
+                interactive,
+            } => crate::commands::search::run(query, limit, json, interactive),
         }
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use owo_colors::OwoColorize;
 use serde_json::Value;
 
-pub fn run(specs: Vec<String>) -> Result<()> {
+pub fn run(specs: Vec<String>, interactive: bool) -> Result<()> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     if known.is_empty() {
         println!(
@@ -20,6 +20,14 @@ pub fn run(specs: Vec<String>) -> Result<()> {
             "No marketplaces registered. Run `zskills marketplace add-recommended` first.".yellow()
         );
         return Ok(());
+    }
+
+    if interactive && specs.is_empty() {
+        return run_interactive(&known);
+    }
+
+    if specs.is_empty() {
+        anyhow::bail!("specify at least one skill name, or use -i/--interactive to browse");
     }
 
     let settings_path = crate::paths::settings_json()?;
@@ -67,6 +75,53 @@ pub fn run(specs: Vec<String>) -> Result<()> {
             count,
             crate::paths::user_skills_dir()?.display()
         );
+    }
+    Ok(())
+}
+
+fn run_interactive(known: &serde_json::Map<String, Value>) -> Result<()> {
+    use dialoguer::FuzzySelect;
+
+    let mut qualified_names: Vec<String> = Vec::new();
+    let mut labels: Vec<String> = Vec::new();
+
+    for (mp_name, entry) in known {
+        if crate::commands::marketplace::is_remote_index(entry) {
+            continue;
+        }
+        let manifest_path = match crate::paths::marketplace_manifest(mp_name) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if let Ok(manifest) = crate::marketplace::load_manifest(&manifest_path) {
+            for plugin in manifest.plugins {
+                let qualified = format!("{}@{}", plugin.name, mp_name);
+                let desc = plugin.description.unwrap_or_default();
+                labels.push(if desc.is_empty() {
+                    qualified.clone()
+                } else {
+                    format!("{}  — {}", qualified, desc)
+                });
+                qualified_names.push(qualified);
+            }
+        }
+    }
+
+    if qualified_names.is_empty() {
+        println!(
+            "{}",
+            "No plugins found. Run `zskills marketplace update` to refresh caches.".yellow()
+        );
+        return Ok(());
+    }
+
+    match FuzzySelect::new()
+        .with_prompt("Install plugin")
+        .items(&labels)
+        .interact_opt()?
+    {
+        None => println!("Aborted."),
+        Some(idx) => run(vec![qualified_names[idx].clone()], false)?,
     }
     Ok(())
 }

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -4,7 +4,15 @@
 use anyhow::Result;
 use owo_colors::OwoColorize;
 
-pub fn run(specs: Vec<String>, purge_bytes: bool) -> Result<()> {
+pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<()> {
+    if interactive && specs.is_empty() {
+        return run_interactive(purge_bytes);
+    }
+
+    if specs.is_empty() {
+        anyhow::bail!("specify at least one skill name, or use -i/--interactive to browse");
+    }
+
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     let settings_path = crate::paths::settings_json()?;
     let inventory_path = crate::paths::installed_plugins_json()?;
@@ -54,4 +62,34 @@ pub fn run(specs: Vec<String>, purge_bytes: bool) -> Result<()> {
     crate::settings::save(&settings_path, &settings)?;
     crate::inventory::save(&inventory_path, &inventory)?;
     Ok(())
+}
+
+fn run_interactive(purge_bytes: bool) -> Result<()> {
+    use dialoguer::MultiSelect;
+
+    let settings_path = crate::paths::settings_json()?;
+    let settings = crate::settings::load(&settings_path)?;
+
+    let ep_keys: Vec<String> = crate::settings::enabled_plugins(&settings)
+        .map(|ep| ep.keys().cloned().collect())
+        .unwrap_or_default();
+
+    if ep_keys.is_empty() {
+        println!("{}", "No enabled plugins to remove.".yellow());
+        return Ok(());
+    }
+
+    let selected: Vec<usize> = MultiSelect::new()
+        .with_prompt("Remove plugins (space to select, enter to confirm)")
+        .items(&ep_keys)
+        .interact_opt()?
+        .unwrap_or_default();
+
+    if selected.is_empty() {
+        println!("Nothing selected.");
+        return Ok(());
+    }
+
+    let names: Vec<String> = selected.iter().map(|&i| ep_keys[i].clone()).collect();
+    run(names, false, purge_bytes)
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -33,7 +33,7 @@ pub enum HitKind {
     Skill,
 }
 
-pub fn run(query: String, limit: u32, as_json: bool) -> Result<()> {
+pub fn run(query: String, limit: u32, as_json: bool, interactive: bool) -> Result<()> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     if known.is_empty() {
         println!(
@@ -105,6 +105,38 @@ pub fn run(query: String, limit: u32, as_json: bool) -> Result<()> {
         println!("           {}", format!("from {}", h.marketplace).dimmed());
     }
     println!("\n{}", format!("{} result(s)", hits.len()).dimmed());
+
+    if interactive {
+        install_from_hits(&hits)?;
+    }
+    Ok(())
+}
+
+fn install_from_hits(hits: &[Hit]) -> Result<()> {
+    use dialoguer::Select;
+
+    let labels: Vec<String> = hits
+        .iter()
+        .map(|h| {
+            if h.description.is_empty() {
+                format!("{}@{}", h.name, h.marketplace)
+            } else {
+                format!("{}@{}  — {}", h.name, h.marketplace, h.description)
+            }
+        })
+        .collect();
+    match Select::new()
+        .with_prompt("Install")
+        .items(&labels)
+        .interact_opt()?
+    {
+        None => println!("Aborted."),
+        Some(idx) => {
+            let h = &hits[idx];
+            let spec = format!("{}@{}", h.name, h.marketplace);
+            crate::commands::install::run(vec![spec], false)?;
+        }
+    }
     Ok(())
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -504,3 +504,48 @@ fn doctor_detects_orphan_and_fixes_it() {
     let s: serde_json::Value = serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
     assert!(s["enabledPlugins"].get("ghost@test-mp").is_none());
 }
+
+#[test]
+fn install_interactive_flag_in_help() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("-i"))
+        .stdout(predicate::str::contains("--interactive"));
+}
+
+#[test]
+fn search_interactive_flag_in_help() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["search", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("-i"))
+        .stdout(predicate::str::contains("--interactive"));
+}
+
+#[test]
+fn remove_interactive_flag_in_help() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["remove", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("-i"))
+        .stdout(predicate::str::contains("--interactive"));
+}
+
+#[test]
+fn install_without_args_or_interactive_errors() {
+    let home = fake_home();
+    zskills(&home).args(["install"]).assert().failure();
+}
+
+#[test]
+fn remove_without_args_or_interactive_errors() {
+    let home = fake_home();
+    zskills(&home).args(["remove"]).assert().failure();
+}


### PR DESCRIPTION
## Summary
- `install -i` browses every plugin across registered marketplaces with a fuzzy picker and installs the selection.
- `search <query> -i` opens a picker over the result list and installs the hit you choose.
- `remove -i` multi-selects from currently-enabled plugins (`enabledPlugins` keys) and removes the lot.

Built on `dialoguer`'s `FuzzySelect` (newly enabled via the `fuzzy-select` feature) and the already-present `MultiSelect`. Purge stays non-interactive.

`required = true` is dropped from the positional skill args on `install` and `remove` so `-i` can be used without any names; both commands still bail when neither is provided.

## Test plan
- [x] `cargo test` — 27/27 (5 new flag-parsing tests added)
- [x] `cargo check` clean
- [ ] Manual: `zskills install -i` opens a fuzzy picker over marketplace plugins
- [ ] Manual: `zskills search foo -i` opens a picker over hits and installs the choice
- [ ] Manual: `zskills remove -i` multi-selects from enabled plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)