### PR TITLE
feat: zskills list aggregates MCP servers across all scopes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,7 +21,15 @@ zskills list [--json]
 |------|---------|-------------|
 | `--json` | off | Emit a machine-readable JSON document for scripting |
 
-The non-JSON output groups results into four plugin buckets (active, installed-but-disabled, enabled-but-not-installed, installed-from-missing-marketplace) plus two Agent Skill buckets (managed by zskills, on-disk-but-untracked).
+The non-JSON output groups results into four plugin buckets (active, installed-but-disabled, enabled-but-not-installed, installed-from-missing-marketplace) plus two Agent Skill buckets (managed by zskills, on-disk-but-untracked), plus a final **MCP Servers** section that aggregates every server visible to Claude Code from all of:
+
+- `~/.claude.json` and `~/.claude/settings.json` — user scope
+- `<cwd>/.mcp.json` and `<cwd>/.claude/settings.json` — project scope
+- `<cwd>/.claude.local/settings.json` — local (gitignored) scope
+- `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS) / `/etc/claude-code/managed-settings.json` (Linux) — managed (org-deployed) scope
+- An attribution column reads each enabled plugin's `plugin.json` / sibling `.mcp.json` and marks entries with `★ plugin:<name>` when the server is bundled by a plugin.
+
+Servers are grouped by scope (managed → local → project → user) and only the *keys* of `env` / `headers` are surfaced (no values), so the output never leaks secrets even when `${VAR}` refs aren't used. Set `ZSKILLS_MANAGED_SETTINGS=<path>` to override the managed-settings probe (useful in CI).
 
 ## `install`
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -7,6 +7,7 @@ pub fn run(json_out: bool, verbose: bool) -> Result<()> {
     let report = crate::reconcile::run()?;
     let inv = crate::agent_skill::load_inventory()?;
     let on_disk = crate::agent_skill::installed_on_disk().unwrap_or_default();
+    let mcps = crate::mcp::load_all().unwrap_or_default();
 
     let managed_names: Vec<&String> = inv.agent_skills.keys().collect();
     let untracked: Vec<String> = on_disk
@@ -51,7 +52,8 @@ pub fn run(json_out: bool, verbose: bool) -> Result<()> {
             "agent_skills": {
                 "managed": groups,
                 "untracked": untracked,
-            }
+            },
+            "mcp_servers": mcps,
         });
         println!("{}", serde_json::to_string_pretty(&out)?);
         return Ok(());
@@ -106,6 +108,8 @@ pub fn run(json_out: bool, verbose: bool) -> Result<()> {
             print_group(src, names, verbose);
         }
     }
+
+    print_mcp_section(&mcps);
 
     if !untracked.is_empty() {
         println!(
@@ -170,6 +174,93 @@ fn print_group(source: &str, names: &[String], verbose: bool) {
             preview.join(", ").dimmed(),
             format!("… [-v to list all {}]", count).dimmed()
         );
+    }
+}
+
+fn print_mcp_section(mcps: &[crate::mcp::McpServer]) {
+    println!("\n{}", "MCP Servers".bold().green());
+    if mcps.is_empty() {
+        println!("  (none configured)");
+        return;
+    }
+
+    let mut by_scope: BTreeMap<u8, (crate::mcp::Scope, Vec<&crate::mcp::McpServer>)> =
+        BTreeMap::new();
+    for m in mcps {
+        by_scope
+            .entry(m.scope.precedence())
+            .or_insert_with(|| (m.scope.clone(), Vec::new()))
+            .1
+            .push(m);
+    }
+
+    let name_w = mcps.iter().map(|m| m.name.len()).max().unwrap_or(0).max(8);
+
+    for (_, (scope, servers)) in by_scope.iter_mut() {
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+        println!(
+            "  {} {}",
+            scope.label().bold(),
+            format!("({})", servers.len()).dimmed()
+        );
+        for m in servers {
+            let attribution = match &m.source {
+                crate::mcp::Source::FromPlugin { plugin } => {
+                    format!("  ★ plugin:{}", plugin).cyan().to_string()
+                }
+                crate::mcp::Source::Manual => String::new(),
+            };
+            let sensitive = match m.transport.sensitive_count() {
+                0 => String::new(),
+                n => format!("  ({})", pluralize_sensitive(&m.transport, n))
+                    .dimmed()
+                    .to_string(),
+            };
+            let deprecated = if m.transport.kind() == "sse" {
+                "  [sse: deprecated]".yellow().to_string()
+            } else {
+                String::new()
+            };
+            println!(
+                "    {:name_w$}  {:5}  {}{}{}{}",
+                m.name,
+                m.transport.kind(),
+                short(&m.transport.short(), 60),
+                attribution,
+                sensitive,
+                deprecated,
+                name_w = name_w
+            );
+        }
+    }
+}
+
+fn pluralize_sensitive(t: &crate::mcp::Transport, n: usize) -> String {
+    let word = match t {
+        crate::mcp::Transport::Stdio { .. } => {
+            if n == 1 {
+                "env"
+            } else {
+                "envs"
+            }
+        }
+        _ => {
+            if n == 1 {
+                "header"
+            } else {
+                "headers"
+            }
+        }
+    };
+    format!("{} {}", n, word)
+}
+
+fn short(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{}…", truncated)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod inventory;
 mod lockfile;
 mod manifest;
 mod marketplace;
+mod mcp;
 mod paths;
 mod reconcile;
 mod settings;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,396 @@
+//! Aggregate MCP servers across Claude Code's known sources.
+//!
+//! Read-only in M1: parsing + display only. No writes.
+//!
+//! Data model is tool-agnostic on purpose — the `McpServer` struct has no
+//! Claude-specific fields. When grok-cli / codex adapters arrive later,
+//! only the *loaders* (which files to look in, where they live on disk)
+//! change; this struct stays put.
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Scope {
+    Managed,
+    User,
+    Project,
+    Local,
+}
+
+impl Scope {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Scope::Managed => "managed",
+            Scope::User => "user",
+            Scope::Project => "project",
+            Scope::Local => "local",
+        }
+    }
+    /// Display order: most-authoritative first.
+    pub fn precedence(&self) -> u8 {
+        match self {
+            Scope::Managed => 0,
+            Scope::Local => 1,
+            Scope::Project => 2,
+            Scope::User => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum Transport {
+    Stdio {
+        command: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+        /// Env var *keys* only — values are never captured (often contain `${VAR}` refs
+        /// or, in rare bad-practice cases, inline secrets).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        env_keys: Vec<String>,
+    },
+    Http {
+        url: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        header_keys: Vec<String>,
+    },
+    Sse {
+        url: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        header_keys: Vec<String>,
+    },
+}
+
+impl Transport {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Transport::Stdio { .. } => "stdio",
+            Transport::Http { .. } => "http",
+            Transport::Sse { .. } => "sse",
+        }
+    }
+    pub fn short(&self) -> String {
+        match self {
+            Transport::Stdio { command, args, .. } => {
+                if args.is_empty() {
+                    command.clone()
+                } else {
+                    format!("{} {}", command, args.join(" "))
+                }
+            }
+            Transport::Http { url, .. } | Transport::Sse { url, .. } => url.clone(),
+        }
+    }
+    /// Number of env vars (stdio) or headers (http/sse). Used for the `(N secret)` hint.
+    pub fn sensitive_count(&self) -> usize {
+        match self {
+            Transport::Stdio { env_keys, .. } => env_keys.len(),
+            Transport::Http { header_keys, .. } | Transport::Sse { header_keys, .. } => {
+                header_keys.len()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Source {
+    Manual,
+    FromPlugin { plugin: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct McpServer {
+    pub name: String,
+    pub scope: Scope,
+    pub transport: Transport,
+    pub source: Source,
+    pub source_file: PathBuf,
+}
+
+/// Load every MCP server visible to Claude Code.
+///
+/// Sources, by precedence (highest first):
+/// 1. **Managed** — org/IT-deployed settings (read-only).
+/// 2. **Local** — `<cwd>/.claude.local/settings.json` (gitignored, personal+creds).
+/// 3. **Project** — `<cwd>/.mcp.json` (recommended) and `<cwd>/.claude/settings.json` (legacy).
+/// 4. **User** — `~/.claude/settings.json`.
+///
+/// Entries are attributed to a plugin when their name matches one declared in
+/// an enabled plugin's `plugin.json` or sibling `.mcp.json`.
+pub fn load_all() -> Result<Vec<McpServer>> {
+    let plugin_index = build_plugin_mcp_index().unwrap_or_default();
+    let attribute = |name: &str| -> Source {
+        plugin_index
+            .get(name)
+            .cloned()
+            .map(|plugin| Source::FromPlugin { plugin })
+            .unwrap_or(Source::Manual)
+    };
+
+    let mut out: Vec<McpServer> = Vec::new();
+
+    if let Some(path) = managed_settings_path() {
+        out.extend(load_settings_file(&path, Scope::Managed, &attribute));
+    }
+
+    if let Ok(cwd) = std::env::current_dir() {
+        out.extend(load_settings_file(
+            &cwd.join(".claude.local").join("settings.json"),
+            Scope::Local,
+            &attribute,
+        ));
+        out.extend(load_mcp_json(
+            &cwd.join(".mcp.json"),
+            Scope::Project,
+            &attribute,
+        ));
+        out.extend(load_settings_file(
+            &cwd.join(".claude").join("settings.json"),
+            Scope::Project,
+            &attribute,
+        ));
+    }
+
+    // User scope lives in TWO files in the wild:
+    //   ~/.claude.json          — where `claude mcp add --scope user` writes (primary)
+    //   ~/.claude/settings.json — also valid per the spec; some users have entries here
+    if let Ok(p) = crate::paths::claude_json() {
+        out.extend(load_settings_file(&p, Scope::User, &attribute));
+    }
+    if let Ok(p) = crate::paths::settings_json() {
+        out.extend(load_settings_file(&p, Scope::User, &attribute));
+    }
+
+    Ok(out)
+}
+
+/// Load servers from a file whose top-level shape is `{"mcpServers": {...}}`.
+/// Used for every Claude settings.json variant.
+fn load_settings_file(
+    path: &Path,
+    scope: Scope,
+    attribute: &dyn Fn(&str) -> Source,
+) -> Vec<McpServer> {
+    let Some(val) = read_json(path) else {
+        return vec![];
+    };
+    let Some(obj) = val.get("mcpServers").and_then(|v| v.as_object()) else {
+        return vec![];
+    };
+    obj.iter()
+        .filter_map(|(name, entry)| {
+            parse_transport(entry).map(|transport| McpServer {
+                name: name.clone(),
+                scope: scope.clone(),
+                transport,
+                source: attribute(name),
+                source_file: path.to_path_buf(),
+            })
+        })
+        .collect()
+}
+
+/// Load servers from a `.mcp.json` file. Accepts BOTH real-world schemas:
+/// the wrapped `{"mcpServers": {...}}` form documented in the spec, and the
+/// flat `{ "<name>": {...} }` form that many plugins ship.
+fn load_mcp_json(path: &Path, scope: Scope, attribute: &dyn Fn(&str) -> Source) -> Vec<McpServer> {
+    let Some(val) = read_json(path) else {
+        return vec![];
+    };
+    let map = val
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .or_else(|| val.as_object());
+    let Some(obj) = map else {
+        return vec![];
+    };
+    obj.iter()
+        .filter_map(|(name, entry)| {
+            parse_transport(entry).map(|transport| McpServer {
+                name: name.clone(),
+                scope: scope.clone(),
+                transport,
+                source: attribute(name),
+                source_file: path.to_path_buf(),
+            })
+        })
+        .collect()
+}
+
+fn read_json(path: &Path) -> Option<Value> {
+    if !path.exists() {
+        return None;
+    }
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice::<Value>(&bytes).ok()
+}
+
+fn parse_transport(entry: &Value) -> Option<Transport> {
+    let obj = entry.as_object()?;
+    let kind = obj.get("type").and_then(|v| v.as_str());
+    match kind {
+        Some("http") => Some(Transport::Http {
+            url: obj.get("url")?.as_str()?.to_string(),
+            header_keys: key_list(obj.get("headers")),
+        }),
+        Some("sse") => Some(Transport::Sse {
+            url: obj.get("url")?.as_str()?.to_string(),
+            header_keys: key_list(obj.get("headers")),
+        }),
+        // No `type` → stdio (Claude's default).
+        _ => Some(Transport::Stdio {
+            command: obj.get("command")?.as_str()?.to_string(),
+            args: obj
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            env_keys: key_list(obj.get("env")),
+        }),
+    }
+}
+
+fn key_list(v: Option<&Value>) -> Vec<String> {
+    v.and_then(|x| x.as_object())
+        .map(|m| m.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Walk enabled plugins' install paths, parse their `.claude-plugin/plugin.json`
+/// (for an embedded `mcpServers` key) and any sibling `.mcp.json` file, and
+/// build a name → plugin-name lookup for attribution.
+fn build_plugin_mcp_index() -> Result<BTreeMap<String, String>> {
+    let mut idx = BTreeMap::new();
+
+    let settings_path = crate::paths::settings_json()?;
+    if !settings_path.exists() {
+        return Ok(idx);
+    }
+    let settings = crate::settings::load(&settings_path)?;
+    let Some(ep) = crate::settings::enabled_plugins(&settings) else {
+        return Ok(idx);
+    };
+
+    let inv_path = crate::paths::installed_plugins_json()?;
+    let inv = crate::inventory::load(&inv_path)?;
+    let plugins = crate::inventory::plugins(&inv);
+
+    for qualified in ep.keys() {
+        let Some((plugin_name, _marketplace)) = qualified.split_once('@') else {
+            continue;
+        };
+        // Walk every recorded install path for this plugin.
+        let install_paths: Vec<PathBuf> = plugins
+            .and_then(|p| p.get(qualified))
+            .and_then(|v| v.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|e| e.get("installPath").and_then(|p| p.as_str()))
+                    .map(PathBuf::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for root in install_paths {
+            // Embedded mcpServers in plugin.json
+            let plugin_json = root.join(".claude-plugin").join("plugin.json");
+            if let Some(v) = read_json(&plugin_json) {
+                if let Some(obj) = v.get("mcpServers").and_then(|x| x.as_object()) {
+                    for name in obj.keys() {
+                        idx.insert(name.clone(), plugin_name.to_string());
+                    }
+                }
+            }
+            // Sibling .mcp.json (either schema)
+            let mcp_json = root.join(".mcp.json");
+            if let Some(v) = read_json(&mcp_json) {
+                let map = v
+                    .get("mcpServers")
+                    .and_then(|x| x.as_object())
+                    .or_else(|| v.as_object());
+                if let Some(obj) = map {
+                    for name in obj.keys() {
+                        idx.insert(name.clone(), plugin_name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    Ok(idx)
+}
+
+/// Platform-specific path for org/IT-deployed managed settings.
+/// Overridable via `ZSKILLS_MANAGED_SETTINGS` for testing.
+fn managed_settings_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("ZSKILLS_MANAGED_SETTINGS") {
+        return Some(PathBuf::from(p));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Some(PathBuf::from(
+            "/Library/Application Support/ClaudeCode/managed-settings.json",
+        ))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        Some(PathBuf::from("/etc/claude-code/managed-settings.json"))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_stdio_basic() {
+        let v = json!({"command":"npx","args":["-y","@x/server"]});
+        let t = parse_transport(&v).unwrap();
+        assert_eq!(t.kind(), "stdio");
+        assert_eq!(t.short(), "npx -y @x/server");
+        assert_eq!(t.sensitive_count(), 0);
+    }
+
+    #[test]
+    fn parse_stdio_counts_env_keys_only() {
+        let v = json!({"command":"x","env":{"A":"${A}","B":"literal"}});
+        assert_eq!(parse_transport(&v).unwrap().sensitive_count(), 2);
+    }
+
+    #[test]
+    fn parse_http_with_headers() {
+        let v = json!({"type":"http","url":"https://x.example","headers":{"Authorization":"Bearer ${X}"}});
+        let t = parse_transport(&v).unwrap();
+        assert_eq!(t.kind(), "http");
+        assert_eq!(t.short(), "https://x.example");
+        assert_eq!(t.sensitive_count(), 1);
+    }
+
+    #[test]
+    fn parse_sse_flagged_distinctly() {
+        let v = json!({"type":"sse","url":"https://s.example"});
+        assert_eq!(parse_transport(&v).unwrap().kind(), "sse");
+    }
+
+    #[test]
+    fn parse_skips_malformed() {
+        let v = json!({"type":"http"}); // missing url
+        assert!(parse_transport(&v).is_none());
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -13,6 +13,17 @@ pub fn settings_json() -> Result<PathBuf> {
     Ok(claude_home()?.join("settings.json"))
 }
 
+/// `~/.claude.json` — Claude Code's user-scope state file, sibling of `~/.claude/`.
+/// This is where `claude mcp add --scope user` writes its `mcpServers` map, distinct
+/// from `~/.claude/settings.json`. Both can contain `mcpServers`; zskills reads both.
+pub fn claude_json() -> Result<PathBuf> {
+    let home = claude_home()?;
+    let parent = home
+        .parent()
+        .context("claude_home has no parent directory")?;
+    Ok(parent.join(".claude.json"))
+}
+
 pub fn plugins_dir() -> Result<PathBuf> {
     Ok(claude_home()?.join("plugins"))
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -549,3 +549,114 @@ fn remove_without_args_or_interactive_errors() {
     let home = fake_home();
     zskills(&home).args(["remove"]).assert().failure();
 }
+
+/// Build a test fixture where CLAUDE_HOME is nested inside a temp parent dir,
+/// so `~/.claude.json` (sibling of `~/.claude/`) can be created at a known path.
+fn fake_home_nested() -> (TempDir, std::path::PathBuf) {
+    let parent = tempfile::tempdir().unwrap();
+    let claude_home = parent.path().join(".claude");
+    fs::create_dir_all(claude_home.join("plugins").join("marketplaces")).unwrap();
+    fs::write(
+        claude_home.join("settings.json"),
+        serde_json::to_string(&json!({"enabledPlugins": {}})).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        claude_home.join("plugins").join("installed_plugins.json"),
+        r#"{"version":2,"plugins":{}}"#,
+    )
+    .unwrap();
+    fs::write(
+        claude_home.join("plugins").join("known_marketplaces.json"),
+        "{}",
+    )
+    .unwrap();
+    (parent, claude_home)
+}
+
+fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("zskills").unwrap();
+    cmd.env("CLAUDE_HOME", claude_home);
+    // Make sure the managed-settings probe doesn't pick up a real system file in CI.
+    cmd.env(
+        "ZSKILLS_MANAGED_SETTINGS",
+        parent.path().join("__no_managed__"),
+    );
+    // Pin CWD so project-scope probes are deterministic.
+    cmd.current_dir(parent.path());
+    cmd
+}
+
+#[test]
+fn list_shows_user_mcps_from_claude_json() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_json = parent.path().join(".claude.json");
+    fs::write(
+        &claude_json,
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "honcho":  { "type": "http", "url": "https://mcp.honcho.dev" },
+                "github":  { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"],
+                             "env": { "GITHUB_TOKEN": "${GITHUB_TOKEN}" } }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("MCP Servers"))
+        .stdout(predicate::str::contains("honcho"))
+        .stdout(predicate::str::contains("github"))
+        .stdout(predicate::str::contains("1 env"));
+}
+
+#[test]
+fn list_shows_project_mcps_from_mcp_json_wrapped() {
+    let (parent, claude_home) = fake_home_nested();
+    fs::write(
+        parent.path().join(".mcp.json"),
+        serde_json::to_string(&json!({
+            "mcpServers": { "postgres": { "command": "docker", "args": ["run", "..."] } }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("project"))
+        .stdout(predicate::str::contains("postgres"));
+}
+
+#[test]
+fn list_handles_flat_mcp_json_schema() {
+    let (parent, claude_home) = fake_home_nested();
+    // Many plugins ship .mcp.json without the `mcpServers` wrapper — flat map.
+    fs::write(
+        parent.path().join(".mcp.json"),
+        serde_json::to_string(&json!({
+            "linear": { "type": "http", "url": "https://mcp.linear.app/mcp" }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("linear"));
+}
+
+#[test]
+fn list_with_no_mcps_anywhere_shows_none_configured() {
+    let (parent, claude_home) = fake_home_nested();
+    zskills_nested(&parent, &claude_home)
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(none configured)"));
+}


### PR DESCRIPTION
## Summary

Adds an MCP Servers section to \`zskills list\` that aggregates every server Claude Code can see — from all six known sources — with per-plugin attribution.

\`\`\`
MCP Servers
  user (2)
    honcho         http   https://mcp.honcho.dev  (3 headers)
    linear-server  http   https://mcp.linear.app/mcp
\`\`\`

## Sources read

| Source | File |
|---|---|
| Managed (org-deployed) | macOS: \`/Library/Application Support/ClaudeCode/managed-settings.json\`, Linux: \`/etc/claude-code/managed-settings.json\` |
| Local (gitignored) | \`<cwd>/.claude.local/settings.json\` |
| Project | \`<cwd>/.mcp.json\` (recommended) + \`<cwd>/.claude/settings.json\` (legacy) |
| User | \`~/.claude.json\` (where \`claude mcp\` actually writes) + \`~/.claude/settings.json\` (per spec) |
| Plugin attribution | each enabled plugin's \`plugin.json\` + sibling \`.mcp.json\` from the install path in inventory |

The \`~/.claude.json\` source isn't documented in the official spec — discovered by inspecting where real \`claude mcp add --scope user\` ends up. Without it the section would have shown \"(none configured)\" for most users.

## Schema discoveries

\`.mcp.json\` ships in TWO real-world shapes:
- Wrapped: \`{\"mcpServers\": {...}}\` — what the spec documents
- Flat: \`{\"<name>\": {...}}\` — what asana, context7, firebase, github, gitlab, greptile, laravel-boost actually ship in the official marketplace

Parser auto-detects.

## Secret handling

Only \`env\` and \`headers\` *keys* are captured. Values never touch memory. Output shows \`(3 envs)\` / \`(1 header)\` hints but never the values, so the transcript and JSON output are safe even when \`\${VAR}\` refs aren't used.

## Tool-agnostic data model

\`McpServer { name, scope, transport, source, source_file }\` has zero Claude-specific fields. The Claude-specific part (which files to look in) is isolated in \`load_all()\`. When grok-cli / codex adapters arrive, only the loaders change; the struct stays.

## Test plan

- [x] 5 new unit tests (stdio/http/sse parsing, env-key counting, malformed rejection)
- [x] 4 new integration tests (claude.json user MCPs, wrapped .mcp.json, flat .mcp.json, empty fallthrough)
- [x] \`cargo test\` — 29/29
- [x] \`cargo fmt --all --check\` clean
- [x] Smoke-tested against real config on dev machine — found and displayed 2 user MCPs (honcho, linear-server) without leaking values

## Out of scope (later milestones)

- M2: \`[[mcps]]\` in \`skills.toml\` + \`sync\` reconciliation
- M3: \`doctor\` checks (binary on PATH, env-var set, orphan detection)
- Interactive \`-i\` for MCPs (config is too varied for fuzzy-pick to add value)
- CRUD that duplicates \`claude mcp add\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)