### PR TITLE
feat: doctor statically validates MCP servers

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -159,17 +159,23 @@ Runs `git pull --ff-only` against each marketplace clone. Claude Code reads the 
 
 ## `doctor`
 
-Reconcile disk ↔ inventory ↔ settings. Reports drift in three categories:
+Reconcile disk ↔ inventory ↔ settings, and statically validate every configured MCP server. Reports drift in four categories:
 
 1. Plugins enabled in `enabledPlugins` but not present in `installed_plugins.json` (broken references — Claude Code will fetch on next start).
 2. Plugins in inventory whose marketplace tap is no longer registered.
 3. Agent skills tracked in inventory but missing from `~/.claude/skills/` on disk.
+4. **MCP server issues** — static checks against every server returned by `list`:
+   - **stdio**: `command` must resolve on `$PATH` (uses `which`-style lookup).
+   - **any transport**: every `${VAR}` reference in `env` (stdio) or `headers` (http/sse) must be set in the user's environment.
+   - **sse transport**: flagged as deprecated; the spec recommends migrating to `http`.
 
 ```
 zskills doctor [--fix]
 ```
 
-With `--fix`, dangling references are removed (settings.json entries pointing nowhere, orphaned inventory entries). `--fix` never deletes installed bytes — that's what `purge` is for.
+With `--fix`, dangling plugin/inventory references are removed. **`--fix` is a no-op for MCP issues** — none of them are auto-fixable (we won't install a missing binary or invent an env var), so doctor's job there is purely to surface what's broken. `--fix` never deletes installed bytes — that's what `purge` is for.
+
+Doctor never spawns or talks to an MCP server. Running-state diagnosis (whether a server is actually connected, last error, latency) is Claude Code's job — replicating it here would risk divergent diagnoses. If you need that, run the server directly or check Claude Code's own logs.
 
 ## `scan`
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,6 +5,8 @@ pub fn run(fix: bool) -> Result<()> {
     let report = crate::reconcile::run()?;
     let mut issues = 0;
 
+    issues += check_mcps();
+
     if !report.enabled_orphan.is_empty() {
         issues += report.enabled_orphan.len();
         println!(
@@ -86,4 +88,63 @@ pub fn run(fix: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Static MCP server checks. Returns the number of warnings emitted.
+///
+/// We don't try to spawn or talk to the servers themselves — that's a runtime
+/// concern that belongs to Claude Code, and replicating it would risk divergent
+/// diagnoses. What we *can* verify without spawning:
+///
+/// 1. **stdio** servers reference a `command` that resolves on `$PATH`.
+/// 2. Every `${VAR}` referenced in `env` (stdio) or `headers` (http/sse) is
+///    actually defined in the user's environment.
+/// 3. SSE servers get a deprecation note (the spec marks `sse` as legacy).
+///
+/// `--fix` is a no-op for MCPs in M3: none of these failures are auto-fixable
+/// (we won't install a missing binary or invent an env var). Surfacing them is
+/// the value-add.
+fn check_mcps() -> usize {
+    let mcps = match crate::mcp::load_all() {
+        Ok(m) => m,
+        Err(_) => return 0,
+    };
+    if mcps.is_empty() {
+        return 0;
+    }
+    let mut issues = 0;
+    let mut by_server: Vec<(String, String, Vec<String>)> = Vec::new(); // (name, scope, messages)
+
+    for m in &mcps {
+        let mut msgs: Vec<String> = Vec::new();
+        if let crate::mcp::Transport::Stdio { command, .. } = &m.transport {
+            if which::which(command).is_err() {
+                msgs.push(format!("command not found on $PATH: {}", command));
+            }
+        }
+        for var in m.transport.referenced_vars() {
+            if std::env::var(var).is_err() {
+                msgs.push(format!("env var `{}` is referenced but not set", var));
+            }
+        }
+        if m.transport.kind() == "sse" {
+            msgs.push("transport `sse` is deprecated; switch to `http`".to_string());
+        }
+        if !msgs.is_empty() {
+            issues += msgs.len();
+            by_server.push((m.name.clone(), m.scope.label().to_string(), msgs));
+        }
+    }
+
+    if by_server.is_empty() {
+        return 0;
+    }
+    println!("{} {} MCP issue(s):", "✗".red(), issues);
+    for (name, scope, msgs) in &by_server {
+        println!("  {} {}", format!("[{}]", scope).dimmed(), name.bold());
+        for msg in msgs {
+            println!("    - {}", msg);
+        }
+    }
+    issues
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -49,20 +49,29 @@ pub enum Transport {
         command: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         args: Vec<String>,
-        /// Env var *keys* only — values are never captured (often contain `${VAR}` refs
-        /// or, in rare bad-practice cases, inline secrets).
+        /// Env var *keys* only — values are never stored, only briefly inspected
+        /// for `${VAR}` references which land in `env_refs`. Both `key` and `var-name`
+        /// are safe to surface; raw values are not, so they get dropped.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         env_keys: Vec<String>,
+        /// Names of `${VAR}` references appearing anywhere in the env values.
+        /// Used by `doctor` to verify each referenced env var is actually set.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        env_refs: Vec<String>,
     },
     Http {
         url: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         header_keys: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        header_refs: Vec<String>,
     },
     Sse {
         url: String,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         header_keys: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        header_refs: Vec<String>,
     },
 }
 
@@ -93,6 +102,15 @@ impl Transport {
             Transport::Http { header_keys, .. } | Transport::Sse { header_keys, .. } => {
                 header_keys.len()
             }
+        }
+    }
+
+    /// Names of all `${VAR}` references in this server's values. Doctor checks
+    /// each against the process environment.
+    pub fn referenced_vars(&self) -> &[String] {
+        match self {
+            Transport::Stdio { env_refs, .. } => env_refs,
+            Transport::Http { header_refs, .. } | Transport::Sse { header_refs, .. } => header_refs,
         }
     }
 }
@@ -235,36 +253,89 @@ fn parse_transport(entry: &Value) -> Option<Transport> {
     let obj = entry.as_object()?;
     let kind = obj.get("type").and_then(|v| v.as_str());
     match kind {
-        Some("http") => Some(Transport::Http {
-            url: obj.get("url")?.as_str()?.to_string(),
-            header_keys: key_list(obj.get("headers")),
-        }),
-        Some("sse") => Some(Transport::Sse {
-            url: obj.get("url")?.as_str()?.to_string(),
-            header_keys: key_list(obj.get("headers")),
-        }),
+        Some("http") => {
+            let (header_keys, header_refs) = keys_and_refs(obj.get("headers"));
+            Some(Transport::Http {
+                url: obj.get("url")?.as_str()?.to_string(),
+                header_keys,
+                header_refs,
+            })
+        }
+        Some("sse") => {
+            let (header_keys, header_refs) = keys_and_refs(obj.get("headers"));
+            Some(Transport::Sse {
+                url: obj.get("url")?.as_str()?.to_string(),
+                header_keys,
+                header_refs,
+            })
+        }
         // No `type` → stdio (Claude's default).
-        _ => Some(Transport::Stdio {
-            command: obj.get("command")?.as_str()?.to_string(),
-            args: obj
-                .get("args")
-                .and_then(|v| v.as_array())
-                .map(|a| {
-                    a.iter()
-                        .filter_map(|x| x.as_str())
-                        .map(str::to_string)
-                        .collect()
-                })
-                .unwrap_or_default(),
-            env_keys: key_list(obj.get("env")),
-        }),
+        _ => {
+            let (env_keys, env_refs) = keys_and_refs(obj.get("env"));
+            Some(Transport::Stdio {
+                command: obj.get("command")?.as_str()?.to_string(),
+                args: obj
+                    .get("args")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|x| x.as_str())
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                env_keys,
+                env_refs,
+            })
+        }
     }
 }
 
-fn key_list(v: Option<&Value>) -> Vec<String> {
-    v.and_then(|x| x.as_object())
-        .map(|m| m.keys().cloned().collect())
-        .unwrap_or_default()
+/// For an env/headers object, return (keys, ${VAR} refs found in values).
+/// Values themselves are dropped — only the `${VAR}` variable *names* are kept.
+fn keys_and_refs(v: Option<&Value>) -> (Vec<String>, Vec<String>) {
+    let Some(obj) = v.and_then(|x| x.as_object()) else {
+        return (vec![], vec![]);
+    };
+    let mut keys: Vec<String> = Vec::new();
+    let mut refs: Vec<String> = Vec::new();
+    for (k, val) in obj {
+        keys.push(k.clone());
+        if let Some(s) = val.as_str() {
+            for r in extract_var_refs(s) {
+                if !refs.contains(&r) {
+                    refs.push(r);
+                }
+            }
+        }
+    }
+    (keys, refs)
+}
+
+/// Pull every `${VAR}` reference out of a string, returning just the variable names.
+/// Accepts identifiers matching `[A-Za-z_][A-Za-z0-9_]*` inside the braces.
+fn extract_var_refs(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        if bytes[i] == b'$' && bytes[i + 1] == b'{' {
+            let start = i + 2;
+            if let Some(end_off) = bytes[start..].iter().position(|&b| b == b'}') {
+                let name = &s[start..start + end_off];
+                let valid = !name.is_empty()
+                    && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    && !name.chars().next().unwrap().is_ascii_digit();
+                if valid {
+                    out.push(name.to_string());
+                }
+                i = start + end_off + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
 }
 
 /// Walk enabled plugins' install paths, parse their `.claude-plugin/plugin.json`
@@ -370,7 +441,10 @@ mod tests {
     #[test]
     fn parse_stdio_counts_env_keys_only() {
         let v = json!({"command":"x","env":{"A":"${A}","B":"literal"}});
-        assert_eq!(parse_transport(&v).unwrap().sensitive_count(), 2);
+        let t = parse_transport(&v).unwrap();
+        assert_eq!(t.sensitive_count(), 2);
+        // Only "A" references a ${VAR}; "B" is a literal and contributes no refs.
+        assert_eq!(t.referenced_vars(), &["A".to_string()]);
     }
 
     #[test]
@@ -380,6 +454,28 @@ mod tests {
         assert_eq!(t.kind(), "http");
         assert_eq!(t.short(), "https://x.example");
         assert_eq!(t.sensitive_count(), 1);
+        assert_eq!(t.referenced_vars(), &["X".to_string()]);
+    }
+
+    #[test]
+    fn extract_var_refs_handles_embedded_and_multiple() {
+        assert_eq!(extract_var_refs("${A}"), vec!["A"]);
+        assert_eq!(extract_var_refs("Bearer ${TOKEN}"), vec!["TOKEN"]);
+        assert_eq!(extract_var_refs("${A}-${B}"), vec!["A", "B"]);
+        assert_eq!(extract_var_refs("literal"), Vec::<String>::new());
+        // Bad shapes don't panic and don't produce false matches.
+        assert_eq!(extract_var_refs("${}"), Vec::<String>::new());
+        assert_eq!(extract_var_refs("${1BAD}"), Vec::<String>::new());
+        assert_eq!(extract_var_refs("$NOTBRACED"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn refs_are_deduped() {
+        let v = json!({"command":"x","env":{"A":"${TOK}","B":"x ${TOK} y"}});
+        assert_eq!(
+            parse_transport(&v).unwrap().referenced_vars(),
+            &["TOK".to_string()]
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -660,3 +660,96 @@ fn list_with_no_mcps_anywhere_shows_none_configured() {
         .success()
         .stdout(predicate::str::contains("(none configured)"));
 }
+
+#[test]
+fn doctor_flags_missing_stdio_command() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_json = parent.path().join(".claude.json");
+    fs::write(
+        &claude_json,
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "ghost": { "command": "this-binary-definitely-does-not-exist-xyz", "args": [] }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("MCP issue"))
+        .stdout(predicate::str::contains("ghost"))
+        .stdout(predicate::str::contains("command not found"));
+}
+
+#[test]
+fn doctor_flags_unset_env_var_referenced_in_mcp() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_json = parent.path().join(".claude.json");
+    fs::write(
+        &claude_json,
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "linear": {
+                    "type": "http",
+                    "url": "https://mcp.linear.app/mcp",
+                    "headers": { "Authorization": "Bearer ${ZSKILLS_TEST_UNSET_TOKEN_XYZ}" }
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .env_remove("ZSKILLS_TEST_UNSET_TOKEN_XYZ")
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ZSKILLS_TEST_UNSET_TOKEN_XYZ"))
+        .stdout(predicate::str::contains("referenced but not set"));
+}
+
+#[test]
+fn doctor_flags_sse_as_deprecated() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_json = parent.path().join(".claude.json");
+    fs::write(
+        &claude_json,
+        serde_json::to_string(&json!({
+            "mcpServers": { "legacy": { "type": "sse", "url": "https://old.example/sse" } }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("legacy"))
+        .stdout(predicate::str::contains("sse"))
+        .stdout(predicate::str::contains("deprecated"));
+}
+
+#[test]
+fn doctor_passes_when_mcps_are_healthy() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_json = parent.path().join(".claude.json");
+    // Use a binary that is guaranteed to be on PATH in any unix env: `sh`.
+    fs::write(
+        &claude_json,
+        serde_json::to_string(&json!({
+            "mcpServers": { "shellish": { "command": "sh", "args": ["-c", "echo"] } }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("All good").or(predicate::str::contains("MCP issue").not()),
+        );
+}


### PR DESCRIPTION
## Summary

Extends `zskills doctor` to validate every MCP server `list` knows about. Three static checks per server, no spawning:

- **stdio**: `command` must resolve on `\$PATH`
- **any transport**: every `\${VAR}` reference in `env` (stdio) / `headers` (http+sse) must be defined in the user's environment
- **sse transport**: flagged as deprecated per the MCP spec

Output sits next to the existing plugin/inventory drift sections:

```
✗ 2 MCP issue(s):
  [user] ghost
    - command not found on \$PATH: this-binary-does-not-exist
  [project] legacy
    - transport `sse` is deprecated; switch to `http`
```

## Design notes

**Why no spawning.** zskills doesn't run MCP servers — Claude Code does. A live "is this server healthy" check would either spawn its own processes (duplicating Claude Code's lifecycle, risking divergent diagnoses) or query Claude Code (no API for that). Both are expensive and worse than the static checks for typical "why isn't this working" debugging.

**Why \`--fix\` is a no-op for MCPs.** None of the failures are auto-fixable. We won't install a missing binary, invent an env var, or migrate sse→http. Surfacing the problem is the contribution; the fix is the user's call.

**Secret safety.** Extends \`Transport\` with \`env_refs\` / \`header_refs\` capturing the \${VAR} *names* referenced in values. Values themselves are still never stored — only variable names get kept, so the M1 secret-safety promise holds.

## Test plan

- [x] \`cargo test\` — 42/42 (14 unit + 28 integration, +7 new this PR)
- [x] \`cargo fmt --all --check\` clean
- [x] Smoke-tested against real config — doctor reports \"All good\" with 2 user MCPs (honcho HTTP, linear-server HTTP), meaning the checks ran and passed

## Out of scope

- Runtime health (connection, latency, last error) — different product; revisit if users actually report needing it.
- Orphan detection for MCPs (\"in settings but not in any manifest or plugin\") — needs M2's manifest first.
- Auto-migration of sse → http.

🤖 Generated with [Claude Code](https://claude.com/claude-code)