### PR TITLE
feat: [[mcps]] manifest support + sync reconciliation (M2)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,6 +110,69 @@ zskills upgrade [<name>...]
 
 Pass specific names to upgrade just those; empty = upgrade everything. The `name` filter matches against the manifest's `npm`, `source`, or `name` fields.
 
+## MCP servers manifest schema
+
+Add `[[mcps]]` tables to `skills.toml` to declaratively manage MCP servers. `sync` writes them to the appropriate runtime config file based on `scope`:
+
+```toml
+# Stdio: a process the runtime spawns directly.
+[[mcps]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+scope = "user"  # default; also "project" or "local"
+
+# HTTP: a remote server reachable over HTTP.
+[[mcps]]
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+transport = "http"  # optional; inferred from `url`
+scope = "user"
+
+# Stdio + mcp-remote proxy pattern (real-world): args reference ${VAR} too.
+[[mcps]]
+name = "honcho"
+command = "npx"
+args = [
+  "mcp-remote",
+  "https://mcp.honcho.dev",
+  "--header", "Authorization:${HONCHO_AUTH}",
+  "--header", "X-Honcho-User-Name:${USER_NAME}",
+]
+env = { HONCHO_AUTH = "${HONCHO_AUTH}", USER_NAME = "${USER}" }
+scope = "user"
+```
+
+| Field | Purpose |
+|---|---|
+| `name` (required) | MCP server name. Becomes the key under `mcpServers`. |
+| `command` | Stdio: the executable to run. Required for stdio transports. |
+| `args` | Stdio: list of args. `${VAR}` refs are allowed and recommended for credentials. |
+| `env` | Stdio: env-var map. Values should use `${VAR}` refs. |
+| `url` | HTTP/SSE: server URL. |
+| `headers` | HTTP/SSE: header map. Same `${VAR}` policy as `env`. |
+| `transport` | `"stdio"` \| `"http"` \| `"sse"`. Optional; inferred from `command` or `url`. SSE is the deprecated spec form — prefer http. |
+| `scope` | `"user"` (default) \| `"project"` \| `"local"`. `"managed"` is not accepted (read-only). |
+
+**Write targets per scope:**
+
+| Scope | File | Notes |
+|---|---|---|
+| `user` | `~/.claude.json` | The file `claude mcp add --scope user` writes to. Wrapped JSON (`{"mcpServers": {...}}`). |
+| `project` | `<cwd>/.mcp.json` | Spec-recommended team-shared file. Created wrapped; if it already exists with the legacy flat schema, the existing shape is preserved. |
+| `local` | `<cwd>/.claude.local/settings.json` | Gitignored personal+creds file. Wrapped. |
+
+**Sync semantics.**
+
+- `sync` installs every MCP from the manifest and overwrites overlapping entries (manifest is source of truth).
+- Without `--prune`, MCP entries currently in the runtime config but absent from the manifest are reported as `skip` — same safety pattern as `[[agent_skills]]`.
+- With `--prune`, those entries are removed from their settings file.
+- **Plugin-injected MCPs are never pruned.** If a server name matches one declared by an enabled plugin, it's owned by that plugin and zskills won't touch it.
+- **Managed scope is never written.** Entries appear in `list`/`doctor` but `sync` ignores them.
+
+**Secret handling.** Values in `env`/`headers` should be `${VAR}` references; the actual secret stays in your shell. Literal values are not blocked but they land in the JSON verbatim — which means they'd go straight into git-committed files at `project` scope. The recommendation is documentation, not enforcement.
+
 ## Agent skills manifest schema
 
 The `[[agent_skills]]` table supports four orthogonal fields, used in combination:

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -155,13 +155,50 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
         .cloned()
         .collect();
 
+    // -------- 2.5) MCP reconciliation --------
+    // Validate every manifest entry up-front; bail on any error so we don't half-apply.
+    for m in &manifest.mcps {
+        m.validate()?;
+    }
+    let desired_mcp_keys: BTreeSet<(crate::mcp::Scope, String)> = manifest
+        .mcps
+        .iter()
+        .map(|m| {
+            let scope = match m.scope_kind().unwrap() {
+                "user" => crate::mcp::Scope::User,
+                "project" => crate::mcp::Scope::Project,
+                "local" => crate::mcp::Scope::Local,
+                _ => unreachable!(),
+            };
+            (scope, m.name.clone())
+        })
+        .collect();
+    // Current state: every writable, manually-added MCP. Skip managed (read-only)
+    // and skip plugin-injected (owned by their plugin, not by zskills's manifest).
+    let current_mcps = crate::mcp::load_all().unwrap_or_default();
+    let current_mcp_keys: BTreeSet<(crate::mcp::Scope, String)> = current_mcps
+        .iter()
+        .filter(|m| m.scope != crate::mcp::Scope::Managed)
+        .filter(|m| matches!(m.source, crate::mcp::Source::Manual))
+        .map(|m| (m.scope.clone(), m.name.clone()))
+        .collect();
+
+    let mcps_to_install: Vec<_> = desired_mcp_keys.difference(&current_mcp_keys).collect();
+    // Sync always rewrites the manifest's entries (overwrite-on-overlap) so the
+    // file is the source of truth; explicit "update" tracking is unnecessary.
+    let mcps_to_update: Vec<_> = desired_mcp_keys.intersection(&current_mcp_keys).collect();
+    let mcps_to_remove: Vec<_> = current_mcp_keys.difference(&desired_mcp_keys).collect();
+
     // -------- 3) Print plan --------
     println!("\n{}", "Plan".bold());
     let nothing = plugins_to_enable.is_empty()
         && plugins_to_disable.is_empty()
         && agent_to_install_named.is_empty()
         && agent_to_remove.is_empty()
-        && deferred_sources_to_install.is_empty();
+        && deferred_sources_to_install.is_empty()
+        && mcps_to_install.is_empty()
+        && mcps_to_update.is_empty()
+        && mcps_to_remove.is_empty();
     if nothing {
         println!("  (no changes — manifest matches current state)");
         return Ok(());
@@ -205,6 +242,44 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
                 "·".dimmed(),
                 n,
                 "(in inventory but not in manifest — pass --prune to delete)".dimmed()
+            );
+        }
+    }
+    for (scope, name) in &mcps_to_install {
+        println!(
+            "  {} install mcp     {} {}",
+            "+".green(),
+            name,
+            format!("({})", scope.label()).dimmed()
+        );
+    }
+    for (scope, name) in &mcps_to_update {
+        println!(
+            "  {} update  mcp     {} {}",
+            "~".cyan(),
+            name,
+            format!("({}) — manifest wins on conflict", scope.label()).dimmed()
+        );
+    }
+    for (scope, name) in &mcps_to_remove {
+        if prune {
+            println!(
+                "  {} remove  mcp     {} {}",
+                "-".red(),
+                name,
+                format!("({}) — not in manifest, will be deleted", scope.label()).dimmed()
+            );
+        } else {
+            println!(
+                "  {} skip    mcp     {} {}",
+                "·".dimmed(),
+                name,
+                format!(
+                    "({}) — in {} but not in manifest, pass --prune to delete",
+                    scope.label(),
+                    scope.label()
+                )
+                .dimmed()
             );
         }
     }
@@ -321,6 +396,35 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
             match crate::agent_skill::remove(n) {
                 Ok(_) => println!("  removed agent skill {}", n.bold()),
                 Err(e) => eprintln!("{} {}: {}", "✗".red(), n, e),
+            }
+        }
+    }
+
+    // -------- 5) Apply MCP changes --------
+    for m in &manifest.mcps {
+        // validate() already ran above, but scope_kind() may fail at runtime if a
+        // future field is added; tolerate per-entry errors without aborting the rest.
+        let scope = match m.scope_kind() {
+            Ok("user") => crate::mcp::Scope::User,
+            Ok("project") => crate::mcp::Scope::Project,
+            Ok("local") => crate::mcp::Scope::Local,
+            _ => {
+                eprintln!("{} mcp `{}`: invalid scope", "✗".red(), m.name);
+                continue;
+            }
+        };
+        if let Err(e) = crate::mcp::upsert(&scope, &m.name, m.to_json_value()) {
+            eprintln!("{} mcp `{}`: {}", "✗".red(), m.name, e);
+        } else {
+            println!("  applied mcp {} ({})", m.name.bold(), scope.label());
+        }
+    }
+    if prune {
+        for (scope, name) in &mcps_to_remove {
+            if let Err(e) = crate::mcp::remove(scope, name) {
+                eprintln!("{} mcp `{}`: {}", "✗".red(), name, e);
+            } else {
+                println!("  removed mcp {} ({})", name.bold(), scope.label());
             }
         }
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -25,6 +25,10 @@ pub struct Manifest {
     /// Agent Skills (the older raw-SKILL.md format, installed into ~/.claude/skills/).
     #[serde(default)]
     pub agent_skills: Vec<AgentSkillEntry>,
+
+    /// MCP servers — written into the runtime's `mcpServers` map at the chosen scope.
+    #[serde(default)]
+    pub mcps: Vec<McpEntry>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -41,6 +45,139 @@ impl SkillEntry {
         self.marketplace
             .as_ref()
             .map(|m| format!("{}@{}", self.name, m))
+    }
+}
+
+/// An MCP server declaration in `skills.toml`.
+///
+/// Exactly one of `command` (stdio) or `url` (http/sse) must be present.
+/// `transport` is optional and inferred: `command` → stdio, `url` → http
+/// (set `transport = "sse"` explicitly if you need the deprecated SSE shape).
+///
+/// `env` and `headers` values should use `${VAR}` references — the manifest
+/// is meant to be reproducible and shareable, so literal secrets land in the
+/// user's shell environment, not in the TOML.
+///
+/// `scope` controls which file zskills writes to:
+/// - `"user"` (default) → `~/.claude.json`
+/// - `"project"` → `<cwd>/.mcp.json`
+/// - `"local"` → `<cwd>/.claude.local/settings.json`
+///
+/// `"managed"` is not accepted — that scope is read-only (deployed by IT).
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct McpEntry {
+    pub name: String,
+    /// `"stdio"` | `"http"` | `"sse"`. Inferred if absent.
+    #[serde(default)]
+    pub transport: Option<String>,
+    // stdio fields
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: std::collections::BTreeMap<String, String>,
+    // http / sse fields
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub headers: std::collections::BTreeMap<String, String>,
+    /// `"user"` (default) | `"project"` | `"local"`.
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+impl McpEntry {
+    /// Resolve the transport kind, preferring an explicit `transport` value
+    /// and falling back to inference from `command` (→ stdio) or `url` (→ http).
+    pub fn transport_kind(&self) -> &'static str {
+        match self.transport.as_deref() {
+            Some("stdio") => "stdio",
+            Some("http") => "http",
+            Some("sse") => "sse",
+            _ if self.command.is_some() => "stdio",
+            _ if self.url.is_some() => "http",
+            _ => "stdio", // fallback — validate() will catch the missing fields
+        }
+    }
+
+    /// Resolve the scope, defaulting to `"user"`. Returns an error if invalid.
+    pub fn scope_kind(&self) -> Result<&'static str> {
+        match self.scope.as_deref().unwrap_or("user") {
+            "user" => Ok("user"),
+            "project" => Ok("project"),
+            "local" => Ok("local"),
+            "managed" => anyhow::bail!(
+                "scope=managed is not writable — managed settings are deployed by IT, not zskills"
+            ),
+            other => anyhow::bail!(
+                "unknown scope {:?} (must be user, project, or local)",
+                other
+            ),
+        }
+    }
+
+    /// Validate that the entry has the required fields for its transport.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            anyhow::bail!("mcp entry missing required field `name`");
+        }
+        self.scope_kind()?;
+        match self.transport_kind() {
+            "stdio" => {
+                if self.command.is_none() {
+                    anyhow::bail!("mcp `{}`: stdio transport requires `command`", self.name);
+                }
+                if self.url.is_some() {
+                    anyhow::bail!(
+                        "mcp `{}`: stdio entry has stray `url` — pick one transport",
+                        self.name
+                    );
+                }
+            }
+            "http" | "sse" => {
+                if self.url.is_none() {
+                    anyhow::bail!("mcp `{}`: http/sse transport requires `url`", self.name);
+                }
+                if self.command.is_some() {
+                    anyhow::bail!(
+                        "mcp `{}`: http/sse entry has stray `command` — pick one transport",
+                        self.name
+                    );
+                }
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
+    /// Convert to the JSON shape the runtime expects under `mcpServers["<name>"]`.
+    pub fn to_json_value(&self) -> serde_json::Value {
+        use serde_json::{json, Map, Value};
+        let mut obj = Map::new();
+        match self.transport_kind() {
+            "stdio" => {
+                obj.insert(
+                    "command".into(),
+                    json!(self.command.clone().unwrap_or_default()),
+                );
+                if !self.args.is_empty() {
+                    obj.insert("args".into(), json!(self.args));
+                }
+                if !self.env.is_empty() {
+                    obj.insert("env".into(), json!(self.env));
+                }
+            }
+            kind @ ("http" | "sse") => {
+                obj.insert("type".into(), json!(kind));
+                obj.insert("url".into(), json!(self.url.clone().unwrap_or_default()));
+                if !self.headers.is_empty() {
+                    obj.insert("headers".into(), json!(self.headers));
+                }
+            }
+            _ => unreachable!(),
+        }
+        Value::Object(obj)
     }
 }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "lowercase")]
 pub enum Scope {
     Managed,
@@ -271,19 +271,30 @@ fn parse_transport(entry: &Value) -> Option<Transport> {
         }
         // No `type` → stdio (Claude's default).
         _ => {
-            let (env_keys, env_refs) = keys_and_refs(obj.get("env"));
+            let (env_keys, mut env_refs) = keys_and_refs(obj.get("env"));
+            let args: Vec<String> = obj
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|x| x.as_str())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+            // Real-world configs (e.g. the mcp-remote proxy pattern) embed
+            // `${VAR}` references inside args, not just env values. Surface
+            // those too so doctor can check whether they're set.
+            for a in &args {
+                for r in extract_var_refs(a) {
+                    if !env_refs.contains(&r) {
+                        env_refs.push(r);
+                    }
+                }
+            }
             Some(Transport::Stdio {
                 command: obj.get("command")?.as_str()?.to_string(),
-                args: obj
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|x| x.as_str())
-                            .map(str::to_string)
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                args,
                 env_keys,
                 env_refs,
             })
@@ -402,6 +413,101 @@ fn build_plugin_mcp_index() -> Result<BTreeMap<String, String>> {
     Ok(idx)
 }
 
+/// Resolve the on-disk file zskills writes to for a given scope.
+/// Returns the path AND a flag telling callers whether to use the wrapped
+/// `{"mcpServers": {...}}` JSON shape (true) or a flat top-level map (false).
+///
+/// - `user`    → `~/.claude.json` (wrapped — matches what `claude mcp` writes).
+/// - `project` → `<cwd>/.mcp.json` (wrapped *if* the file already exists with
+///   the wrapper; otherwise flat — preserves what's there. New files get wrapped
+///   per the spec).
+/// - `local`   → `<cwd>/.claude.local/settings.json` (wrapped — it's a
+///   settings.json variant).
+///
+/// `managed` is intentionally not supported: that scope is read-only.
+pub fn write_target(scope: &Scope) -> Result<(PathBuf, bool)> {
+    match scope {
+        Scope::User => Ok((crate::paths::claude_json()?, true)),
+        Scope::Local => {
+            let cwd = std::env::current_dir()?;
+            Ok((cwd.join(".claude.local").join("settings.json"), true))
+        }
+        Scope::Project => {
+            let cwd = std::env::current_dir()?;
+            let path = cwd.join(".mcp.json");
+            let wrapped = if !path.exists() {
+                true // default to spec-compliant for new files
+            } else {
+                match read_json(&path) {
+                    Some(v) => v.get("mcpServers").is_some(),
+                    None => true,
+                }
+            };
+            Ok((path, wrapped))
+        }
+        Scope::Managed => {
+            anyhow::bail!("cannot write to managed scope — deployed by IT, not zskills")
+        }
+    }
+}
+
+/// Set or replace one MCP server entry in the target file for `scope`. Atomic.
+/// `name` is the server name; `entry` is the JSON value to store under it.
+pub fn upsert(scope: &Scope, name: &str, entry: serde_json::Value) -> Result<()> {
+    let (path, wrapped) = write_target(scope)?;
+    write_with_mutation(&path, wrapped, |servers| {
+        servers.insert(name.to_string(), entry);
+    })
+}
+
+/// Remove one MCP server entry from the target file for `scope`. Atomic.
+/// No-op if the entry isn't present.
+pub fn remove(scope: &Scope, name: &str) -> Result<()> {
+    let (path, wrapped) = write_target(scope)?;
+    if !path.exists() {
+        return Ok(());
+    }
+    write_with_mutation(&path, wrapped, |servers| {
+        servers.shift_remove(name);
+    })
+}
+
+/// Read the target file (creating an empty shell if missing), apply `mutate` to
+/// the mcpServers map, and write back atomically. Preserves all other top-level
+/// keys (hooks, permissions, env, etc.) and the existing wrapped-vs-flat shape.
+fn write_with_mutation(
+    path: &Path,
+    wrapped: bool,
+    mutate: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+) -> Result<()> {
+    use serde_json::{Map, Value};
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let mut top: Map<String, Value> = if path.exists() {
+        let bytes = std::fs::read(path)?;
+        match serde_json::from_slice::<Value>(&bytes)? {
+            Value::Object(m) => m,
+            _ => anyhow::bail!("{} is not a JSON object", path.display()),
+        }
+    } else {
+        Map::new()
+    };
+
+    if wrapped {
+        let servers = top
+            .entry("mcpServers")
+            .or_insert_with(|| Value::Object(Map::new()))
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("mcpServers must be a JSON object"))?;
+        mutate(servers);
+    } else {
+        mutate(&mut top);
+    }
+
+    crate::settings::save(path, &top)
+}
+
 /// Platform-specific path for org/IT-deployed managed settings.
 /// Overridable via `ZSKILLS_MANAGED_SETTINGS` for testing.
 fn managed_settings_path() -> Option<PathBuf> {
@@ -476,6 +582,25 @@ mod tests {
             parse_transport(&v).unwrap().referenced_vars(),
             &["TOK".to_string()]
         );
+    }
+
+    #[test]
+    fn parse_stdio_extracts_refs_from_args_too() {
+        // mcp-remote proxy pattern: `${VAR}` is referenced inside args,
+        // not in the env block. Doctor needs to see those.
+        let v = json!({
+            "command": "npx",
+            "args": [
+                "mcp-remote",
+                "https://example.com",
+                "--header", "Authorization:${AUTH_HEADER}",
+                "--header", "X-User-Name:${USER_NAME}"
+            ],
+            "env": {}
+        });
+        let refs = parse_transport(&v).unwrap().referenced_vars().to_vec();
+        assert!(refs.contains(&"AUTH_HEADER".to_string()));
+        assert!(refs.contains(&"USER_NAME".to_string()));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -753,3 +753,178 @@ fn doctor_passes_when_mcps_are_healthy() {
             predicate::str::contains("All good").or(predicate::str::contains("MCP issue").not()),
         );
 }
+
+#[test]
+fn sync_installs_mcp_from_manifest_into_claude_json() {
+    let (parent, claude_home) = fake_home_nested();
+    let manifest_dir = tempfile::tempdir().unwrap();
+    let manifest_path = manifest_dir.path().join("skills.toml");
+    fs::write(
+        &manifest_path,
+        r#"
+[[mcps]]
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+transport = "http"
+scope = "user"
+
+[[mcps]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+scope = "user"
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+"#,
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["sync", "--file", manifest_path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("install mcp"))
+        .stdout(predicate::str::contains("linear"))
+        .stdout(predicate::str::contains("github"));
+
+    let claude_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(parent.path().join(".claude.json")).unwrap()).unwrap();
+    assert_eq!(claude_json["mcpServers"]["linear"]["type"], "http");
+    assert_eq!(
+        claude_json["mcpServers"]["linear"]["url"],
+        "https://mcp.linear.app/mcp"
+    );
+    assert_eq!(claude_json["mcpServers"]["github"]["command"], "npx");
+    assert_eq!(
+        claude_json["mcpServers"]["github"]["env"]["GITHUB_TOKEN"],
+        "${GITHUB_TOKEN}"
+    );
+}
+
+#[test]
+fn sync_writes_project_mcp_to_dot_mcp_json() {
+    let (parent, claude_home) = fake_home_nested();
+    let manifest_dir = tempfile::tempdir().unwrap();
+    let manifest_path = manifest_dir.path().join("skills.toml");
+    fs::write(
+        &manifest_path,
+        r#"
+[[mcps]]
+name = "postgres"
+command = "docker"
+args = ["run", "--rm", "..."]
+scope = "project"
+"#,
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["sync", "--file", manifest_path.to_str().unwrap()])
+        .assert()
+        .success();
+    let mcp_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(parent.path().join(".mcp.json")).unwrap()).unwrap();
+    assert_eq!(mcp_json["mcpServers"]["postgres"]["command"], "docker");
+}
+
+#[test]
+fn sync_preserves_unrelated_fields_in_claude_json() {
+    let (parent, claude_home) = fake_home_nested();
+    // Pre-populate ~/.claude.json with a bunch of unrelated top-level keys.
+    let claude_json_path = parent.path().join(".claude.json");
+    fs::write(
+        &claude_json_path,
+        serde_json::to_string(&json!({
+            "anonymousId": "abc",
+            "claudeCodeFirstTokenDate": "2026-01-01",
+            "cachedDynamicConfigs": { "foo": "bar" },
+            "mcpServers": { "existing": { "type": "http", "url": "https://x.example" } }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let manifest_dir = tempfile::tempdir().unwrap();
+    let manifest_path = manifest_dir.path().join("skills.toml");
+    fs::write(
+        &manifest_path,
+        r#"
+[[mcps]]
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+scope = "user"
+"#,
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["sync", "--file", manifest_path.to_str().unwrap()])
+        .assert()
+        .success();
+    let after: serde_json::Value =
+        serde_json::from_slice(&fs::read(&claude_json_path).unwrap()).unwrap();
+    // Unrelated fields preserved
+    assert_eq!(after["anonymousId"], "abc");
+    assert_eq!(after["claudeCodeFirstTokenDate"], "2026-01-01");
+    assert_eq!(after["cachedDynamicConfigs"]["foo"], "bar");
+    // New entry landed
+    assert_eq!(
+        after["mcpServers"]["linear"]["url"],
+        "https://mcp.linear.app/mcp"
+    );
+    // Existing entry untouched (sync doesn't prune without --prune)
+    assert_eq!(after["mcpServers"]["existing"]["type"], "http");
+}
+
+#[test]
+fn sync_prune_removes_mcps_not_in_manifest() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_json_path = parent.path().join(".claude.json");
+    fs::write(
+        &claude_json_path,
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "old": { "type": "http", "url": "https://old.example" },
+                "keep": { "type": "http", "url": "https://keep.example" }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let manifest_dir = tempfile::tempdir().unwrap();
+    let manifest_path = manifest_dir.path().join("skills.toml");
+    fs::write(
+        &manifest_path,
+        r#"
+[[mcps]]
+name = "keep"
+url = "https://keep.example"
+scope = "user"
+"#,
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["sync", "--file", manifest_path.to_str().unwrap(), "--prune"])
+        .assert()
+        .success();
+    let after: serde_json::Value =
+        serde_json::from_slice(&fs::read(&claude_json_path).unwrap()).unwrap();
+    assert!(after["mcpServers"].get("old").is_none());
+    assert!(after["mcpServers"].get("keep").is_some());
+}
+
+#[test]
+fn sync_rejects_invalid_mcp_entry() {
+    let (parent, claude_home) = fake_home_nested();
+    let manifest_dir = tempfile::tempdir().unwrap();
+    let manifest_path = manifest_dir.path().join("skills.toml");
+    // No command AND no url → stdio inferred, missing command → validation fails.
+    fs::write(
+        &manifest_path,
+        r#"
+[[mcps]]
+name = "broken"
+scope = "user"
+"#,
+    )
+    .unwrap();
+    zskills_nested(&parent, &claude_home)
+        .args(["sync", "--file", manifest_path.to_str().unwrap()])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## Summary

The third primitive zskills now manages declaratively: MCP servers. With this, \`skills.toml\` is the single source of truth for plugins, Agent Skills, **and** MCP servers across all scopes Claude Code understands.

\`\`\`toml
[[mcps]]
name = \"github\"
command = \"npx\"
args = [\"-y\", \"@modelcontextprotocol/server-github\"]
env = { GITHUB_TOKEN = \"\${GITHUB_TOKEN}\" }
scope = \"user\"

[[mcps]]
name = \"linear\"
url = \"https://mcp.linear.app/mcp\"
scope = \"user\"
\`\`\`

## Stacked on #11

This PR's base is \`feat/mcp-doctor\` (PR #11). When #11 merges, the base auto-retargets to \`main\` and the diff narrows to just M2's files.

## Sync semantics

- **Install / update**: in manifest → written to scope file. Manifest wins on conflicts.
- **Remove**: in current settings but not in manifest → skip by default, deleted with \`--prune\` (same safety pattern as \`[[agent_skills]]\`).
- **Plugin-injected MCPs never pruned**: a server name matching one declared by an enabled plugin's \`plugin.json\` / \`.mcp.json\` is owned by that plugin; zskills won't touch it.
- **Managed scope never written**: read-only by design.

## Per-scope write targets

| Scope | File | Shape |
|---|---|---|
| \`user\` | \`~/.claude.json\` | wrapped (\`{\"mcpServers\": {...}}\`) — matches what \`claude mcp\` writes |
| \`project\` | \`<cwd>/.mcp.json\` | wrapped for new files; preserves existing flat shape if present |
| \`local\` | \`<cwd>/.claude.local/settings.json\` | wrapped |

Atomic writes via tempfile + rename. Unrelated top-level keys (\`anonymousId\`, \`hooks\`, cached configs) are preserved — verified by integration test.

## Bug fix bundled in

The M3 parser only extracted \`\${VAR}\` refs from \`env\` and \`headers\`, not from stdio \`args\`. The real-world \`mcp-remote\` proxy pattern (e.g. the honcho config we saw in chat) embeds credential refs in \`--header\` args, so doctor was silently missing those. Fixed; new unit test covers it.

## Test plan

- [x] \`cargo test\` — 48/48 (15 unit + 33 integration, +6 new this PR)
- [x] \`cargo fmt --all --check\` clean
- [x] No real-config smoke test for sync (writing is destructive; tests cover all the write paths against fake homes)

## Out of scope

- **Update detection**: sync always overwrites overlapping entries rather than comparing first. Acceptable trade-off — manifest is source of truth, file rewrites are atomic, semantic content is preserved. Could add a no-op skip later if file rewrites become noisy.
- **Inline-secret detection**: literal values in \`env\`/\`headers\` aren't blocked or warned today. Documented as a recommendation, not enforcement.
- **Adapter trait for non-Claude runtimes**: M2 stays Claude-specific. The data shapes were designed to extend cleanly when grok-cli / Codex adapters arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)