### PR TITLE
docs: ship Agent Skill + MCP-aware docs for v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ cargo install --git https://github.com/zot24/zskills
 
 Requires `git` on `$PATH`.
 
+### Companion Agent Skill
+
+This repo also ships an Agent Skill that teaches Claude how to use zskills. Add it to your `skills.toml`:
+
+```toml
+[[agent_skills]]
+source = "zot24/zskills"
+```
+
+Then `zskills sync`. Claude will reach for zskills with confidence for install / search / sync / doctor / MCP management.
+
 ## Why
 
 Existing tooling is per-runtime, per-language, and per-primitive: there's a JavaScript shim for Claude skills, a separate flow for MCP servers, no way to track ownership across machines, no declarative reproducibility. zskills is a single static binary that:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-How zskills models the three sources of truth in your Claude Code install and reconciles between them.
+How zskills models the three sources of truth in your Claude Code install — across three primitives — and reconciles between them.
 
 ## The three states
 
@@ -8,13 +8,13 @@ How zskills models the three sources of truth in your Claude Code install and re
 |---|---|---|
 | **Intent** | `skills.toml` | What you *want* installed and enabled |
 | **Inventory** | `~/.claude/plugins/installed_plugins.json` + `~/.claude/skills/.zskills.json` | What *exists* on disk |
-| **Activation** | `~/.claude/settings.json` → `enabledPlugins` | What's currently *running* in a Claude Code session |
+| **Activation** | `~/.claude/settings.json` → `enabledPlugins`; `~/.claude.json` + per-scope MCP files → `mcpServers` | What's currently *running* in a Claude Code session |
 
-The first is what zskills writes from. The second and third are what Claude Code reads. zskills' job is to keep all three consistent.
+The first is what zskills writes from. The second and third are what Claude Code reads. zskills' job is to keep all three consistent across all three primitives.
 
-## Two ecosystems
+## Three primitives
 
-Claude Code has two parallel skill systems that we manage from one manifest:
+zskills models a single manifest over three first-class types of artifact, each with its own activation surface:
 
 ### Claude Code plugins
 - Distributed via **marketplaces** (Git repos with a `.claude-plugin/marketplace.json`)
@@ -29,7 +29,21 @@ Claude Code has two parallel skill systems that we manage from one manifest:
 - No "enabled" flag — files-on-disk *is* the activation
 - Inventory: `~/.claude/skills/.zskills.json` (we own this; Claude Code doesn't write it)
 
-Both kinds are declared in `skills.toml`:
+### MCP servers
+- No "installed bytes" of zskills's own — the MCP server is just a process to spawn (stdio) or a URL to call (http/sse). Inventory and activation collapse into the same record.
+- Activation lives in `mcpServers` keys across multiple files, by scope:
+
+  | Scope | File | Notes |
+  |---|---|---|
+  | `managed` | `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS) / `/etc/claude-code/managed-settings.json` (Linux) | IT-deployed. Read-only — `sync` never writes here. |
+  | `local` | `<cwd>/.claude.local/settings.json` | Gitignored, personal+creds. |
+  | `project` | `<cwd>/.mcp.json` (recommended) OR `<cwd>/.claude/settings.json` (legacy) | Team-shared via git. |
+  | `user` | `~/.claude.json` (where `claude mcp add --scope user` writes) AND `~/.claude/settings.json` | Both are loaded; sync writes to `~/.claude.json`. |
+  | (attribution) | Each enabled plugin's `plugin.json` + sibling `.mcp.json` | Plugin-bundled entries — surfaced in `list` as `★ plugin:<name>`, **never pruned** by sync. |
+
+- The data model in `src/mcp.rs` (`McpServer { name, scope, transport, source, source_file }`) is intentionally runtime-agnostic — when grok-cli / Codex adapters arrive, only the loader paths change; the struct stays.
+
+All three are declared in `skills.toml`:
 
 ```toml
 [[skills]]                          # plugin
@@ -41,6 +55,18 @@ source = "owner/repo"
 
 [[agent_skills]]                    # local-only agent skill
 name = "my-internal-tool"           # name required; source omitted = no remote refresh
+
+[[mcps]]                            # MCP server, stdio transport
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+scope = "user"
+
+[[mcps]]                            # MCP server, http transport
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+scope = "user"
 ```
 
 ## Atomic JSON writes
@@ -105,13 +131,16 @@ Same idea for `skills.toml` writes: we use `toml_edit::DocumentMut` so existing 
                          doctor
 ```
 
-Three failure modes:
+Failure modes covered by doctor:
 
-1. **Settings says enabled, inventory says nothing** — broken reference. Claude Code's startup install will fix this on next launch, OR `doctor --fix` removes the flag.
+1. **Settings says enabled, inventory says nothing** — broken plugin reference. Claude Code's startup install will fix this on next launch, OR `doctor --fix` removes the flag.
 2. **Inventory says installed, marketplace gone** — orphan from a `marketplace remove`. `doctor` reports; `purge` cleans.
 3. **Agent skill inventory entry, no bytes on disk** — someone `rm -rf`'d the skill manually. `doctor --fix` drops the inventory entry; `sync` would reinstall from manifest.
+4. **MCP stdio command not found on `$PATH`** — flagged per-server; `--fix` is a no-op (we won't install missing binaries).
+5. **MCP `${VAR}` reference but the env var is unset** — flagged per-server; `--fix` is a no-op (we won't invent env vars).
+6. **MCP uses deprecated `sse` transport** — flagged; the spec recommends migrating to `http`.
 
-Doctor never deletes plugin bytes. That's `purge`'s job — a deliberate, explicit operation.
+Doctor never deletes plugin bytes — that's `purge`'s job. Doctor also **never spawns or contacts an MCP server**: runtime state (connection, latency, last error) is Claude Code's domain. Replicating it here would risk divergent diagnoses ("zskills says fine, Claude says auth failed"). Static checks only.
 
 ## Marketplace update strategies
 
@@ -187,20 +216,31 @@ The trade-off is one process spawn per fetch, which is fine: marketplace updates
 ## Path resolution
 
 ```
+~/.claude.json                          MCP servers (user scope, where `claude mcp` writes)
 ~/.claude/                              ($CLAUDE_HOME)
-├── settings.json                       activation
+├── settings.json                       activation; may also carry mcpServers
 ├── plugins/
 │   ├── installed_plugins.json          plugin inventory
 │   ├── known_marketplaces.json         tap registry
 │   ├── marketplaces/<name>/            tap clones
 │   └── cache/<mp>/<name>/<v>/          plugin bytes
+│        └── .claude-plugin/plugin.json plugin manifest (may declare mcpServers)
+│        └── .mcp.json                  plugin-bundled MCP servers (sibling shape)
 └── skills/
     ├── .zskills.json                   agent skill inventory
     └── <name>/SKILL.md                 agent skill bytes
 
+<cwd>/.mcp.json                         project-scope MCPs (team-shared, git-committed)
+<cwd>/.claude/settings.json             legacy project-scope MCPs + enabledPlugins
+<cwd>/.claude.local/settings.json       local-scope MCPs (gitignored, personal+creds)
+
+/Library/Application Support/ClaudeCode/managed-settings.json   managed MCPs (macOS, IT-deployed, read-only)
+/etc/claude-code/managed-settings.json                          managed MCPs (Linux)
+                                        Override with $ZSKILLS_MANAGED_SETTINGS.
+
 $XDG_CACHE_HOME/zskills/agent-skills/<owner>-<repo>/  source clones
 $XDG_CONFIG_HOME/zskills/skills.toml                  manifest (fallback)
-./skills.toml                                         manifest (project-scope wins)
+./skills.toml                                         manifest (project-scope wins, NOT auto-loaded since v0.5.1)
 ```
 
 `CLAUDE_HOME` env var overrides `~/.claude`. `XDG_CACHE_HOME` and `XDG_CONFIG_HOME` are respected. On macOS, zskills uses `~/.config/zskills/` for the manifest by default (matching cargo/starship/atuin) rather than the platform's `~/Library/Application Support/` location.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,19 @@ source = "jakubkrehel/make-interfaces-feel-better"
 [[agent_skills]]
 npm = "get-shit-done-cc"
 claims = ["gsd-*"]
+
+# MCP servers (v0.7+)
+[[mcps]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+scope = "user"
+
+[[mcps]]
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+scope = "user"
 ```
 
 Then:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -178,6 +178,69 @@ rustup update stable
 cargo install --git https://github.com/zot24/zskills --force
 ```
 
+## `doctor` flags `command not found on $PATH` for an MCP
+
+The MCP server's `command` (stdio transport) doesn't resolve via `which`-style lookup. Two fixes:
+
+- Install the binary. For npx-launched servers, `npx` itself is on PATH but a global like `node` is required first.
+- If the config has a non-absolute name pointing at something only available in a Node/Python project shell, switch to an absolute path or wrap with `npx -y <package>`.
+
+zskills never spawns the server itself; the check is purely "is the file findable." So this catches the common "I'm not in the right shell environment" case before Claude Code does.
+
+## `doctor` says `env var X is referenced but not set`
+
+An MCP entry references `${X}` in `env`, `headers`, or `args`, but `X` isn't defined in your shell. Export it (and put it in your shell rc for persistence):
+
+```bash
+export GITHUB_TOKEN=ghp_...
+```
+
+zskills extracts `${VAR}` references from values **without storing the values themselves** — only the variable *names* land in our data structures. So this check is safe even if you paste a literal secret elsewhere in the same entry.
+
+## `doctor` says `transport sse is deprecated`
+
+The MCP spec marks `sse` as legacy in favor of `http`. To migrate an existing entry, edit its config:
+
+```diff
+-{ "type": "sse",  "url": "https://x.example/sse" }
++{ "type": "http", "url": "https://x.example/http" }
+```
+
+(Check the server's docs for the correct HTTP endpoint — it usually differs from the SSE endpoint.) If you manage MCPs declaratively, change `transport = "http"` (or remove `transport` to let zskills infer it from `url`) and run `zskills sync`.
+
+## `sync` overwrote my hand-edited MCP entry
+
+`sync` treats `skills.toml` as the source of truth: any MCP in the manifest is rewritten to match the manifest's values on every run. If you customized an entry in `~/.claude.json` directly, those changes are lost on the next sync.
+
+Two options:
+
+- **Move the customization into the manifest** so it's tracked and reproducible.
+- **Remove the entry from `skills.toml`** — then the manifest doesn't claim ownership and sync leaves it alone (and without `--prune`, never removes it).
+
+## MCP entry didn't appear after `zskills sync` — where did it go?
+
+Check the scope you targeted. zskills writes per-scope:
+
+- `scope = "user"` → `~/.claude.json` (NOT `~/.claude/settings.json` — that file isn't where `claude mcp` writes today)
+- `scope = "project"` → `<cwd>/.mcp.json`
+- `scope = "local"` → `<cwd>/.claude.local/settings.json`
+
+Verify with `zskills list --paths`. If the entry shows up there but Claude Code doesn't see it, restart Claude Code (or use its `/mcp` flow) so it re-reads the settings file.
+
+## `zskills list` doesn't show an MCP that exists in my managed-settings file
+
+It should, with `scope = managed`. If it doesn't:
+
+- Confirm the file exists at `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS) or `/etc/claude-code/managed-settings.json` (Linux).
+- Confirm `mcpServers` is a top-level key in that file.
+- Set `ZSKILLS_MANAGED_SETTINGS=<absolute-path>` to override the auto-discovered path (useful when corp IT puts it elsewhere, or for CI where you want to skip the probe).
+
+Managed scope is **read-only** by design — `zskills sync` never writes to it, even with `--prune`.
+
+## I want to remove an MCP from one scope without touching others
+
+`sync --prune` removes everything not in the manifest, across every writable scope. For a one-MCP one-scope removal today, edit the relevant settings file directly (or use `claude mcp remove` if it targets the scope you want). A finer-grained removal API is on the [roadmap](https://github.com/zot24/zskills/issues/14).
+
 ## How do I uninstall zskills entirely?
 
 ```bash

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -173,7 +173,91 @@ Moves both `enabledPlugins` entries from the project's `.claude/settings.json` (
 
 zskills doesn't push this direction yet (user-scope → project-scope). If you need a particular project to pin an exact version of a skill that diverges from the global one, copy `~/.claude/skills/<name>/` into the project's `.claude/skills/<name>/` and commit it. Claude Code resolves project scope before user scope, so the project's pinned copy wins.
 
-## 13. Find a skill before installing it
+## 13. See every MCP server configured on this machine
+
+Claude Code can read MCP servers from up to six files (per scope). `zskills list` aggregates the lot and attributes plugin-injected entries:
+
+```bash
+zskills list                # everything; MCPs are the last section
+zskills list --paths        # also show which file each entry was loaded from
+zskills list --json | jq '.mcp_servers'
+```
+
+Output looks like:
+
+```
+MCP Servers
+  user (3)
+    github          stdio  npx -y @modelcontextprotocol/server-github  ★ plugin:github  (1 env)
+    honcho          http   https://mcp.honcho.dev                                       (3 headers)
+    linear-server   http   https://mcp.linear.app/mcp
+  project (1)
+    postgres        stdio  docker run --rm postgres-mcp                                 (2 envs)
+```
+
+Only `env` / `header` *keys* are surfaced — values are never read into memory, so the output is safe even if a secret got pasted in literally instead of as a `${VAR}` ref.
+
+## 14. Declare MCP servers in the manifest
+
+```toml
+[[mcps]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+scope = "user"
+
+[[mcps]]
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+scope = "user"
+```
+
+```bash
+zskills sync                # writes both into ~/.claude.json atomically
+```
+
+Restart Claude Code (or use its `/mcp` prompt) so it picks up the new servers.
+
+## 15. Centralize scattered MCP configs
+
+You've added MCP servers ad-hoc with `claude mcp add` from different projects; now they're spread across `~/.claude.json`, project `.mcp.json` files, and one rogue `.claude.local/settings.json`. To consolidate at user scope:
+
+1. **See what's where:**
+
+   ```bash
+   zskills list --paths
+   ```
+
+2. **Manually transcribe each into `~/.config/zskills/skills.toml`** as `[[mcps]]` entries. Use `${VAR}` refs for any credentials — never paste literal tokens.
+
+3. **Sync with prune** to write at user scope AND delete the duplicates from other scopes:
+
+   ```bash
+   zskills sync --prune
+   ```
+
+`--prune` removes MCP entries currently in settings files but absent from the manifest. **Plugin-injected MCPs are never pruned** — zskills detects them by name match against every enabled plugin's `plugin.json` / sibling `.mcp.json` and leaves them alone. **Managed scope is never written** — IT-deployed entries are read-only.
+
+A `dump-mcps` helper to skip the manual transcription step is on the roadmap (see [issue #14](https://github.com/zot24/zskills/issues/14)).
+
+## 16. Validate MCPs before launching Claude Code
+
+```bash
+zskills doctor
+```
+
+Three static checks per MCP server, no process spawning:
+
+- **stdio**: `command` must resolve on `$PATH` (e.g. `npx` is installed, the package would be reachable).
+- **any transport**: every `${VAR}` referenced in `env` / `headers` / `args` must be defined in your shell environment.
+- **sse transport**: flagged as deprecated; switch to `transport = "http"`.
+
+`--fix` is a no-op for MCP findings — none of them are auto-fixable (zskills won't install a missing binary or invent an env var). The contribution is surfacing the problem so you know before Claude Code complains.
+
+Doctor never spawns or talks to a server. Runtime health (connection, latency, last error) is Claude Code's job; replicating it here would risk divergent diagnoses.
+
+## 17. Find a skill before installing it
 
 You remember there's a Stripe integration somewhere but you don't know which marketplace ships it:
 

--- a/skills/zskills/SKILL.md
+++ b/skills/zskills/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: zskills
+description: Declarative package manager for agentic coding CLIs — manages skills, plugins, and MCP servers across user/project/local scopes via a single skills.toml manifest. Use when installing, removing, listing, syncing, or troubleshooting Claude Code plugins, Agent Skills, or MCP servers; when reconciling drift between settings.json and on-disk state; when bootstrapping a fresh machine; or when consolidating scattered configs from many projects into one global place.
+allowed-tools: Bash, Read, Edit, Write
+---
+
+# zskills
+
+A single Rust binary that manages three primitives for Claude Code (and, by design, future agentic CLIs like grok-cli / Codex):
+
+- **Plugins** — marketplace-distributed, controlled via `~/.claude/settings.json` → `enabledPlugins`
+- **Agent Skills** — raw `SKILL.md` directories under `~/.claude/skills/<name>/`
+- **MCP servers** — declared in `~/.claude.json`, `<project>/.mcp.json`, `<project>/.claude/settings.json`, `<project>/.claude.local/settings.json`, and (read-only) `/Library/Application Support/ClaudeCode/managed-settings.json`
+
+Everything reconciles atomically from one `skills.toml` manifest. Preserves every unknown JSON field — hooks, permissions, env, anything Claude Code adds.
+
+## When to use
+
+- **Installing things**: `zskills install <name>` (or `zskills install -i` for fuzzy picker) is faster and safer than editing `settings.json` by hand.
+- **Bootstrapping a machine**: drop your `skills.toml` in `~/.config/zskills/`, run `zskills sync`. Reproducible.
+- **MCP visibility**: `zskills list` aggregates every MCP across all 6 known sources with plugin attribution — no other tool surfaces plugin-injected servers separately.
+- **MCP validation**: `zskills doctor` statically checks command-on-PATH, unset `${VAR}` refs, deprecated SSE transport — without spawning anything.
+- **Consolidating scattered configs**: project-scope skills/MCPs duplicated across many repos can be promoted to user scope (skills today; MCPs is a roadmap item, see issue #14).
+- **Diagnosing drift**: `zskills doctor` reports broken references, orphans, dangling inventory entries. `--fix` cleans (without deleting bytes).
+
+## When NOT to use
+
+- Don't reach for zskills to *configure* a single MCP one-off — `claude mcp add` is fine for that, and zskills's value is the manifest-driven reproducibility, not CRUD parity.
+- Don't use zskills to manage Claude Code itself (it doesn't install/upgrade Claude Code, only skills/plugins/MCPs).
+
+## Commands
+
+```bash
+# Listing
+zskills list                       # what's installed across plugins, Agent Skills, MCPs
+zskills list --paths               # also show on-disk location of every entry
+zskills list -v                    # expand grouped npm-bundle agent skills
+zskills list --json                # machine-readable for scripting
+
+# Search + install
+zskills search <query>             # substring-match across registered marketplaces
+zskills search <query> -i          # also opens an interactive picker; selection installs
+zskills install <name>             # name@marketplace if ambiguous
+zskills install -i                 # fuzzy-pick from all marketplaces (no <name> needed)
+zskills install -i                 # uses fzf if on $PATH; falls back to built-in picker
+
+# Remove
+zskills remove <name>              # apt-style: disable + drop inventory, keep bytes
+zskills remove -i                  # multi-select picker over enabled plugins
+zskills purge <name>               # also delete bytes
+
+# Enable / disable without (un)installing
+zskills enable <name>
+zskills disable <name>
+
+# Declarative manifest (the headline command)
+zskills sync                       # apply ~/.config/zskills/skills.toml
+zskills sync --dry-run             # preview
+zskills sync --prune               # destructive removals: delete agent skill bytes and
+                                   # MCP entries not in manifest
+zskills sync --file ./skills.toml  # project-local manifest (NOT auto-loaded)
+
+# Refresh from origin
+zskills upgrade                    # marketplaces + git agent skills + npm agent skills
+zskills upgrade <name>...          # narrow to specific entries
+
+# Diagnostics
+zskills doctor                     # report plugin / inventory / MCP issues
+zskills doctor --fix               # clean dangling references (never deletes bytes)
+
+# Project-scope discovery + promotion
+zskills scan [path]                # find project-scope skills across a tree
+zskills migrate <project>          # promote one project's skills to user scope
+zskills migrate <project> --remove-from-project
+zskills migrate-skill <name>       # promote ONE skill across every project
+zskills migrate-all <dir>          # interactive sweep, prompt per duplicated skill
+
+# Marketplace registry
+zskills marketplace add <owner/repo>
+zskills marketplace add-recommended  # seed Anthropic-official defaults
+zskills marketplace list
+zskills marketplace update [name]    # git pull / tarball fetch
+zskills marketplace remove <name>
+```
+
+## Manifest schema (skills.toml)
+
+```toml
+# ──── Plugins (marketplace-distributed) ────
+[[skills]]
+name = "umbrel-app"
+marketplace = "zot24-skills"
+
+[[skills]]
+name = "github"
+marketplace = "claude-plugins-official"
+
+# ──── Agent Skills (raw SKILL.md format) ────
+# Git repo with skills/<name>/SKILL.md
+[[agent_skills]]
+source = "jakubkrehel/make-interfaces-feel-better"
+
+# Pick ONE skill out of a multi-skill repo
+[[agent_skills]]
+source = "owner/multi-skill-repo"
+name = "specific-skill"
+
+# npm package with glob ownership over installed directories
+[[agent_skills]]
+npm = "get-shit-done-cc"
+claims = ["gsd-*"]
+
+# Local-only entry (just tracked, never refreshed)
+[[agent_skills]]
+name = "my-internal-tool"
+
+# ──── MCP servers ────
+# Stdio (process spawn)
+[[mcps]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
+scope = "user"   # default; also "project" or "local"
+
+# HTTP / remote MCP
+[[mcps]]
+name = "linear"
+url = "https://mcp.linear.app/mcp"
+transport = "http"   # optional; inferred from `url`
+scope = "user"
+
+# Stdio + mcp-remote proxy (args reference ${VAR} for credentials)
+[[mcps]]
+name = "honcho"
+command = "npx"
+args = [
+  "mcp-remote",
+  "https://mcp.honcho.dev",
+  "--header", "Authorization:${HONCHO_AUTH}",
+  "--header", "X-Honcho-User-Name:${USER_NAME}",
+]
+env = { HONCHO_AUTH = "${HONCHO_AUTH}", USER_NAME = "${USER}" }
+scope = "user"
+```
+
+### Secret handling
+
+Values in `env` / `headers` should be `${VAR}` references — the manifest is reproducible and shareable, so credentials stay in your shell environment. `${VAR}` is preserved verbatim on write; never resolved.
+
+### Scope routing (where sync writes MCPs)
+
+| scope | File |
+|---|---|
+| `user` (default) | `~/.claude.json` |
+| `project` | `<cwd>/.mcp.json` |
+| `local` | `<cwd>/.claude.local/settings.json` |
+
+`managed` is read-only — not writable from manifest.
+
+## Common workflows
+
+### Bootstrap a fresh machine
+```bash
+cargo install --git https://github.com/zot24/zskills
+mkdir -p ~/.config/zskills && cp <somewhere>/skills.toml ~/.config/zskills/
+zskills marketplace add-recommended
+zskills sync
+```
+
+### Install one thing fast
+```bash
+zskills install firecrawl@zot24-skills
+# OR: open a picker
+zskills install -i
+```
+
+### See what's where
+```bash
+zskills list             # everything
+zskills list --paths     # also show on-disk locations
+```
+
+### Diagnose problems
+```bash
+zskills doctor           # surface drift + MCP issues (no spawning)
+zskills doctor --fix     # clean dangling settings/inventory references
+```
+
+### Centralize MCPs across scopes
+Today the flow is two steps:
+1. `zskills list` to see all current MCPs across `~/.claude.json`, `<proj>/.mcp.json`, etc.
+2. Add `[[mcps]]` entries to `skills.toml`, then `zskills sync --prune` to write them at user scope and remove the duplicates from other scopes. **Plugin-injected MCPs are protected** — sync never prunes those.
+
+A `dump-mcps` helper to automate step 2 is on the roadmap (see issue #14).
+
+## Mental model
+
+zskills tracks three states per primitive:
+
+| State | Lives at | Authoritative for |
+|---|---|---|
+| **Intent** | `skills.toml` | What you *want* installed |
+| **Inventory** | `installed_plugins.json` / `.zskills.json` | What *exists* on disk |
+| **Activation** | `settings.json` → `enabledPlugins`, `~/.claude.json` → `mcpServers` | What's *running* |
+
+`sync` reconciles intent → activation by writing settings files and (for agent skills) cloning/pulling repos. `doctor` cross-checks all three for drift.
+
+## Safety guarantees
+
+- **Atomic JSON writes**: tempfile + rename. Preserves every unknown top-level key — hooks, permissions, env, plugin/MCP entries zskills doesn't know about.
+- **`./skills.toml` NOT auto-loaded** since v0.5.1 (it caused destructive surprises). Pass `--file ./skills.toml` explicitly.
+- **No removal without `--prune`** for agent skills and MCPs. The default is additive.
+- **`doctor` never deletes bytes**. Use `purge` for that — deliberate, explicit.
+- **Plugin-injected MCPs never pruned**. zskills knows they're owned by their plugin.
+- **Managed-scope MCPs never written**. IT-deployed, read-only.
+
+## Troubleshooting quick reference
+
+| Symptom | Likely fix |
+|---|---|
+| `no skills.toml found` | Create `~/.config/zskills/skills.toml` or pass `--file <path>` |
+| `skill X is ambiguous` | Qualify with `name@marketplace` |
+| `enabled but NOT installed` | Restart Claude Code (will install on next boot) or `doctor --fix` |
+| `agent skill in inventory, missing on disk` | `sync` to re-fetch, or `doctor --fix` to drop inventory entry |
+| MCP `doctor` says `command not found` | Install the binary, or fix the path in the manifest |
+| MCP `doctor` says `env var X referenced but not set` | Export `X` in your shell |
+| MCP `doctor` says `sse: deprecated` | Migrate the entry to `transport = "http"` |
+| Sync wants to disable plugins you want to keep | Add them to `skills.toml` so manifest matches intent |
+
+Full reference: <https://zskills.zot24.com> · Source: <https://github.com/zot24/zskills>


### PR DESCRIPTION
## Summary

Two things in one PR — a companion Agent Skill, and docs that match v0.7.0's actual surface.

### New: companion Agent Skill

`skills/zskills/SKILL.md` teaches Claude Code (and future agentic CLIs that adopt the same convention) how to use zskills end-to-end. Installable via the standard pattern:

\`\`\`toml
[[agent_skills]]
source = \"zot24/zskills\"
\`\`\`

Covers: when to reach for zskills, every command, the full manifest schema with `[[mcps]]` examples, secret-handling rules, scope routing, mental model (intent / inventory / activation), safety guarantees, and a troubleshooting quick-reference.

### Docs updated for v0.7.0

| File | What changed |
|---|---|
| `docs/use-cases.md` | +4 MCP scenarios: see what's configured, declare in manifest, centralize scattered configs (with `--prune` + plugin-injected protection semantics), validate with `doctor` |
| `docs/troubleshooting.md` | +7 MCP entries: command-not-found, unset \${VAR}, sse deprecation, scope routing, managed-settings probe, sync-overwrites, per-scope removal |
| `docs/architecture.md` | Promoted MCPs to a first-class third primitive. Added the full per-scope file table. Doctor section now covers all MCP failure modes. Path-resolution diagram includes \`.claude.json\`, \`.mcp.json\`, \`.claude.local/settings.json\`, managed-settings |
| `docs/index.md` | Quick Start manifest example now includes `[[mcps]]` (stdio + http) |
| `README.md` | Short \"Companion Agent Skill\" section |

## Test plan

- [x] \`cargo test\` — 51/51 (no code changes; just docs + new skill file)
- [x] \`cargo fmt --all --check\` clean
- [x] mdbook will pick up `docs/*` automatically on the next site build

## Out of scope

- Programmatic site rebuild — handled by the existing site CI on merge
- Marketplace registration — the skill lives in the zskills repo for now; if it earns a place in `zot24-skills` later, that's a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)