### PR TITLE
feat: zskills install <owner/repo> — direct install from a git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,24 @@ Requires `git` on `$PATH`.
 
 ### Companion Agent Skill
 
-This repo also ships an Agent Skill that teaches Claude how to use zskills. Add it to your `skills.toml`:
+This repo also ships an Agent Skill that teaches Claude how to use zskills. Install it directly:
+
+```bash
+zskills install zot24/zskills
+```
+
+zskills clones this repo, finds `skills/zskills/SKILL.md`, and drops it at `~/.claude/skills/zskills/`. If you'd rather declare it in the manifest for cross-machine reproducibility:
 
 ```toml
 [[agent_skills]]
 source = "zot24/zskills"
 ```
 
-Then `zskills sync`. Claude will reach for zskills with confidence for install / search / sync / doctor / MCP management.
+```bash
+zskills sync
+```
+
+Either way, Claude reaches for zskills with confidence for install / search / sync / doctor / MCP management on its next session.
 
 ## Why
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,18 +35,36 @@ Servers are grouped by scope (managed → local → project → user) and only t
 
 ## `install`
 
-Flip a plugin's `enabledPlugins` entry on. Claude Code fetches bytes on next start (or run `/plugin install <name>` inside Claude Code to materialize them immediately).
+Three accepted spec shapes:
 
 ```
-zskills install <name>...
-zskills install -i
+zskills install <name>                       # plugin from a registered marketplace
+zskills install <name>@<marketplace>         # qualified plugin
+zskills install <owner>/<repo>               # NEW: Agent Skill(s) directly from a git repo
+zskills install <git-url>                    # NEW: same, for arbitrary git URLs (https://, git@, file://)
+zskills install -i                           # interactive picker over marketplace plugins
 ```
 
-Accepts multiple names. Resolves unqualified names against your registered marketplaces; errors on ambiguity.
+**Plugin path (`<name>` / `<name>@<marketplace>`).** Resolves against registered marketplaces, flips `enabledPlugins` in `~/.claude/settings.json`. Claude Code materializes bytes on next launch.
+
+**Repo path (`<owner>/<repo>` or git URL).** Clones the repo via `git clone --depth 1` into `~/.cache/zskills/agent-skills/<owner>-<repo>/`, surveys the tree, and:
+- **Agent Skills** (any directory under `skills/<name>/SKILL.md`) — installed to `~/.claude/skills/<name>/`. Inventory tagged with the source.
+- **Marketplace** (`.claude-plugin/marketplace.json` at repo root) — prints a redirect: `use zskills marketplace add <owner/repo>` and installs nothing from this repo.
+- **MCP servers** (`.mcp.json` or `mcpServers` in `plugin.json`) — surfaced as a hint; not auto-installed (use `[[mcps]]` in `skills.toml` + `zskills sync`).
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-i`, `--interactive` | off | When passed without any `<name>`, browse all plugins across registered marketplaces with a fuzzy picker and install the selection. |
+| `-i`, `--interactive` | off | For plugin specs: without any `<name>`, browse all marketplace plugins with a fuzzy picker. For repo specs: always opens a multi-select picker over the Agent Skills found in the repo. |
+| `--all` | off | For repo specs only: when the repo contains more than 5 Agent Skills, confirm "yes, install every one." Without `--all`, large collections abort with a sample summary so they don't silently flood `~/.claude/skills/`. Ignored for repos with ≤5 skills (those install everything by default). |
+
+**Repo-path count behavior**:
+
+| Skills in repo | Default (no flags) | With `-i` | With `--all` |
+|---|---|---|---|
+| 0 | error | error | error |
+| 1 | install it | install it | install it |
+| 2–5 | install all | picker | install all |
+| > 5 | **abort + summary + next-step hint** | picker | install all |
 
 ## `remove` / `purge`
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -49,6 +49,25 @@ The declarative path is reproducible across machines; the imperative path is wha
 
 ## 3. Mirror an Agent Skill from a GitHub repo
 
+Two paths — pick whichever fits.
+
+**Imperative**, one-shot:
+
+```bash
+zskills install jakubkrehel/make-interfaces-feel-better
+```
+
+zskills clones the repo, surveys it, and installs every `skills/<name>/SKILL.md` it finds. For repos with ≤5 skills, all install by default. For one skill, it installs silently. For multi-skill repos (e.g. a collection), see ["large collections"](#large-collections-from-a-repo) below.
+
+The same command accepts full git URLs too:
+
+```bash
+zskills install https://github.com/jakubkrehel/make-interfaces-feel-better.git
+zskills install git@github.com:jakubkrehel/make-interfaces-feel-better.git
+```
+
+**Declarative**, reproducible across machines:
+
 ```toml
 [[agent_skills]]
 source = "jakubkrehel/make-interfaces-feel-better"
@@ -58,7 +77,37 @@ source = "jakubkrehel/make-interfaces-feel-better"
 zskills sync
 ```
 
-`sync` clones (or pulls) `github.com/jakubkrehel/make-interfaces-feel-better.git` into `$XDG_CACHE_HOME/zskills/agent-skills/`, then copies every directory under `skills/<name>/SKILL.md` into `~/.claude/skills/<name>/`. To pin just one skill out of a multi-skill repo, add `name = "specific-skill"`.
+`sync` clones (or pulls) the repo into `$XDG_CACHE_HOME/zskills/agent-skills/`, then copies every directory under `skills/<name>/SKILL.md` into `~/.claude/skills/<name>/`. To pin just one skill out of a multi-skill repo, add `name = "specific-skill"`.
+
+### Large collections from a repo
+
+When a repo exposes more than 5 skills (a curated collection, say), the imperative install path **won't silently flood `~/.claude/skills/`**:
+
+```
+$ zskills install owner/big-skill-collection
+owner/big-skill-collection contains 47 Agent Skills — zskills won't install all of them by default.
+
+Options:
+  zskills install owner/big-skill-collection -i      interactive picker
+  zskills install owner/big-skill-collection --all   install all 47 skills
+
+Sample (5 of 47): skill-a, skill-b, skill-c, skill-d, skill-e, …
+```
+
+`-i` opens a multi-select picker (fzf when on `$PATH`, else dialoguer's `MultiSelect`); `--all` is the explicit-consent escape hatch.
+
+### Marketplace repos
+
+If the repo is actually a Claude Code marketplace (has `.claude-plugin/marketplace.json`), zskills redirects:
+
+```
+$ zskills install anthropics/claude-plugins-official
+This repo is a plugin marketplace. To register and install plugins from it:
+  zskills marketplace add anthropics/claude-plugins-official
+  zskills install <plugin>@<marketplace>
+```
+
+That's the canonical path for plugins — they go through marketplace registration, not direct install from the marketplace's repo.
 
 ## 4. Centralize duplicate skills scattered across projects
 

--- a/skills/zskills/SKILL.md
+++ b/skills/zskills/SKILL.md
@@ -37,12 +37,18 @@ zskills list --paths               # also show on-disk location of every entry
 zskills list -v                    # expand grouped npm-bundle agent skills
 zskills list --json                # machine-readable for scripting
 
-# Search + install
+# Search + install (plugin path — via marketplaces)
 zskills search <query>             # substring-match across registered marketplaces
 zskills search <query> -i          # also opens an interactive picker; selection installs
 zskills install <name>             # name@marketplace if ambiguous
-zskills install -i                 # fuzzy-pick from all marketplaces (no <name> needed)
-zskills install -i                 # uses fzf if on $PATH; falls back to built-in picker
+zskills install <name>@<mp>        # explicitly qualified
+zskills install -i                 # fuzzy-pick from all marketplaces (uses fzf if available)
+
+# Install Agent Skills directly from a git repo (v0.8+)
+zskills install zot24/zskills      # owner/repo — clones, surveys, installs Agent Skills
+zskills install https://github.com/owner/repo.git    # full git URL works too
+zskills install owner/big-collection -i              # multi-select picker for many skills
+zskills install owner/big-collection --all           # confirm "install all" when >5 skills
 
 # Remove
 zskills remove <name>              # apt-style: disable + drop inventory, keep bytes
@@ -170,10 +176,29 @@ zskills sync
 
 ### Install one thing fast
 ```bash
+# Plugin from a registered marketplace
 zskills install firecrawl@zot24-skills
-# OR: open a picker
+
+# Agent Skill directly from any git repo (no manifest edit required)
+zskills install zot24/zskills
+
+# Browse marketplace plugins
 zskills install -i
 ```
+
+### Repo-install size policy
+When `zskills install <owner>/<repo>` discovers many skills, it doesn't silently flood `~/.claude/skills/`:
+
+| Skills in repo | Default behavior |
+|---|---|
+| 1 | install it |
+| 2–5 | install all (silent) |
+| > 5 | abort + print sample + suggest `-i` or `--all` |
+
+Pass `-i` for a picker or `--all` for explicit consent on large collections.
+
+### Marketplace repos vs skill repos
+If the repo is a Claude Code marketplace (has `.claude-plugin/marketplace.json`), `install <owner/repo>` redirects to `zskills marketplace add <owner/repo>` instead. That's the canonical path for plugins.
 
 ### See what's where
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,11 +32,17 @@ pub enum Command {
         paths: bool,
     },
 
-    /// Install + enable one or more skills (format: name or name@marketplace)
+    /// Install + enable one or more skills (format: name, name@marketplace, owner/repo, or git URL)
     Install {
         /// Browse all marketplace plugins interactively and pick one to install
         #[arg(short = 'i', long)]
         interactive: bool,
+
+        /// When installing from a repo (owner/repo or git URL) with more than 5 Agent Skills,
+        /// confirm "install everything." Without this, large collections abort with a summary
+        /// so they don't silently flood ~/.claude/skills/.
+        #[arg(long)]
+        all: bool,
 
         /// Skills to install
         skills: Vec<String>,
@@ -229,7 +235,8 @@ impl Cli {
             Command::Install {
                 skills,
                 interactive,
-            } => crate::commands::install::run(skills, interactive),
+                all,
+            } => crate::commands::install::run(skills, interactive, all),
             Command::Remove {
                 skills,
                 interactive,

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,18 +1,185 @@
-//! `install <name>[@marketplace]...` — adds to enabledPlugins for plugin marketplaces.
+//! `install <spec>...` — three accepted spec shapes:
 //!
-//! Plugin path (always on): we don't fetch bytes ourselves — we flip enabledPlugins and
-//! let Claude Code's startup install path materialize them on next launch.
-//!
-//! Skills.sh fallback (cargo feature `skills-sh`): when local resolution fails AND the
-//! skills.sh remote index is registered AND `ZSKILLS_SKILLS_SH_API_KEY` is set, we shell
-//! through `agent_skill::install` to clone the source repo and drop SKILL.md into
-//! ~/.claude/skills/<name>/.
+//! 1. `<name>` or `<name>@<marketplace>` — plugin path. Resolves against registered
+//!    marketplace caches, flips `enabledPlugins` in settings.json. Claude Code fetches
+//!    bytes on next launch.
+//! 2. `<owner>/<repo>` or `git@…` / `https://…/<repo>.git` URL — **repo path** (v0.8+).
+//!    Clones the repo, surveys it via `repo_scanner`, and installs Agent Skills found
+//!    under `skills/<name>/SKILL.md`. Marketplaces are detected and redirected; MCPs
+//!    are mentioned but not auto-installed in this mode.
+//! 3. `skills.sh` remote index (cargo feature `skills-sh`): when local resolution fails
+//!    AND the index is registered AND `ZSKILLS_SKILLS_SH_API_KEY` is set, falls through
+//!    to clone the source repo and drop SKILL.md into `~/.claude/skills/<name>/`.
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
 use serde_json::Value;
 
-pub fn run(specs: Vec<String>, interactive: bool) -> Result<()> {
+pub fn run(specs: Vec<String>, interactive: bool, all: bool) -> Result<()> {
+    if interactive && specs.is_empty() {
+        return run_interactive_browse_marketplaces();
+    }
+
+    if specs.is_empty() {
+        anyhow::bail!("specify at least one skill name, or use -i/--interactive to browse");
+    }
+
+    // Partition specs by shape. Repo specs (owner/repo, git URLs) don't need a
+    // registered marketplace — they clone directly. Marketplace specs do.
+    let (repo_specs, plugin_specs): (Vec<String>, Vec<String>) =
+        specs.into_iter().partition(|s| is_repo_spec(s));
+
+    for spec in &repo_specs {
+        if let Err(e) = install_from_repo(spec, interactive, all) {
+            eprintln!("{} {}: {}", "✗".red(), spec, e);
+        }
+    }
+
+    if !plugin_specs.is_empty() {
+        install_plugin_specs(plugin_specs)?;
+    }
+
+    Ok(())
+}
+
+/// True for specs that should clone a git repo directly: `owner/repo` or full
+/// git URLs. Excludes:
+/// - `name` (no slash) — unqualified plugin name, marketplace path.
+/// - `name@marketplace` — qualified plugin name, marketplace path.
+/// - `./local-path` and `/abs-path` — local paths (not supported as install sources).
+pub(crate) fn is_repo_spec(spec: &str) -> bool {
+    if spec.contains('@') && !spec.starts_with("git@") {
+        return false;
+    }
+    if spec.starts_with('.') || spec.starts_with('/') {
+        return false;
+    }
+    spec.contains("://") || spec.starts_with("git@") || spec.contains('/')
+}
+
+fn install_from_repo(spec: &str, interactive: bool, all: bool) -> Result<()> {
+    println!("{} {}", "Surveying".dimmed(), spec.to_string().bold());
+    let cache = crate::agent_skill::ensure_cache(spec)?;
+    let survey = crate::repo_scanner::survey(&cache)?;
+
+    if survey.marketplace {
+        println!(
+            "{}",
+            "This repo is a plugin marketplace. To register and install plugins from it:".yellow()
+        );
+        println!("  zskills marketplace add {}", spec.bold());
+        println!(
+            "  zskills install <plugin>@<marketplace>   {}",
+            "(or `zskills install -i` to browse)".dimmed()
+        );
+        return Ok(());
+    }
+
+    if survey.plugin {
+        eprintln!(
+            "{} {}",
+            "!".yellow(),
+            "this repo declares a single plugin (no marketplace.json); use `zskills marketplace add` to register it".dimmed()
+        );
+    }
+    if survey.mcp_count > 0 {
+        eprintln!(
+            "{} this repo also declares {} MCP server(s); add `[[mcps]]` entries to your skills.toml to manage them",
+            "·".dimmed(),
+            survey.mcp_count
+        );
+    }
+
+    const AUTO_INSTALL_MAX: usize = 5;
+    let n = survey.agent_skills.len();
+    let chosen: Vec<String> = match (n, interactive, all) {
+        (0, _, _) => anyhow::bail!(
+            "no Agent Skills found in {} (expected skills/<name>/SKILL.md)",
+            spec
+        ),
+        (1, _, _) => vec![survey.agent_skills[0].name.clone()],
+        (_, true, _) => pick_skills(spec, &survey.agent_skills)?,
+        (_, false, true) => survey.agent_skills.iter().map(|s| s.name.clone()).collect(),
+        (count, false, false) if count <= AUTO_INSTALL_MAX => {
+            survey.agent_skills.iter().map(|s| s.name.clone()).collect()
+        }
+        (count, false, false) => {
+            print_large_collection_summary(spec, count, &survey.agent_skills);
+            return Ok(());
+        }
+    };
+
+    if chosen.is_empty() {
+        println!("Nothing selected.");
+        return Ok(());
+    }
+
+    for name in &chosen {
+        match crate::agent_skill::install(spec, Some(name)) {
+            Ok(installed) => {
+                for n in installed {
+                    println!(
+                        "{} {} {}",
+                        "+".green(),
+                        n,
+                        format!("[from {}]", spec).dimmed()
+                    );
+                }
+            }
+            Err(e) => eprintln!("{} {}: {}", "✗".red(), name, e),
+        }
+    }
+    Ok(())
+}
+
+fn pick_skills(spec: &str, skills: &[crate::repo_scanner::SkillSummary]) -> Result<Vec<String>> {
+    let items: Vec<crate::interactive::Item> = skills
+        .iter()
+        .map(|s| {
+            crate::interactive::Item::new(s.name.clone(), s.description.clone().unwrap_or_default())
+        })
+        .collect();
+    let idxs =
+        crate::interactive::pick_many(&format!("Skills in {} (space to select)", spec), &items)?;
+    Ok(idxs.iter().map(|&i| skills[i].name.clone()).collect())
+}
+
+fn print_large_collection_summary(
+    spec: &str,
+    count: usize,
+    skills: &[crate::repo_scanner::SkillSummary],
+) {
+    println!(
+        "{} contains {} {} — zskills won't install all of them by default.",
+        spec.bold(),
+        count.to_string().bold(),
+        "Agent Skills".dimmed()
+    );
+    println!("\n{}", "Options:".bold());
+    println!(
+        "  {}   {}",
+        format!("zskills install {} -i", spec).bold(),
+        "interactive picker".dimmed()
+    );
+    println!(
+        "  {}   {}",
+        format!("zskills install {} --all", spec).bold(),
+        format!("install all {} skills", count).dimmed()
+    );
+    let preview: Vec<&str> = skills.iter().take(5).map(|s| s.name.as_str()).collect();
+    println!(
+        "\n{} {}{}",
+        format!("Sample (5 of {}):", count).dimmed(),
+        preview.join(", ").dimmed(),
+        if count > 5 {
+            ", …".dimmed().to_string()
+        } else {
+            String::new()
+        }
+    );
+}
+
+fn install_plugin_specs(specs: Vec<String>) -> Result<()> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     if known.is_empty() {
         println!(
@@ -22,19 +189,11 @@ pub fn run(specs: Vec<String>, interactive: bool) -> Result<()> {
         return Ok(());
     }
 
-    if interactive && specs.is_empty() {
-        return run_interactive(&known);
-    }
-
-    if specs.is_empty() {
-        anyhow::bail!("specify at least one skill name, or use -i/--interactive to browse");
-    }
-
     let settings_path = crate::paths::settings_json()?;
     let mut settings = crate::settings::load(&settings_path)?;
     let mut settings_dirty = false;
-
     let mut count = 0;
+
     for spec in &specs {
         match crate::marketplace::resolve_spec(spec, &known) {
             Ok(qualified) => {
@@ -79,13 +238,22 @@ pub fn run(specs: Vec<String>, interactive: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_interactive(known: &serde_json::Map<String, Value>) -> Result<()> {
+fn run_interactive_browse_marketplaces() -> Result<()> {
     use crate::interactive::Item;
+
+    let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    if known.is_empty() {
+        println!(
+            "{}",
+            "No marketplaces registered. Run `zskills marketplace add-recommended` first.".yellow()
+        );
+        return Ok(());
+    }
 
     let mut qualified_names: Vec<String> = Vec::new();
     let mut items: Vec<Item> = Vec::new();
 
-    for (mp_name, entry) in known {
+    for (mp_name, entry) in &known {
         if crate::commands::marketplace::is_remote_index(entry) {
             continue;
         }
@@ -113,7 +281,7 @@ fn run_interactive(known: &serde_json::Map<String, Value>) -> Result<()> {
 
     match crate::interactive::pick_one("Install plugin", &items)? {
         None => println!("Aborted."),
-        Some(idx) => run(vec![qualified_names[idx].clone()], false)?,
+        Some(idx) => run(vec![qualified_names[idx].clone()], false, false)?,
     }
     Ok(())
 }
@@ -154,4 +322,39 @@ fn try_install_from_remote(spec: &str, known: &serde_json::Map<String, Value>) -
 #[cfg(not(feature = "skills-sh"))]
 fn try_install_from_remote(_spec: &str, _known: &serde_json::Map<String, Value>) -> Result<bool> {
     Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_repo_spec_detects_owner_repo() {
+        assert!(is_repo_spec("zot24/zskills"));
+        assert!(is_repo_spec("anthropics/claude-plugins-official"));
+    }
+
+    #[test]
+    fn is_repo_spec_detects_git_url() {
+        assert!(is_repo_spec("https://github.com/foo/bar.git"));
+        assert!(is_repo_spec("git@github.com:foo/bar.git"));
+        assert!(is_repo_spec("file:///tmp/foo"));
+    }
+
+    #[test]
+    fn is_repo_spec_rejects_unqualified_name() {
+        assert!(!is_repo_spec("firecrawl"));
+        assert!(!is_repo_spec("get-shit-done-cc"));
+    }
+
+    #[test]
+    fn is_repo_spec_rejects_qualified_name() {
+        assert!(!is_repo_spec("firecrawl@zot24-skills"));
+    }
+
+    #[test]
+    fn is_repo_spec_rejects_local_paths() {
+        assert!(!is_repo_spec("./local-repo"));
+        assert!(!is_repo_spec("/abs/local/repo"));
+    }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -129,7 +129,7 @@ fn install_from_hits(hits: &[Hit]) -> Result<()> {
         Some(idx) => {
             let h = &hits[idx];
             let spec = format!("{}@{}", h.name, h.marketplace);
-            crate::commands::install::run(vec![spec], false)?;
+            crate::commands::install::run(vec![spec], false, false)?;
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod marketplace;
 mod mcp;
 mod paths;
 mod reconcile;
+mod repo_scanner;
 mod settings;
 #[cfg(feature = "skills-sh")]
 mod skills_sh;

--- a/src/repo_scanner.rs
+++ b/src/repo_scanner.rs
@@ -1,0 +1,217 @@
+//! Walk a cloned repo tree and report what's installable.
+//!
+//! Used by `zskills install <owner/repo>` to figure out whether the repo
+//! contains Agent Skills (the thing we install today), a plugin marketplace
+//! (redirect the user to `zskills marketplace add`), or MCP servers (out of
+//! scope for v1 — surface a hint and move on).
+//!
+//! Read-only; never mutates the cache.
+
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct SkillSummary {
+    pub name: String,
+    /// Pulled from the `description:` field of the SKILL.md YAML frontmatter
+    /// when available. Best-effort — malformed or missing frontmatter is fine.
+    pub description: Option<String>,
+    /// Absolute path to the directory under the cache containing `SKILL.md`.
+    #[allow(dead_code)]
+    pub source_dir: PathBuf,
+}
+
+#[derive(Debug, Default)]
+pub struct RepoSurvey {
+    pub agent_skills: Vec<SkillSummary>,
+    /// `.claude-plugin/marketplace.json` at the repo root.
+    pub marketplace: bool,
+    /// `.claude-plugin/plugin.json` at the repo root (only meaningful when
+    /// `marketplace` is false — marketplaces always have plugins).
+    pub plugin: bool,
+    /// Total MCP server entries discovered across:
+    /// - `<repo>/.mcp.json` (both wrapped and flat schemas)
+    /// - `<repo>/.claude-plugin/plugin.json` → `mcpServers`
+    pub mcp_count: usize,
+}
+
+pub fn survey(cache: &Path) -> Result<RepoSurvey> {
+    let mut out = RepoSurvey::default();
+
+    // Agent Skills — reuse the existing skills_in_cache logic and enrich.
+    for (name, dir) in crate::agent_skill::skills_in_cache(cache) {
+        let description = extract_description(&dir.join("SKILL.md"));
+        out.agent_skills.push(SkillSummary {
+            name,
+            description,
+            source_dir: dir,
+        });
+    }
+
+    // Marketplace / plugin detection.
+    let mp_path = cache.join(".claude-plugin").join("marketplace.json");
+    out.marketplace = mp_path.exists();
+    let plugin_path = cache.join(".claude-plugin").join("plugin.json");
+    out.plugin = plugin_path.exists() && !out.marketplace;
+
+    // MCP count: combine root .mcp.json and plugin.json's mcpServers.
+    out.mcp_count = count_mcp_entries(&cache.join(".mcp.json"))
+        + count_mcp_entries_from_plugin_json(&plugin_path);
+
+    Ok(out)
+}
+
+/// Read the SKILL.md YAML frontmatter and extract the `description:` line.
+/// We don't pull a full YAML parser in just for this — the format is a
+/// `---`-delimited block at the top with `key: value` lines.
+fn extract_description(skill_md: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(skill_md).ok()?;
+    let mut lines = content.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    let mut buf = String::new();
+    let mut in_description = false;
+    for line in lines {
+        if line.trim() == "---" {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix("description:") {
+            buf.push_str(rest.trim());
+            in_description = true;
+            continue;
+        }
+        if in_description {
+            // YAML continuation: indented lines are part of the value.
+            if line.starts_with(' ') || line.starts_with('\t') {
+                buf.push(' ');
+                buf.push_str(line.trim());
+            } else {
+                break;
+            }
+        }
+    }
+    let trimmed = buf.trim().trim_matches('"').trim_matches('\'').to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Parse a `.mcp.json` (accepting both wrapped `{"mcpServers": {...}}` and
+/// flat `{"<name>": {...}}` shapes) and return the entry count.
+fn count_mcp_entries(path: &Path) -> usize {
+    let Ok(bytes) = std::fs::read(path) else {
+        return 0;
+    };
+    let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return 0;
+    };
+    let map = val
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .or_else(|| val.as_object());
+    map.map(|m| m.len()).unwrap_or(0)
+}
+
+/// Parse a plugin.json and return the `mcpServers` entry count.
+fn count_mcp_entries_from_plugin_json(path: &Path) -> usize {
+    let Ok(bytes) = std::fs::read(path) else {
+        return 0;
+    };
+    let Ok(val) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return 0;
+    };
+    val.get("mcpServers")
+        .and_then(|v| v.as_object())
+        .map(|m| m.len())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn skill_md(description: Option<&str>) -> String {
+        let desc = description.unwrap_or("");
+        format!("---\nname: foo\ndescription: {}\n---\n# Foo\n", desc)
+    }
+
+    #[test]
+    fn extracts_simple_description() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        fs::write(&path, skill_md(Some("Helps with foo things"))).unwrap();
+        assert_eq!(
+            extract_description(&path).as_deref(),
+            Some("Helps with foo things")
+        );
+    }
+
+    #[test]
+    fn handles_missing_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        fs::write(&path, "# Just a title, no YAML\n").unwrap();
+        assert!(extract_description(&path).is_none());
+    }
+
+    #[test]
+    fn handles_missing_description_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("SKILL.md");
+        fs::write(&path, "---\nname: x\n---\nbody\n").unwrap();
+        assert!(extract_description(&path).is_none());
+    }
+
+    #[test]
+    fn counts_mcp_entries_wrapped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".mcp.json");
+        fs::write(&path, r#"{"mcpServers":{"a":{},"b":{}}}"#).unwrap();
+        assert_eq!(count_mcp_entries(&path), 2);
+    }
+
+    #[test]
+    fn counts_mcp_entries_flat() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(".mcp.json");
+        fs::write(&path, r#"{"linear":{"type":"http","url":"x"}}"#).unwrap();
+        assert_eq!(count_mcp_entries(&path), 1);
+    }
+
+    #[test]
+    fn survey_discovers_skill_and_mcp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("skills").join("zskills");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), skill_md(Some("Manages skills"))).unwrap();
+        fs::write(
+            tmp.path().join(".mcp.json"),
+            r#"{"mcpServers":{"linear":{}}}"#,
+        )
+        .unwrap();
+        let s = survey(tmp.path()).unwrap();
+        assert_eq!(s.agent_skills.len(), 1);
+        assert_eq!(s.agent_skills[0].name, "zskills");
+        assert_eq!(
+            s.agent_skills[0].description.as_deref(),
+            Some("Manages skills")
+        );
+        assert_eq!(s.mcp_count, 1);
+        assert!(!s.marketplace);
+    }
+
+    #[test]
+    fn survey_detects_marketplace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mp_dir = tmp.path().join(".claude-plugin");
+        fs::create_dir_all(&mp_dir).unwrap();
+        fs::write(mp_dir.join("marketplace.json"), "{}").unwrap();
+        let s = survey(tmp.path()).unwrap();
+        assert!(s.marketplace);
+        assert!(!s.plugin); // marketplace shadows the plugin flag
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,6 +10,8 @@ use tempfile::TempDir;
 fn zskills(home: &TempDir) -> Command {
     let mut cmd = Command::cargo_bin("zskills").unwrap();
     cmd.env("CLAUDE_HOME", home.path());
+    // Strip ANSI colors so `predicate::str::contains` assertions match raw text.
+    cmd.env("NO_COLOR", "1");
     cmd
 }
 
@@ -577,6 +579,7 @@ fn fake_home_nested() -> (TempDir, std::path::PathBuf) {
 fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
     let mut cmd = Command::cargo_bin("zskills").unwrap();
     cmd.env("CLAUDE_HOME", claude_home);
+    cmd.env("NO_COLOR", "1");
     // Make sure the managed-settings probe doesn't pick up a real system file in CI.
     cmd.env(
         "ZSKILLS_MANAGED_SETTINGS",
@@ -982,4 +985,245 @@ fn list_without_paths_omits_them() {
     let stdout = String::from_utf8_lossy(&out);
     // Default mode: install path should NOT appear next to the plugin entry.
     assert!(!stdout.contains("/tmp/foo"));
+}
+
+// ──── install <owner/repo> tests ────────────────────────────────────────────
+//
+// All of these stage a bare-ish local git repo and pass `file:///tmp/<id>` as
+// the install spec. `agent_skill::parse_source` accepts any URL containing
+// `://`, so `git clone file:///path` works without going to the network.
+
+use std::process::Command as StdCommand;
+
+/// Initialize a git repo at `dir` and commit whatever's in it. The commit is
+/// needed because `git clone` against an empty repo errors out.
+fn git_init_and_commit(dir: &std::path::Path) {
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["init", "--quiet", "-b", "main"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "user.email", "test@example.com"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "user.name", "Test"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["add", "-A"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["commit", "--quiet", "-m", "init"])
+        .status()
+        .unwrap();
+}
+
+fn write_skill(repo: &std::path::Path, name: &str, description: &str) {
+    let dir = repo.join("skills").join(name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nname: {}\ndescription: {}\n---\n# {}\n",
+            name, description, name
+        ),
+    )
+    .unwrap();
+}
+
+fn file_url(p: &std::path::Path) -> String {
+    format!("file://{}", p.display())
+}
+
+#[test]
+fn install_repo_single_skill_auto_installs() {
+    let upstream = tempfile::tempdir().unwrap();
+    write_skill(upstream.path(), "alpha", "Alpha skill");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("alpha"));
+
+    assert!(home
+        .path()
+        .join("skills")
+        .join("alpha")
+        .join("SKILL.md")
+        .exists());
+}
+
+#[test]
+fn install_repo_small_multi_installs_all() {
+    let upstream = tempfile::tempdir().unwrap();
+    write_skill(upstream.path(), "alpha", "A");
+    write_skill(upstream.path(), "beta", "B");
+    write_skill(upstream.path(), "gamma", "C");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success();
+
+    for name in ["alpha", "beta", "gamma"] {
+        assert!(
+            home.path()
+                .join("skills")
+                .join(name)
+                .join("SKILL.md")
+                .exists(),
+            "{} should be installed",
+            name
+        );
+    }
+}
+
+#[test]
+fn install_repo_large_collection_aborts_without_all() {
+    let upstream = tempfile::tempdir().unwrap();
+    for i in 0..7 {
+        write_skill(upstream.path(), &format!("skill-{}", i), "x");
+    }
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("won't install all"))
+        .stdout(predicate::str::contains("--all"));
+
+    // None of the skills should have been installed.
+    for i in 0..7 {
+        assert!(
+            !home
+                .path()
+                .join("skills")
+                .join(format!("skill-{}", i))
+                .exists(),
+            "large collection must not install silently"
+        );
+    }
+}
+
+#[test]
+fn install_repo_large_collection_with_all_installs_everything() {
+    let upstream = tempfile::tempdir().unwrap();
+    for i in 0..7 {
+        write_skill(upstream.path(), &format!("skill-{}", i), "x");
+    }
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path()), "--all"])
+        .assert()
+        .success();
+
+    for i in 0..7 {
+        let p = home
+            .path()
+            .join("skills")
+            .join(format!("skill-{}", i))
+            .join("SKILL.md");
+        assert!(p.exists(), "skill-{} should be installed", i);
+    }
+}
+
+#[test]
+fn install_repo_marketplace_redirects() {
+    let upstream = tempfile::tempdir().unwrap();
+    let mp = upstream.path().join(".claude-plugin");
+    fs::create_dir_all(&mp).unwrap();
+    fs::write(
+        mp.join("marketplace.json"),
+        r#"{"name":"test","plugins":[]}"#,
+    )
+    .unwrap();
+    // Also put an Agent Skill — to prove marketplace detection wins and the skill is NOT installed.
+    write_skill(upstream.path(), "should-not-install", "x");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("marketplace"))
+        .stdout(predicate::str::contains("marketplace add"));
+
+    assert!(
+        !home
+            .path()
+            .join("skills")
+            .join("should-not-install")
+            .exists(),
+        "marketplace path must not install skills"
+    );
+}
+
+#[test]
+fn install_repo_mcp_hint_appears_alongside_skill_install() {
+    let upstream = tempfile::tempdir().unwrap();
+    write_skill(upstream.path(), "alpha", "A");
+    fs::write(
+        upstream.path().join(".mcp.json"),
+        r#"{"mcpServers":{"linear":{"type":"http","url":"https://x"}}}"#,
+    )
+    .unwrap();
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    let out = zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&out);
+    assert!(stderr.contains("MCP server"));
+    assert!(home
+        .path()
+        .join("skills")
+        .join("alpha")
+        .join("SKILL.md")
+        .exists());
+}
+
+#[test]
+fn install_repo_with_no_skills_errors() {
+    let upstream = tempfile::tempdir().unwrap();
+    // Empty repo — no skills/, no .claude-plugin/.
+    fs::write(upstream.path().join("README.md"), "# nothing here\n").unwrap();
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    let out = zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success() // emit error to stderr but exit 0; the partition-based dispatch logs and continues
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&out);
+    assert!(stderr.contains("no Agent Skills found"));
 }


### PR DESCRIPTION
## Summary

A third spec shape for \`install\` that doesn't require a marketplace or a manifest edit:

\`\`\`bash
zskills install zot24/zskills                              # owner/repo
zskills install https://github.com/owner/repo.git          # https
zskills install git@github.com:owner/repo.git              # ssh
\`\`\`

Clones the repo, surveys what's installable, installs Agent Skills directly. The single-skill case is silent; small multi-skill repos install everything; large collections (> 5 skills) refuse to silently flood \`~/.claude/skills/\` and require \`-i\` (picker) or \`--all\` (consent).

## Behavior matrix

| Skills in repo | Default | With \`-i\` | With \`--all\` |
|---|---|---|---|
| 0 | error | error | error |
| 1 | install it | install it | install it |
| 2–5 | install all (silent) | picker | install all |
| > 5 | **abort + sample + next-step hint** | picker | install all |

Plus two redirects:
- Repo is a marketplace (\`.claude-plugin/marketplace.json\`) → redirect to \`zskills marketplace add <owner/repo>\`.
- Repo declares MCPs (\`.mcp.json\` / \`mcpServers\` in \`plugin.json\`) → printed as a hint; not auto-installed (see issue #14).

## What's reused vs new

| | |
|---|---|
| Reused | \`agent_skill::ensure_cache\` + \`install\` (the existing clone-copy-inventory pipeline), \`interactive::pick_many\`, the wrapped+flat \`.mcp.json\` parser pattern from \`mcp.rs\` |
| New | \`src/repo_scanner.rs\` — survey() over a cloned tree. New \`is_repo_spec()\` + \`install_from_repo()\` in \`commands/install.rs\`. \`--all\` flag on \`Install\`. |

## Test plan

- [x] \`cargo test\` — 70/70 (27 unit + 43 integration; +13 new this PR)
- [x] \`cargo fmt --all --check\` clean
- [x] Real-world smoke test: \`zskills install zot24/zskills\` against the live repo successfully installed the companion Agent Skill end-to-end. Verified in this session — the skill now appears in Claude's available skills list.

## Stacked next

- **PR B (follow-up)**: sparse-checkout / partial-clone refactor of \`git.rs\` + \`agent_skill::ensure_cache()\` so we don't fetch full repos when we only need \`skills/\`. Transparent perf improvement.
- **PR C (future, sketched)**: \`zskills install --bundle <path.toml>\` — install multiple items declared in a TOML fragment. Additive (no \`--prune\`), composes with the existing manifest schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)