### PR TITLE
feat: install from repo + cross-client skill path + sync --adopt

### DIFF
--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -1,9 +1,11 @@
-//! Agent Skills (the older raw-SKILL.md format).
+//! Agent Skills (the raw-SKILL.md format).
 //!
 //! Install model:
 //! - source repos live at $XDG_CACHE_HOME/zskills/agent-skills/<owner>-<repo>/
-//! - installed skill trees live at ~/.claude/skills/<name>/
-//! - our inventory lives at ~/.claude/skills/.zskills.json
+//! - installed skill trees live at ~/.agents/skills/<name>/ (cross-client convention
+//!   from <https://agentskills.io/integrate-skills>; visible to Claude Code, Grok CLI,
+//!   and any other compliant client)
+//! - our inventory lives at ~/.agents/skills/.zskills.json
 //!
 //! Repo convention we recognize: `skills/<skill-name>/SKILL.md` under the source repo.
 
@@ -120,7 +122,7 @@ pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
     out
 }
 
-/// Copy a skill directory into ~/.claude/skills/<name>/ (deletes existing first).
+/// Copy a skill directory into ~/.agents/skills/<name>/ (deletes existing first).
 pub fn install_to_user_dir(skill_name: &str, src_dir: &Path) -> Result<()> {
     let dest = crate::paths::user_skills_dir()?.join(skill_name);
     if dest.exists() {
@@ -148,7 +150,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Remove an installed agent skill from ~/.claude/skills/<name>/.
+/// Remove an installed agent skill from ~/.agents/skills/<name>/.
 pub fn remove_from_user_dir(skill_name: &str) -> Result<()> {
     let dest = crate::paths::user_skills_dir()?.join(skill_name);
     if dest.exists() {
@@ -160,7 +162,7 @@ pub fn remove_from_user_dir(skill_name: &str) -> Result<()> {
 /// Install an npm-based agent skill. Runs `npm install -g <pkg>` (or `install_cmd`),
 /// then determines ownership of on-disk skills via:
 ///
-/// 1. diff `~/.claude/skills/` before/after (catches packages that place new files)
+/// 1. diff `~/.agents/skills/` before/after (catches packages that place new files)
 /// 2. glob-match `claims` patterns (catches packages that update pre-existing files)
 /// 3. preserve existing inventory tags for this source
 ///
@@ -288,8 +290,10 @@ fn run_install_command(package: &str, install_cmd: Option<&str>) -> Result<()> {
         return Ok(());
     }
 
+    // `--no-fund --no-audit` silences npm's footer chatter so zskills's own
+    // output stays signal-only; we don't manage funding info or audit advice.
     let status = std::process::Command::new("npm")
-        .args(["install", "-g", package])
+        .args(["install", "-g", "--no-fund", "--no-audit", package])
         .status()
         .with_context(|| format!("running npm install -g {}", package))?;
     anyhow::ensure!(status.success(), "npm install -g {} failed", package);
@@ -310,7 +314,7 @@ fn npm_installed_version(package: &str) -> Result<String> {
     Ok(ver)
 }
 
-/// What's currently present in ~/.claude/skills/ (directories with SKILL.md).
+/// What's currently present in ~/.agents/skills/ (directories with SKILL.md).
 pub fn installed_on_disk() -> Result<Vec<String>> {
     let dir = crate::paths::user_skills_dir()?;
     if !dir.exists() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,7 @@ pub enum Command {
 
         /// When installing from a repo (owner/repo or git URL) with more than 5 Agent Skills,
         /// confirm "install everything." Without this, large collections abort with a summary
-        /// so they don't silently flood ~/.claude/skills/.
+        /// so they don't silently flood ~/.agents/skills/.
         #[arg(long)]
         all: bool,
 
@@ -102,6 +102,12 @@ pub enum Command {
         /// in the manifest). Without this, sync only enables/disables — it never deletes.
         #[arg(long)]
         prune: bool,
+
+        /// Adopt orphans into the manifest instead of skipping/pruning them. Every
+        /// installed agent skill, enabled plugin, and configured MCP that isn't yet
+        /// listed gets appended to the manifest. Inverse of `--prune`.
+        #[arg(long, conflicts_with = "prune")]
+        adopt: bool,
     },
 
     /// Reconcile disk ↔ inventory ↔ settings; report orphans + mismatches
@@ -250,7 +256,8 @@ impl Cli {
                 file,
                 dry_run,
                 prune,
-            } => crate::commands::sync::run(file, dry_run, prune),
+                adopt,
+            } => crate::commands::sync::run(file, dry_run, prune, adopt),
             Command::Doctor { fix } => crate::commands::doctor::run(fix),
             Command::Scan { path, depth, json } => crate::commands::scan::run(path, depth, json),
             Command::Migrate {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -9,7 +9,7 @@
 //!    are mentioned but not auto-installed in this mode.
 //! 3. `skills.sh` remote index (cargo feature `skills-sh`): when local resolution fails
 //!    AND the index is registered AND `ZSKILLS_SKILLS_SH_API_KEY` is set, falls through
-//!    to clone the source repo and drop SKILL.md into `~/.claude/skills/<name>/`.
+//!    to clone the source repo and drop SKILL.md into `~/.agents/skills/<name>/`.
 
 use anyhow::Result;
 use owo_colors::OwoColorize;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -552,10 +552,7 @@ fn mcp_entry_from_raw(
     match obj.get("type").and_then(|v| v.as_str()) {
         Some("http") => {
             e.transport = Some("http".into());
-            e.url = obj
-                .get("url")
-                .and_then(|v| v.as_str())
-                .map(str::to_string);
+            e.url = obj.get("url").and_then(|v| v.as_str()).map(str::to_string);
             if let Some(h) = obj.get("headers").and_then(|v| v.as_object()) {
                 for (k, v) in h {
                     if let Some(s) = v.as_str() {
@@ -566,10 +563,7 @@ fn mcp_entry_from_raw(
         }
         Some("sse") => {
             e.transport = Some("sse".into());
-            e.url = obj
-                .get("url")
-                .and_then(|v| v.as_str())
-                .map(str::to_string);
+            e.url = obj.get("url").and_then(|v| v.as_str()).map(str::to_string);
             if let Some(h) = obj.get("headers").and_then(|v| v.as_object()) {
                 for (k, v) in h {
                     if let Some(s) = v.as_str() {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
+pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Result<()> {
     // Warn loudly if a `./skills.toml` exists and the user didn't pass --file.
     if file.is_none() {
         if let Some(cwd_path) = crate::manifest::cwd_skills_toml() {
@@ -208,12 +208,21 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
         println!("  {} enable  plugin  {}", "+".green(), k);
     }
     for k in &plugins_to_disable {
-        println!(
-            "  {} disable plugin  {} {}",
-            "-".yellow(),
-            k,
-            "(in settings but not in manifest)".dimmed()
-        );
+        if adopt {
+            println!(
+                "  {} adopt   plugin  {} {}",
+                "+".cyan(),
+                k,
+                "(enabled but not in manifest — adding)".dimmed()
+            );
+        } else {
+            println!(
+                "  {} disable plugin  {} {}",
+                "-".yellow(),
+                k,
+                "(in settings but not in manifest)".dimmed()
+            );
+        }
     }
     for n in &agent_to_install_named {
         println!("  {} install agent   {}", "+".green(), n);
@@ -229,7 +238,14 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
         }
     }
     for n in &agent_to_remove {
-        if prune {
+        if adopt {
+            println!(
+                "  {} adopt   agent   {} {}",
+                "+".cyan(),
+                n,
+                "(in inventory but not in manifest — adding)".dimmed()
+            );
+        } else if prune {
             println!(
                 "  {} remove  agent   {} {}",
                 "-".red(),
@@ -241,7 +257,7 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
                 "  {} skip    agent   {} {}",
                 "·".dimmed(),
                 n,
-                "(in inventory but not in manifest — pass --prune to delete)".dimmed()
+                "(in inventory but not in manifest — pass --prune to delete, or --adopt to add to manifest)".dimmed()
             );
         }
     }
@@ -262,7 +278,14 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
         );
     }
     for (scope, name) in &mcps_to_remove {
-        if prune {
+        if adopt {
+            println!(
+                "  {} adopt   mcp     {} {}",
+                "+".cyan(),
+                name,
+                format!("({}) — adding to manifest", scope.label()).dimmed()
+            );
+        } else if prune {
             println!(
                 "  {} remove  mcp     {} {}",
                 "-".red(),
@@ -275,7 +298,7 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
                 "·".dimmed(),
                 name,
                 format!(
-                    "({}) — in {} but not in manifest, pass --prune to delete",
+                    "({}) — in {} but not in manifest, pass --prune to delete, or --adopt to add to manifest",
                     scope.label(),
                     scope.label()
                 )
@@ -286,6 +309,83 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
 
     if dry_run {
         println!("\n(dry-run; no changes written)");
+        return Ok(());
+    }
+
+    // -------- 3.5) Adopt (optional) --------
+    // When --adopt is passed, append every orphan to the manifest BEFORE the
+    // reconciliation pass. After this the manifest contains the orphans, so
+    // they're no longer "to remove" / "to disable" and the apply phase skips them.
+    if adopt {
+        let mut adopted = 0usize;
+        for k in &plugins_to_disable {
+            let (name, mp) = k
+                .split_once('@')
+                .map(|(n, m)| (n.to_string(), Some(m.to_string())))
+                .unwrap_or_else(|| ((*k).clone(), None));
+            let entry = crate::manifest::SkillEntry {
+                name,
+                marketplace: mp,
+                version: None,
+            };
+            if crate::manifest::append_skill(&path, &entry)? {
+                adopted += 1;
+            }
+        }
+        for n in &agent_to_remove {
+            let inv_entry = inv.agent_skills.get(n);
+            let src = inv_entry.map(|e| e.source.as_str());
+            let manifest_entry = match src {
+                Some("local") | None => crate::manifest::AgentSkillEntry {
+                    name: Some(n.clone()),
+                    ..Default::default()
+                },
+                Some(s) if s.starts_with("npm:") => crate::manifest::AgentSkillEntry {
+                    npm: Some(s.trim_start_matches("npm:").to_string()),
+                    name: Some(n.clone()),
+                    ..Default::default()
+                },
+                Some(s) => crate::manifest::AgentSkillEntry {
+                    source: Some(s.to_string()),
+                    name: Some(n.clone()),
+                    ..Default::default()
+                },
+            };
+            if crate::manifest::append_agent_skill(&path, &manifest_entry)? {
+                adopted += 1;
+            }
+        }
+        for (scope, name) in &mcps_to_remove {
+            let raw = match crate::mcp::read_raw(scope, name) {
+                Some(v) => v,
+                None => {
+                    eprintln!(
+                        "{} mcp `{}` ({}): could not re-read config — skipping adoption",
+                        "!".yellow(),
+                        name,
+                        scope.label()
+                    );
+                    continue;
+                }
+            };
+            let mcp_entry = mcp_entry_from_raw(name, scope, &raw);
+            if crate::manifest::append_mcp(&path, &mcp_entry)? {
+                adopted += 1;
+            }
+        }
+        println!(
+            "\n{} adopted {} orphan(s) into {}",
+            "✓".green(),
+            adopted,
+            path.display()
+        );
+        if adopted == 0 {
+            return Ok(());
+        }
+        println!(
+            "  {}",
+            "re-run `zskills sync` to confirm the manifest now matches state".dimmed()
+        );
         return Ok(());
     }
 
@@ -431,4 +531,73 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool) -> Result<()> {
 
     println!("\n{} applied.", "✓".green());
     Ok(())
+}
+
+/// Convert a raw `mcpServers["<name>"]` JSON value (as it lives in
+/// settings.json / .mcp.json / .claude.json) into a manifest `McpEntry`.
+/// Preserves env / header *values* verbatim — these may be literal secrets,
+/// `${VAR}` references, or both. The user can sanitise after adoption.
+fn mcp_entry_from_raw(
+    name: &str,
+    scope: &crate::mcp::Scope,
+    raw: &serde_json::Value,
+) -> crate::manifest::McpEntry {
+    let mut e = crate::manifest::McpEntry {
+        name: name.to_string(),
+        scope: Some(scope.label().to_string()),
+        ..Default::default()
+    };
+    let Some(obj) = raw.as_object() else { return e };
+
+    match obj.get("type").and_then(|v| v.as_str()) {
+        Some("http") => {
+            e.transport = Some("http".into());
+            e.url = obj
+                .get("url")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            if let Some(h) = obj.get("headers").and_then(|v| v.as_object()) {
+                for (k, v) in h {
+                    if let Some(s) = v.as_str() {
+                        e.headers.insert(k.clone(), s.to_string());
+                    }
+                }
+            }
+        }
+        Some("sse") => {
+            e.transport = Some("sse".into());
+            e.url = obj
+                .get("url")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            if let Some(h) = obj.get("headers").and_then(|v| v.as_object()) {
+                for (k, v) in h {
+                    if let Some(s) = v.as_str() {
+                        e.headers.insert(k.clone(), s.to_string());
+                    }
+                }
+            }
+        }
+        _ => {
+            // stdio (Claude's default when `type` is absent)
+            e.command = obj
+                .get("command")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            if let Some(args) = obj.get("args").and_then(|v| v.as_array()) {
+                e.args = args
+                    .iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect();
+            }
+            if let Some(env) = obj.get("env").and_then(|v| v.as_object()) {
+                for (k, v) in env {
+                    if let Some(s) = v.as_str() {
+                        e.env.insert(k.clone(), s.to_string());
+                    }
+                }
+            }
+        }
+    }
+    e
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -22,7 +22,8 @@ pub struct Manifest {
     #[serde(default)]
     pub skills: Vec<SkillEntry>,
 
-    /// Agent Skills (the older raw-SKILL.md format, installed into ~/.claude/skills/).
+    /// Agent Skills (raw SKILL.md trees, installed into ~/.agents/skills/ per the
+    /// cross-client convention — visible to Claude Code, Grok CLI, etc.).
     #[serde(default)]
     pub agent_skills: Vec<AgentSkillEntry>,
 
@@ -186,9 +187,9 @@ impl McpEntry {
 /// Exactly one of `source`, `npm`, or (for local-only entries) `name` should be set.
 ///
 /// - `source`: `owner/repo` (GitHub) or a git URL. `sync` clones/pulls and copies
-///   skills under `skills/<name>/` into `~/.claude/skills/<name>/`.
+///   skills under `skills/<name>/` into `~/.agents/skills/<name>/`.
 /// - `npm`: npm package name. `sync` runs `npm install -g <pkg>` and trusts the
-///   package's post-install to place files under `~/.claude/skills/`. After install,
+///   package's post-install to place files under `~/.agents/skills/`. After install,
 ///   zskills diffs the directory and tags every new skill with `source: "npm:<pkg>"`.
 /// - `install_cmd`: optional override for npm packages with custom setup (e.g.,
 ///   `"npx some-tool install"`).
@@ -204,7 +205,7 @@ pub struct AgentSkillEntry {
     pub install_cmd: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
-    /// Optional glob patterns matching skill directory names in `~/.claude/skills/`.
+    /// Optional glob patterns matching skill directory names in `~/.agents/skills/`.
     /// After install, every match gets tagged with this entry's source — useful when
     /// the install command updates pre-existing files (no diff) but you want zskills
     /// to take ownership of them. Example: `claims = ["gsd-*"]`.
@@ -300,6 +301,154 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
         t["name"] = value(n);
     }
     let _ = Array::new(); // unused; placate compiler if toml_edit changes shape
+    aot.push(t);
+
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(true)
+}
+
+/// Append a `[[skills]]` entry. Skips if `name@marketplace` already present.
+pub fn append_skill(path: &Path, entry: &SkillEntry) -> Result<bool> {
+    use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+
+    let raw = if path.exists() {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("reading manifest {}", path.display()))?
+    } else {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        String::new()
+    };
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
+
+    if let Some(Item::ArrayOfTables(existing)) = doc.get("skills") {
+        for t in existing.iter() {
+            let name = t.get("name").and_then(|v| v.as_str()).map(str::to_string);
+            let mp = t
+                .get("marketplace")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            if name.as_deref() == Some(&entry.name) && mp == entry.marketplace {
+                return Ok(false);
+            }
+        }
+    }
+
+    let aot = match doc
+        .entry("skills")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()))
+    {
+        Item::ArrayOfTables(a) => a,
+        slot => {
+            *slot = Item::ArrayOfTables(ArrayOfTables::new());
+            match slot {
+                Item::ArrayOfTables(a) => a,
+                _ => unreachable!(),
+            }
+        }
+    };
+    let mut t = Table::new();
+    t["name"] = value(&entry.name);
+    if let Some(mp) = &entry.marketplace {
+        t["marketplace"] = value(mp);
+    }
+    if let Some(v) = &entry.version {
+        t["version"] = value(v);
+    }
+    aot.push(t);
+
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(true)
+}
+
+/// Append an `[[mcps]]` entry. Skips if (name, scope) already present.
+pub fn append_mcp(path: &Path, entry: &McpEntry) -> Result<bool> {
+    use toml_edit::{value, Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table};
+
+    let raw = if path.exists() {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("reading manifest {}", path.display()))?
+    } else {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        String::new()
+    };
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
+
+    let new_scope = entry.scope.clone().unwrap_or_else(|| "user".into());
+    if let Some(Item::ArrayOfTables(existing)) = doc.get("mcps") {
+        for t in existing.iter() {
+            let name = t.get("name").and_then(|v| v.as_str()).map(str::to_string);
+            let scope = t
+                .get("scope")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| "user".into());
+            if name.as_deref() == Some(&entry.name) && scope == new_scope {
+                return Ok(false);
+            }
+        }
+    }
+
+    let aot = match doc
+        .entry("mcps")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()))
+    {
+        Item::ArrayOfTables(a) => a,
+        slot => {
+            *slot = Item::ArrayOfTables(ArrayOfTables::new());
+            match slot {
+                Item::ArrayOfTables(a) => a,
+                _ => unreachable!(),
+            }
+        }
+    };
+
+    let mut t = Table::new();
+    t["name"] = value(&entry.name);
+    if let Some(s) = &entry.scope {
+        if s != "user" {
+            t["scope"] = value(s);
+        }
+    }
+    if let Some(transport) = &entry.transport {
+        t["transport"] = value(transport);
+    }
+    if let Some(c) = &entry.command {
+        t["command"] = value(c);
+    }
+    if !entry.args.is_empty() {
+        let mut arr = Array::new();
+        for a in &entry.args {
+            arr.push(a.as_str());
+        }
+        t["args"] = value(arr);
+    }
+    if !entry.env.is_empty() {
+        let mut tbl = InlineTable::new();
+        for (k, v) in &entry.env {
+            tbl.insert(k, v.as_str().into());
+        }
+        t["env"] = value(tbl);
+    }
+    if let Some(u) = &entry.url {
+        t["url"] = value(u);
+    }
+    if !entry.headers.is_empty() {
+        let mut tbl = InlineTable::new();
+        for (k, v) in &entry.headers {
+            tbl.insert(k, v.as_str().into());
+        }
+        t["headers"] = value(tbl);
+    }
     aot.push(t);
 
     std::fs::write(path, doc.to_string())

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -451,6 +451,52 @@ pub fn write_target(scope: &Scope) -> Result<(PathBuf, bool)> {
     }
 }
 
+/// Read back the raw JSON entry for `name` at `scope` from whichever file
+/// currently declares it. Used by `sync --adopt` to copy a server's full
+/// config (including env/header values) into skills.toml without re-asking
+/// the user for transport details.
+pub fn read_raw(scope: &Scope, name: &str) -> Option<Value> {
+    let candidates: Vec<PathBuf> = match scope {
+        Scope::User => {
+            let mut v = vec![];
+            if let Ok(p) = crate::paths::claude_json() {
+                v.push(p);
+            }
+            if let Ok(p) = crate::paths::settings_json() {
+                v.push(p);
+            }
+            v
+        }
+        Scope::Project => std::env::current_dir()
+            .ok()
+            .map(|cwd| {
+                vec![
+                    cwd.join(".mcp.json"),
+                    cwd.join(".claude").join("settings.json"),
+                ]
+            })
+            .unwrap_or_default(),
+        Scope::Local => std::env::current_dir()
+            .ok()
+            .map(|cwd| vec![cwd.join(".claude.local").join("settings.json")])
+            .unwrap_or_default(),
+        Scope::Managed => managed_settings_path().into_iter().collect(),
+    };
+    for path in candidates {
+        let Some(val) = read_json(&path) else { continue };
+        let map = val
+            .get("mcpServers")
+            .and_then(|v| v.as_object())
+            .or_else(|| val.as_object());
+        if let Some(obj) = map {
+            if let Some(entry) = obj.get(name) {
+                return Some(entry.clone());
+            }
+        }
+    }
+    None
+}
+
 /// Set or replace one MCP server entry in the target file for `scope`. Atomic.
 /// `name` is the server name; `entry` is the JSON value to store under it.
 pub fn upsert(scope: &Scope, name: &str, entry: serde_json::Value) -> Result<()> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -483,7 +483,9 @@ pub fn read_raw(scope: &Scope, name: &str) -> Option<Value> {
         Scope::Managed => managed_settings_path().into_iter().collect(),
     };
     for path in candidates {
-        let Some(val) = read_json(&path) else { continue };
+        let Some(val) = read_json(&path) else {
+            continue;
+        };
         let map = val
             .get("mcpServers")
             .and_then(|v| v.as_object())

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -47,12 +47,24 @@ pub fn marketplace_manifest(name: &str) -> Result<PathBuf> {
         .join("marketplace.json"))
 }
 
-/// ~/.claude/skills/ — where Agent Skills (the older format, raw SKILL.md trees) live.
-pub fn user_skills_dir() -> Result<PathBuf> {
-    Ok(claude_home()?.join("skills"))
+/// `~/.agents/` — the cross-client agent home from the Agent Skills spec,
+/// sibling of `~/.claude/`. Override with `AGENTS_HOME` (mirrors `CLAUDE_HOME`).
+pub fn agents_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("AGENTS_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".agents"))
 }
 
-/// ~/.claude/skills/.zskills.json — our inventory of which Agent Skills we manage and where they came from.
+/// ~/.agents/skills/ — the cross-client Agent Skills location per the
+/// [Agent Skills spec](https://agentskills.io/integrate-skills). Skills installed here are
+/// visible to any compliant client (Claude Code, Grok CLI, …), not just Claude.
+pub fn user_skills_dir() -> Result<PathBuf> {
+    Ok(agents_home()?.join("skills"))
+}
+
+/// ~/.agents/skills/.zskills.json — our inventory of which Agent Skills we manage and where they came from.
 pub fn agent_skills_inventory() -> Result<PathBuf> {
     Ok(user_skills_dir()?.join(".zskills.json"))
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
-//! End-to-end CLI tests. We point CLAUDE_HOME at a tempdir so the binary
-//! cannot touch the real `~/.claude/`.
+//! End-to-end CLI tests. We point CLAUDE_HOME and AGENTS_HOME at the same
+//! tempdir so the binary cannot touch the real `~/.claude/` or `~/.agents/`,
+//! and so `<tempdir>/skills/` is the install target for Agent Skills.
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -10,6 +11,10 @@ use tempfile::TempDir;
 fn zskills(home: &TempDir) -> Command {
     let mut cmd = Command::cargo_bin("zskills").unwrap();
     cmd.env("CLAUDE_HOME", home.path());
+    // Sandbox the cross-client Agent Skills home to the same tempdir so
+    // `<tempdir>/skills/` is the install target (mirrors the production layout
+    // where ~/.agents/skills/ lives alongside ~/.claude/).
+    cmd.env("AGENTS_HOME", home.path());
     // Strip ANSI colors so `predicate::str::contains` assertions match raw text.
     cmd.env("NO_COLOR", "1");
     cmd
@@ -579,6 +584,8 @@ fn fake_home_nested() -> (TempDir, std::path::PathBuf) {
 fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
     let mut cmd = Command::cargo_bin("zskills").unwrap();
     cmd.env("CLAUDE_HOME", claude_home);
+    // Pin the cross-client Agent Skills home next to CLAUDE_HOME so tests stay sandboxed.
+    cmd.env("AGENTS_HOME", parent.path().join(".agents"));
     cmd.env("NO_COLOR", "1");
     // Make sure the managed-settings probe doesn't pick up a real system file in CI.
     cmd.env(


### PR DESCRIPTION
## Summary

- **`zskills install <owner/repo>`** — install Agent Skills directly from a git repo, no marketplace needed (single skills auto-install; ≤5 skills install all; large collections require `-i` or `--all`).
- **Cross-client skill path** — Agent Skills now land in `~/.agents/skills/` (the [agentskills.io](https://agentskills.io/integrate-skills) convention) instead of `~/.claude/skills/`, so Claude Code, Grok CLI, and any other compliant client see them. New `AGENTS_HOME` env var mirrors `CLAUDE_HOME` for test sandboxing.
- **`zskills sync --adopt`** — inverse of `--prune`. Instead of skipping or deleting orphans (installed skills/plugins/MCPs not yet in the manifest), append them to `skills.toml`. Full MCP transport details (env, headers, args) preserved verbatim via new `mcp::read_raw`. Helpers `append_skill` and `append_mcp` added to `manifest.rs` (both dedupe).
- **Quieter npm** — `npm install -g <pkg>` now runs with `--no-fund --no-audit` so npm's funding/audit footer chatter doesn't leak into zskills output.
- Orphan messages in `sync` now mention both `--prune` and `--adopt` so the alternative is discoverable from the output itself.

## Test plan
- [x] `cargo test --release` — all 43 tests pass
- [ ] `zskills install <owner/repo>` against a single-skill repo lands at `~/.agents/skills/<name>/`
- [ ] `zskills sync --adopt --dry-run` lists orphans as `adopt` lines
- [ ] `zskills sync --adopt` writes entries to `skills.toml`; re-running `sync` reports no changes
- [ ] `zskills install <some-npm-pkg>` (via manifest entry) no longer shows the npm fund/audit footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)