### PR TITLE
feat: sparse Agent Skill installs from git repos + install --skill flag

### DIFF
--- a/DESIGN-sparse-install.md
+++ b/DESIGN-sparse-install.md
@@ -1,0 +1,80 @@
+# Design: sparse Agent Skill installs from git repos
+
+## Problem
+
+`zskills install <owner>/<repo>` clones the repo into
+`$XDG_CACHE_HOME/zskills/agent-skills/<owner>-<repo>/` and copies the skill's
+source directory into `~/.agents/skills/<name>/`. For the `skills/<name>/SKILL.md`
+layout that copy is already minimal (the skill subdirectory *is* the skill).
+But for a repo with a **root-level SKILL.md** (e.g. `ogulcancelik/herdr`, a full
+Rust project that also ships a skill), `skills_in_cache()` returns the cache
+root as the skill's source dir, so the install copies the *entire* repo —
+`src/`, `vendor/`, `Cargo.lock`, `website/`, `.git/`, megabytes of bytes the
+skill never uses.
+
+## Approach: keep clone-to-cache, fix materialization
+
+The cache clone already gives us everything git sparse-checkout would, and
+`upgrade` already depends on it (`ensure_cache` → `git pull` → re-copy). So we
+keep the clone-to-cache design and change only *what gets copied out*:
+
+- **`skills/<name>/` layout** — unchanged: copy the whole skill subdirectory
+  (that directory is the skill's own tree by convention).
+- **Root-level SKILL.md** — sparse copy. Materialize only:
+  1. `SKILL.md` itself;
+  2. conventional skill dirs if present: `references/`, `assets/`, `scripts/`;
+  3. any *relative paths referenced from SKILL.md* (markdown links
+     `[x](path)` and inline-code spans `` `path` ``) that actually exist in
+     the repo. The parser is deliberately liberal because every candidate is
+     filtered through "does this path exist in the clone?" — a mention of
+     `src/main.rs` copies that one file, never the whole `src/` tree.
+     Paths with `..` components, absolute paths, URLs, and anchors are rejected.
+- **`.git/` is never copied** in any layout (the recursive copy now skips it).
+
+No inventory schema change is needed: `Entry.source` already records the origin
+repo, and `upgrade` refreshes from the cache clone exactly as before — the next
+upgrade of a root-level skill simply re-materializes sparsely.
+
+## `--skill <name>` flag
+
+`zskills install <owner>/<repo> --skill <name>` selects a single skill from a
+multi-skill repo non-interactively (the same name shown by the survey /
+manifest `name` field). It conflicts with `--all` (clap `conflicts_with`), and
+errors if the named skill isn't in the repo. It also bypasses the >5-skill
+size-policy prompt, since the selection is explicit. If given alongside
+marketplace-plugin specs, those specs are rejected with a hint (the flag is
+meaningful only for repo installs).
+
+## Migration / compat
+
+- Existing full-repo installs keep working untouched — nothing rewrites
+  `~/.agents/skills/` outside explicit actions.
+- **Detection**: a legacy full-repo install reliably contains a `.git/`
+  directory (it was a verbatim copy of the clone). `zskills doctor` flags such
+  dirs: *"full-repo install; run `zskills upgrade <name>` or re-install to
+  slim"*.
+- **Conversion**: `zskills upgrade` (and `doctor --fix`, both explicit user
+  actions) re-run the install path, which deletes the dest dir and re-copies
+  sparsely — the transparent slim-down. `doctor --fix` only re-installs
+  entries whose inventory `source` is a repo spec it can re-fetch.
+
+## Non-changes (deliberate)
+
+- Root-level skill naming stays cache-dir-derived (`<owner>-<repo>`). Using
+  the frontmatter `name:` would be nicer, but it would break `upgrade` for
+  existing manifests/inventories that recorded the old name. Separate change
+  if ever.
+- No git sparse-checkout: it saves clone bytes but complicates `upgrade`
+  and buys little once the copy-out is sparse. `--depth 1` already bounds
+  history.
+
+## Tests
+
+- Unit (in `agent_skill.rs`): referenced-path extraction (links, code spans,
+  rejection of URLs/absolute/`..`), sparse path-set computation.
+- E2E (in `tests/cli.rs`, existing `git init` + `file://` style):
+  - root-level skill installs SKILL.md + referenced file + conventional dirs,
+    and does **not** install `src/`, `Cargo.toml`, `.git/`;
+  - `--skill` selects one skill from a multi-skill repo; unknown name errors;
+    conflicts with `--all`; bypasses the large-collection abort;
+  - `doctor` flags a simulated legacy full-repo install and `--fix` slims it.

--- a/IMPLEMENTATION-REPORT.md
+++ b/IMPLEMENTATION-REPORT.md
@@ -1,0 +1,85 @@
+# Implementation report: sparse Agent Skill installs
+
+Branch: `feat/sparse-install` (off `main` @ 64274b2). Design in
+`DESIGN-sparse-install.md` (written before implementation).
+
+## What changed
+
+**Sparse materialization (`src/agent_skill.rs`).** The root cause of the
+motivating bug (`zskills install ogulcancelik/herdr` landing the whole Rust
+project in `~/.agents/skills/`) was `skills_in_cache()`'s root-level fallback:
+it returned the cache clone's root as the skill's source dir, and the installer
+copied that verbatim — `src/`, `vendor/`, `.git/` and all. The clone-to-cache
+architecture was already right (and `upgrade` depends on it), so only the
+copy-out changed:
+
+- Root-level skills now go through `install_root_skill_sparse()`, which
+  materializes only: `SKILL.md`; the conventional dirs `references/`,
+  `assets/`, `scripts/` when present; and relative paths referenced from
+  SKILL.md (markdown link targets plus path-like inline-code spans). The
+  parser (`referenced_relative_paths`) is liberal on purpose — every candidate
+  is filtered through "does it exist in the clone?" — but rejects URLs,
+  absolute paths, anchors, whitespace, and `..` escapes, and skips fenced code
+  blocks.
+- `copy_dir_recursive` now skips `.git/` in every layout.
+- `skills/<name>/SKILL.md` installs are unchanged (already minimal).
+- No inventory schema change: `Entry.source` already carries the origin repo,
+  so `upgrade` keeps working exactly as before and re-materializes sparsely.
+
+**`--skill <name>` flag (`src/cli.rs`, `src/commands/install.rs`).**
+Non-interactive single-skill selection from a multi-skill repo. Conflicts with
+`--all` (clap-level), bypasses the >5-skill size policy since the selection is
+explicit, errors with the list of available names when the skill isn't found,
+and bails if used without any repo spec.
+
+**Doctor migration path (`src/commands/doctor.rs`).** A legacy full-repo
+install reliably contains a `.git/` directory (it was a verbatim clone copy).
+`zskills doctor` now flags such installs — "full-repo install … run
+`zskills upgrade <name>` or `zskills doctor --fix` to re-install slim" — and
+`doctor --fix` re-runs the install from the recorded inventory source, which
+replaces the dir with the sparse copy. Both are explicit user actions; nothing
+touches existing installs otherwise. `zskills upgrade` converts transparently
+for manifest-managed skills, since it re-runs the same install path.
+
+**Docs.** `docs/commands.md` documents the flag, the updated count-behavior
+table, and sparse-install semantics.
+
+**Deliberate non-change:** root-level skill naming stays cache-dir-derived
+(`<owner>-<repo>`); switching to the frontmatter `name:` would break `upgrade`
+for existing manifests/inventories (rationale in the design doc).
+
+## Commits
+
+| SHA | Message |
+|---|---|
+| c00e43e | docs: design proposal for sparse agent-skill installs |
+| 7a650f4 | feat(agent-skill): sparse materialization for root-level skills |
+| 4028009 | feat(install): `--skill <name>` to select one skill from a multi-skill repo |
+| 15ab432 | chore: fix map-values clippy lint in list.rs (pre-existing, newer clippy) |
+| f93bf2b | feat(doctor): flag legacy full-repo skill installs; `--fix` re-installs slim |
+| 1206a24 | test: e2e coverage for sparse installs, `--skill`, and doctor slim-down |
+| 6af1a80 | docs: document `--skill` flag and sparse root-level installs |
+
+## Tests
+
+Matching the repo's existing styles (unit tests in-module; e2e in
+`tests/cli.rs` with `git init` + `file://` upstreams and a sandboxed fake
+home). New coverage:
+
+- Unit (7): referenced-path extraction — links, code spans, URL/absolute/`..`
+  rejection, anchor + `./` stripping, fenced-block skipping, bare-word
+  rejection; `sparse_root_paths` composition.
+- E2E (6): root-level install is sparse (referenced + conventional paths in,
+  `src/`/`vendor/`/`Cargo.toml`/`.git` out); `--skill` selects one skill /
+  errors on unknown names with the available list / conflicts with `--all` /
+  bypasses the large-collection abort; `doctor` flags a simulated legacy
+  full-repo install and `--fix` slims it.
+- Harness improvement: `XDG_CACHE_HOME` is now sandboxed in the test helper,
+  so repo-install tests no longer write clone caches into the real `~/.cache`.
+
+Results (matching CI: `cargo fmt --all --check`, `cargo clippy --all-targets
+--all-features -- -D warnings`, `cargo test`):
+
+- fmt: clean
+- clippy: clean (`-D warnings`)
+- tests: **34 unit + 49 e2e, all passing, 0 failed**

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,15 +56,18 @@ zskills install -i                           # interactive picker over marketpla
 |------|---------|-------------|
 | `-i`, `--interactive` | off | For plugin specs: without any `<name>`, browse all marketplace plugins with a fuzzy picker. For repo specs: always opens a multi-select picker over the Agent Skills found in the repo. |
 | `--all` | off | For repo specs only: when the repo contains more than 5 Agent Skills, confirm "yes, install every one." Without `--all`, large collections abort with a sample summary so they don't silently flood `~/.agents/skills/`. Ignored for repos with ≤5 skills (those install everything by default). |
+| `--skill <name>` | none | For repo specs only: install exactly one skill by name (the manifest `name` field) — the non-interactive counterpart to `-i` for multi-skill repos. Bypasses the >5-skill size policy (the selection is explicit) and conflicts with `--all`. |
 
 **Repo-path count behavior**:
 
-| Skills in repo | Default (no flags) | With `-i` | With `--all` |
-|---|---|---|---|
-| 0 | error | error | error |
-| 1 | install it | install it | install it |
-| 2–5 | install all | picker | install all |
-| > 5 | **abort + summary + next-step hint** | picker | install all |
+| Skills in repo | Default (no flags) | With `-i` | With `--all` | With `--skill <name>` |
+|---|---|---|---|---|
+| 0 | error | error | error | error |
+| 1 | install it | install it | install it | install if it matches |
+| 2–5 | install all | picker | install all | install just that one |
+| > 5 | **abort + summary + next-step hint** | picker | install all | install just that one |
+
+**Sparse installs (root-level SKILL.md).** A repo whose `SKILL.md` sits at the repo root inside a larger project (source code, lockfiles, websites…) is installed *sparsely*: only `SKILL.md`, the conventional skill dirs (`references/`, `assets/`, `scripts/`), and relative paths that `SKILL.md` links to are copied out — never the whole source tree, and never `.git/`. Installs from the `skills/<name>/SKILL.md` layout copy the skill subdirectory as before. Legacy full-repo installs are flagged by `zskills doctor` and slimmed on the next `zskills upgrade` (or `doctor --fix`).
 
 ## `remove` / `purge`
 

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -133,8 +133,124 @@ pub fn install_to_user_dir(skill_name: &str, src_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Skill dirs that are copied wholesale for a root-level skill even when
+/// SKILL.md doesn't link to them — the conventional layout from the spec.
+const CONVENTIONAL_SKILL_DIRS: &[&str] = &["references", "assets", "scripts"];
+
+/// Sparse-install a **root-level** skill (SKILL.md at the repo root of a larger
+/// project): materialize only SKILL.md, the conventional skill dirs, and the
+/// relative paths SKILL.md references — never the whole source tree.
+pub fn install_root_skill_sparse(skill_name: &str, cache: &Path) -> Result<()> {
+    let dest = crate::paths::user_skills_dir()?.join(skill_name);
+    if dest.exists() {
+        std::fs::remove_dir_all(&dest)?;
+    }
+    std::fs::create_dir_all(&dest)?;
+    for rel in sparse_root_paths(cache) {
+        let src = cache.join(&rel);
+        let target = dest.join(&rel);
+        if src.is_dir() {
+            copy_dir_recursive(&src, &target)?;
+        } else {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(&src, &target)?;
+        }
+    }
+    Ok(())
+}
+
+/// Relative paths (against the repo root) to materialize for a root-level
+/// skill: SKILL.md, present conventional dirs, and referenced paths that
+/// actually exist in the clone.
+pub(crate) fn sparse_root_paths(cache: &Path) -> Vec<PathBuf> {
+    let mut set: std::collections::BTreeSet<PathBuf> = std::collections::BTreeSet::new();
+    set.insert(PathBuf::from("SKILL.md"));
+    for dir in CONVENTIONAL_SKILL_DIRS {
+        if cache.join(dir).is_dir() {
+            set.insert(PathBuf::from(dir));
+        }
+    }
+    if let Ok(md) = std::fs::read_to_string(cache.join("SKILL.md")) {
+        for rel in referenced_relative_paths(&md) {
+            if cache.join(&rel).exists() {
+                set.insert(PathBuf::from(rel));
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Extract candidate relative paths from SKILL.md: markdown link targets and
+/// inline-code spans. Liberal by design — callers filter candidates through
+/// "does this path exist in the clone?" — but rejects anything unsafe or
+/// clearly not a repo path (URLs, absolute paths, `..` escapes, anchors).
+pub(crate) fn referenced_relative_paths(skill_md: &str) -> Vec<String> {
+    fn accept(candidate: &str) -> Option<String> {
+        let c = candidate.trim().trim_start_matches("./");
+        let c = c.split('#').next().unwrap_or("");
+        let c = c.trim_end_matches('/');
+        if c.is_empty()
+            || c.contains("://")
+            || c.starts_with('/')
+            || c.starts_with("mailto:")
+            || c.contains(char::is_whitespace)
+        {
+            return None;
+        }
+        let escapes = Path::new(c)
+            .components()
+            .any(|comp| matches!(comp, std::path::Component::ParentDir));
+        if escapes {
+            return None;
+        }
+        Some(c.to_string())
+    }
+
+    let mut out = Vec::new();
+
+    // Markdown link targets: `](target)`.
+    let mut rest = skill_md;
+    while let Some(i) = rest.find("](") {
+        rest = &rest[i + 2..];
+        let Some(j) = rest.find(')') else { break };
+        if let Some(p) = accept(&rest[..j]) {
+            out.push(p);
+        }
+        rest = &rest[j + 1..];
+    }
+
+    // Inline code spans on prose lines: `path/to/thing`. Skip fenced blocks,
+    // and require the span to look path-like (a `/` or an extension dot) so
+    // bare words like `install` don't become candidates.
+    let mut in_fence = false;
+    for line in skill_md.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        for (idx, span) in line.split('`').enumerate() {
+            if idx % 2 == 1 && (span.contains('/') || span.contains('.')) {
+                if let Some(p) = accept(span) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+
+    out
+}
+
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    for entry in walkdir::WalkDir::new(src).follow_links(false) {
+    let walker = walkdir::WalkDir::new(src)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| e.depth() == 0 || e.file_name() != ".git");
+    for entry in walker {
         let entry = entry?;
         let rel = entry.path().strip_prefix(src)?;
         let target = dst.join(rel);
@@ -370,7 +486,13 @@ pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
     let mut inv = load_inventory()?;
     let mut installed_names = Vec::new();
     for (skill_name, src_dir) in &chosen {
-        install_to_user_dir(skill_name, src_dir)?;
+        if src_dir == &cache {
+            // Root-level SKILL.md in a larger project — materialize sparsely
+            // instead of copying the whole source tree.
+            install_root_skill_sparse(skill_name, &cache)?;
+        } else {
+            install_to_user_dir(skill_name, src_dir)?;
+        }
         inv.agent_skills.insert(
             skill_name.clone(),
             Entry {
@@ -404,7 +526,72 @@ fn chrono_now_iso() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::glob_match;
+    use super::{glob_match, referenced_relative_paths, sparse_root_paths};
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn referenced_paths_from_markdown_links() {
+        let md = "See [the guide](references/guide.md) and [docs](docs/setup.md).\n";
+        let got = referenced_relative_paths(md);
+        assert!(got.contains(&"references/guide.md".to_string()));
+        assert!(got.contains(&"docs/setup.md".to_string()));
+    }
+
+    #[test]
+    fn referenced_paths_from_inline_code_spans() {
+        let md = "Run `scripts/setup.sh` first, then read `NOTES.md`.\n";
+        let got = referenced_relative_paths(md);
+        assert!(got.contains(&"scripts/setup.sh".to_string()));
+        assert!(got.contains(&"NOTES.md".to_string()));
+    }
+
+    #[test]
+    fn referenced_paths_reject_urls_absolute_and_escapes() {
+        let md = "[web](https://example.com/x.md) [abs](/etc/passwd) \
+                  [up](../secrets.md) [anchor](#section) `run --all`\n";
+        assert!(referenced_relative_paths(md).is_empty());
+    }
+
+    #[test]
+    fn referenced_paths_strip_anchor_and_leading_dot_slash() {
+        let md = "[a](./references/a.md#top)\n";
+        assert_eq!(referenced_relative_paths(md), vec!["references/a.md"]);
+    }
+
+    #[test]
+    fn referenced_paths_skip_fenced_code_blocks() {
+        let md = "```\n`vendor/blob.bin`\n```\n`assets/logo.png`\n";
+        assert_eq!(referenced_relative_paths(md), vec!["assets/logo.png"]);
+    }
+
+    #[test]
+    fn referenced_paths_ignore_bare_words_in_code_spans() {
+        let md = "Use `install` and `skills` commands.\n";
+        assert!(referenced_relative_paths(md).is_empty());
+    }
+
+    #[test]
+    fn sparse_root_paths_picks_skill_md_conventional_dirs_and_referenced() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("SKILL.md"),
+            "---\nname: x\n---\nSee [guide](docs/guide.md) and [gone](docs/missing.md).\n",
+        )
+        .unwrap();
+        fs::create_dir_all(tmp.path().join("references")).unwrap();
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::write(tmp.path().join("docs/guide.md"), "g").unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "fn main(){}").unwrap();
+
+        let got = sparse_root_paths(tmp.path());
+        assert!(got.contains(&PathBuf::from("SKILL.md")));
+        assert!(got.contains(&PathBuf::from("references")));
+        assert!(got.contains(&PathBuf::from("docs/guide.md")));
+        assert!(!got.contains(&PathBuf::from("docs/missing.md")));
+        assert!(!got.iter().any(|p| p.starts_with("src")));
+    }
 
     #[test]
     fn glob_prefix() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,12 @@ pub enum Command {
         #[arg(long)]
         all: bool,
 
+        /// When installing from a repo, install only the named skill (the manifest
+        /// `name` field / the name shown by the survey). Non-interactive alternative
+        /// to `-i` for multi-skill repos.
+        #[arg(long, conflicts_with = "all", value_name = "NAME")]
+        skill: Option<String>,
+
         /// Skills to install
         skills: Vec<String>,
     },
@@ -242,7 +248,8 @@ impl Cli {
                 skills,
                 interactive,
                 all,
-            } => crate::commands::install::run(skills, interactive, all),
+                skill,
+            } => crate::commands::install::run(skills, interactive, all, skill),
             Command::Remove {
                 skills,
                 interactive,

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -55,6 +55,26 @@ pub fn run(fix: bool) -> Result<()> {
         }
     }
 
+    // Agent skills: legacy full-repo installs. Before sparse installs
+    // (v0.8), a root-level skill was a verbatim copy of the whole clone —
+    // reliably detectable by the `.git/` directory it dragged along.
+    let full_repo_installs = find_full_repo_installs(&inv)?;
+    if !full_repo_installs.is_empty() {
+        issues += full_repo_installs.len();
+        println!(
+            "{} {} agent skill(s) are full-repo installs (whole source tree, not just the skill):",
+            "✗".red(),
+            full_repo_installs.len()
+        );
+        for (name, source) in &full_repo_installs {
+            println!("  - {} {}", name, format!("[from {}]", source).dimmed());
+        }
+        println!(
+            "  {}",
+            "run `zskills upgrade <name>` or `zskills doctor --fix` to re-install slim".dimmed()
+        );
+    }
+
     if issues == 0 {
         println!(
             "{} All good — disk, inventory, and settings are in sync.",
@@ -82,12 +102,41 @@ pub fn run(fix: bool) -> Result<()> {
         }
         crate::agent_skill::save_inventory(&inv)?;
 
+        // Full-repo installs: re-run the install from the recorded source,
+        // which re-materializes sparsely (delete + slim copy).
+        for (name, source) in &full_repo_installs {
+            match crate::agent_skill::install(source, Some(name)) {
+                Ok(_) => println!("  re-installed {} slim from {}", name, source),
+                Err(e) => println!("  {} could not re-install {}: {}", "✗".red(), name, e),
+            }
+        }
+
         println!("{} Fixed {} issue(s).", "✓".green(), issues);
     } else {
         println!("\nRun {} to clean up.", "zskills doctor --fix".bold());
     }
 
     Ok(())
+}
+
+/// Managed agent skills whose installed dir contains a `.git/` directory —
+/// the signature of a pre-sparse full-repo install. Returns `(name, source)`
+/// pairs, only for entries with a git-fetchable source (npm installs and
+/// local-only skills are never full-repo copies).
+fn find_full_repo_installs(
+    inv: &crate::agent_skill::Inventory,
+) -> Result<Vec<(String, String)>> {
+    let skills_dir = crate::paths::user_skills_dir()?;
+    let mut out = Vec::new();
+    for (name, entry) in &inv.agent_skills {
+        if entry.source.starts_with("npm:") {
+            continue;
+        }
+        if skills_dir.join(name).join(".git").exists() {
+            out.push((name.clone(), entry.source.clone()));
+        }
+    }
+    Ok(out)
 }
 
 /// Static MCP server checks. Returns the number of warnings emitted.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -123,9 +123,7 @@ pub fn run(fix: bool) -> Result<()> {
 /// the signature of a pre-sparse full-repo install. Returns `(name, source)`
 /// pairs, only for entries with a git-fetchable source (npm installs and
 /// local-only skills are never full-repo copies).
-fn find_full_repo_installs(
-    inv: &crate::agent_skill::Inventory,
-) -> Result<Vec<(String, String)>> {
+fn find_full_repo_installs(inv: &crate::agent_skill::Inventory) -> Result<Vec<(String, String)>> {
     let skills_dir = crate::paths::user_skills_dir()?;
     let mut out = Vec::new();
     for (name, entry) in &inv.agent_skills {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use owo_colors::OwoColorize;
 use serde_json::Value;
 
-pub fn run(specs: Vec<String>, interactive: bool, all: bool) -> Result<()> {
+pub fn run(specs: Vec<String>, interactive: bool, all: bool, skill: Option<String>) -> Result<()> {
     if interactive && specs.is_empty() {
         return run_interactive_browse_marketplaces();
     }
@@ -29,8 +29,12 @@ pub fn run(specs: Vec<String>, interactive: bool, all: bool) -> Result<()> {
     let (repo_specs, plugin_specs): (Vec<String>, Vec<String>) =
         specs.into_iter().partition(|s| is_repo_spec(s));
 
+    if skill.is_some() && repo_specs.is_empty() {
+        anyhow::bail!("--skill only applies to repo installs (owner/repo or git URL)");
+    }
+
     for spec in &repo_specs {
-        if let Err(e) = install_from_repo(spec, interactive, all) {
+        if let Err(e) = install_from_repo(spec, interactive, all, skill.as_deref()) {
             eprintln!("{} {}: {}", "✗".red(), spec, e);
         }
     }
@@ -57,7 +61,7 @@ pub(crate) fn is_repo_spec(spec: &str) -> bool {
     spec.contains("://") || spec.starts_with("git@") || spec.contains('/')
 }
 
-fn install_from_repo(spec: &str, interactive: bool, all: bool) -> Result<()> {
+fn install_from_repo(spec: &str, interactive: bool, all: bool, skill: Option<&str>) -> Result<()> {
     println!("{} {}", "Surveying".dimmed(), spec.to_string().bold());
     let cache = crate::agent_skill::ensure_cache(spec)?;
     let survey = crate::repo_scanner::survey(&cache)?;
@@ -90,6 +94,24 @@ fn install_from_repo(spec: &str, interactive: bool, all: bool) -> Result<()> {
         );
     }
 
+    // Explicit single-skill selection bypasses the size policy — the user
+    // already told us exactly what to install.
+    if let Some(name) = skill {
+        anyhow::ensure!(
+            survey.agent_skills.iter().any(|s| s.name == name),
+            "skill '{}' not found in {} (available: {})",
+            name,
+            spec,
+            survey
+                .agent_skills
+                .iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        return install_chosen(spec, &[name.to_string()]);
+    }
+
     const AUTO_INSTALL_MAX: usize = 5;
     let n = survey.agent_skills.len();
     let chosen: Vec<String> = match (n, interactive, all) {
@@ -114,7 +136,11 @@ fn install_from_repo(spec: &str, interactive: bool, all: bool) -> Result<()> {
         return Ok(());
     }
 
-    for name in &chosen {
+    install_chosen(spec, &chosen)
+}
+
+fn install_chosen(spec: &str, chosen: &[String]) -> Result<()> {
+    for name in chosen {
         match crate::agent_skill::install(spec, Some(name)) {
             Ok(installed) => {
                 for n in installed {
@@ -281,7 +307,7 @@ fn run_interactive_browse_marketplaces() -> Result<()> {
 
     match crate::interactive::pick_one("Install plugin", &items)? {
         None => println!("Aborted."),
-        Some(idx) => run(vec![qualified_names[idx].clone()], false, false)?,
+        Some(idx) => run(vec![qualified_names[idx].clone()], false, false, None)?,
     }
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -250,7 +250,7 @@ fn print_mcp_section(mcps: &[crate::mcp::McpServer], paths: bool) {
 
     let name_w = mcps.iter().map(|m| m.name.len()).max().unwrap_or(0).max(8);
 
-    for (_, (scope, servers)) in by_scope.iter_mut() {
+    for (scope, servers) in by_scope.values_mut() {
         servers.sort_by(|a, b| a.name.cmp(&b.name));
         println!(
             "  {} {}",

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -129,7 +129,7 @@ fn install_from_hits(hits: &[Hit]) -> Result<()> {
         Some(idx) => {
             let h = &hits[idx];
             let spec = format!("{}@{}", h.name, h.marketplace);
-            crate::commands::install::run(vec![spec], false, false)?;
+            crate::commands::install::run(vec![spec], false, false, None)?;
         }
     }
     Ok(())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -15,6 +15,8 @@ fn zskills(home: &TempDir) -> Command {
     // `<tempdir>/skills/` is the install target (mirrors the production layout
     // where ~/.agents/skills/ lives alongside ~/.claude/).
     cmd.env("AGENTS_HOME", home.path());
+    // Sandbox the clone cache too, so repo-install tests never touch ~/.cache.
+    cmd.env("XDG_CACHE_HOME", home.path().join("cache"));
     // Strip ANSI colors so `predicate::str::contains` assertions match raw text.
     cmd.env("NO_COLOR", "1");
     cmd
@@ -1052,6 +1054,181 @@ fn write_skill(repo: &std::path::Path, name: &str, description: &str) {
 
 fn file_url(p: &std::path::Path) -> String {
     format!("file://{}", p.display())
+}
+
+/// A repo that ships a root-level SKILL.md inside a larger source project
+/// (the `ogulcancelik/herdr` shape). Returns the repo path — a named subdir
+/// so the derived skill name is stable (tempdir basenames start with `.`).
+fn write_root_skill_project(parent: &std::path::Path) -> std::path::PathBuf {
+    let repo = parent.join("herdr-repo");
+    fs::create_dir_all(repo.join("references")).unwrap();
+    fs::create_dir_all(repo.join("docs")).unwrap();
+    fs::create_dir_all(repo.join("src")).unwrap();
+    fs::create_dir_all(repo.join("vendor")).unwrap();
+    fs::write(
+        repo.join("SKILL.md"),
+        "---\nname: herdr\ndescription: Control herdr\n---\n\
+         See [usage](docs/usage.md) for details.\n",
+    )
+    .unwrap();
+    fs::write(repo.join("references/guide.md"), "guide").unwrap();
+    fs::write(repo.join("docs/usage.md"), "usage").unwrap();
+    fs::write(repo.join("src/main.rs"), "fn main() {}").unwrap();
+    fs::write(repo.join("vendor/blob.bin"), "blob").unwrap();
+    fs::write(repo.join("Cargo.toml"), "[package]\nname = \"herdr\"\n").unwrap();
+    git_init_and_commit(&repo);
+    repo
+}
+
+#[test]
+fn install_repo_root_skill_is_sparse() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = write_root_skill_project(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(&repo)])
+        .assert()
+        .success();
+
+    let dest = home.path().join("skills").join("herdr-repo");
+    // What the skill needs: SKILL.md, referenced paths, conventional dirs.
+    assert!(dest.join("SKILL.md").exists());
+    assert!(
+        dest.join("docs/usage.md").exists(),
+        "referenced path copied"
+    );
+    assert!(
+        dest.join("references/guide.md").exists(),
+        "conventional dir copied"
+    );
+    // What it doesn't: the source tree.
+    assert!(!dest.join("src").exists(), "src/ must not be installed");
+    assert!(
+        !dest.join("vendor").exists(),
+        "vendor/ must not be installed"
+    );
+    assert!(!dest.join("Cargo.toml").exists());
+    assert!(!dest.join(".git").exists(), ".git must never be installed");
+}
+
+#[test]
+fn install_skill_flag_selects_single_skill() {
+    let upstream = tempfile::tempdir().unwrap();
+    write_skill(upstream.path(), "alpha", "A");
+    write_skill(upstream.path(), "beta", "B");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path()), "--skill", "beta"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("beta"));
+
+    assert!(home.path().join("skills/beta/SKILL.md").exists());
+    assert!(!home.path().join("skills/alpha").exists());
+}
+
+#[test]
+fn install_skill_flag_unknown_name_errors() {
+    let upstream = tempfile::tempdir().unwrap();
+    write_skill(upstream.path(), "alpha", "A");
+    write_skill(upstream.path(), "beta", "B");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    let out = zskills(&home)
+        .args(["install", &file_url(upstream.path()), "--skill", "nope"])
+        .assert()
+        .success() // partition-based dispatch logs to stderr and continues
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&out);
+    assert!(stderr.contains("'nope' not found"));
+    assert!(
+        stderr.contains("alpha"),
+        "error should list available skills"
+    );
+    assert!(!home.path().join("skills/alpha").exists());
+}
+
+#[test]
+fn install_skill_flag_conflicts_with_all() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", "owner/repo", "--skill", "x", "--all"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn install_skill_flag_bypasses_large_collection_policy() {
+    let upstream = tempfile::tempdir().unwrap();
+    for i in 0..7 {
+        write_skill(upstream.path(), &format!("skill-{}", i), "x");
+    }
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path()), "--skill", "skill-3"])
+        .assert()
+        .success();
+
+    assert!(home.path().join("skills/skill-3/SKILL.md").exists());
+    assert!(!home.path().join("skills/skill-0").exists());
+}
+
+#[test]
+fn doctor_flags_full_repo_install_and_fix_slims_it() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = write_root_skill_project(upstream.path());
+
+    // Simulate a pre-sparse install: a verbatim copy of the clone, .git and all.
+    let home = fake_home();
+    let dest = home.path().join("skills").join("herdr-repo");
+    fs::create_dir_all(dest.join(".git")).unwrap();
+    fs::create_dir_all(dest.join("src")).unwrap();
+    fs::write(dest.join("SKILL.md"), "---\nname: herdr\n---\n").unwrap();
+    fs::write(dest.join("src/main.rs"), "fn main() {}").unwrap();
+    fs::write(dest.join("Cargo.toml"), "[package]\n").unwrap();
+    fs::write(
+        home.path().join("skills/.zskills.json"),
+        json!({
+            "version": 1,
+            "agent_skills": {
+                "herdr-repo": {
+                    "source": file_url(&repo),
+                    "installed_at": "@0",
+                    "head_sha": "legacy"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("full-repo install"))
+        .stdout(predicate::str::contains("herdr-repo"));
+
+    zskills(&home)
+        .args(["doctor", "--fix"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("re-installed herdr-repo slim"));
+
+    assert!(dest.join("SKILL.md").exists());
+    assert!(dest.join("docs/usage.md").exists());
+    assert!(!dest.join(".git").exists(), "slim re-install drops .git");
+    assert!(!dest.join("src").exists(), "slim re-install drops src/");
+    assert!(!dest.join("Cargo.toml").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`zskills install ogulcancelik/herdr` — a repo with a root-level `SKILL.md` inside a full Rust project — landed the **entire source tree** (`src/`, `vendor/`, `Cargo.lock`, `website/`, `.git/`, ~49 MB) in `~/.agents/skills/ogulcancelik-herdr`, when only the skill's own files were needed.

## Changes

- **Sparse materialization for root-level skills** (`agent_skill.rs`): only `SKILL.md`, the conventional skill dirs (`references/`, `assets/`, `scripts/`) when present, and relative paths referenced from `SKILL.md` (markdown links + path-like inline-code spans, each existence-checked against the clone; URLs, absolute paths, and `..` escapes rejected) are copied out. `.git/` is never copied in any layout. `skills/<name>/` installs unchanged. No inventory schema change — `upgrade` keeps working as-is and re-materializes sparsely.
- **`install --skill <name>`**: non-interactive single-skill selection from a multi-skill repo; conflicts with `--all`, bypasses the >5-skill size policy, errors listing available names.
- **Migration** (`doctor`): legacy full-repo installs (detectable by the `.git/` they carry) are flagged with a slim-down hint; `doctor --fix` re-installs them slim from the recorded source; `upgrade` converts transparently. No user bytes touched outside explicit actions.
- Design rationale in `DESIGN-sparse-install.md`; full write-up in `IMPLEMENTATION-REPORT.md`.

## Testing

- 7 new unit tests (referenced-path parser, sparse path-set) + 6 new e2e tests (sparse install, `--skill` behaviors, doctor flag/fix) — **34 unit + 49 e2e passing**, fmt + clippy (`-D warnings`) clean.
- Test harness now sandboxes `XDG_CACHE_HOME` so repo-install tests stop writing into the real `~/.cache`.
- Live smoke test against `ogulcancelik/herdr`: install shrank from ~49 MB (whole clone) to 1.4 MB. Caveat: herdr's root `scripts/`/`assets/` are project dev files and get included by the conventional-dir rule — the accepted trade-off of that heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)