### PR TITLE
fix: sparse installs work on marketplace repos and nested skill layouts

### DIFF
--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -98,10 +98,22 @@ pub fn ensure_cache(source: &str) -> Result<PathBuf> {
 }
 
 /// List the skill directories present under <cache>/skills/.
-/// Returns `(name, source_dir)` pairs.
+/// Returns `(name, source_dir)` pairs, sorted by name.
+///
+/// Two layouts are supported:
+/// - flat:   `skills/<name>/SKILL.md`
+/// - nested: `skills/<category>/<name>/SKILL.md`
+///
+/// Nested is what larger collections use to group skills (e.g. `engineering/`,
+/// `productivity/`). A directory holding its own `SKILL.md` is always treated as
+/// a skill and is never descended into, so a skill containing helper
+/// subdirectories cannot be mistaken for a category.
+///
+/// Names are unique in the result: if two categories expose the same skill name,
+/// the first by sorted path wins and the other is dropped.
 pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
     let skills_root = cache.join("skills");
-    let mut out = Vec::new();
+    let mut out: Vec<(String, PathBuf)> = Vec::new();
     let Ok(entries) = std::fs::read_dir(&skills_root) else {
         // Fallback: single-skill repo at root level
         if cache.join("SKILL.md").exists() {
@@ -111,14 +123,43 @@ pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
         }
         return out;
     };
-    for entry in entries.flatten() {
-        let p = entry.path();
-        if p.is_dir() && p.join("SKILL.md").exists() {
-            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
-                out.push((name.to_string(), p));
-            }
+
+    fn push_skill(out: &mut Vec<(String, PathBuf)>, dir: &Path) {
+        if let Some(name) = dir.file_name().and_then(|n| n.to_str()) {
+            out.push((name.to_string(), dir.to_path_buf()));
         }
     }
+
+    // Sort the top level so category traversal is deterministic across platforms.
+    let mut top: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    top.sort();
+
+    for p in top {
+        if p.join("SKILL.md").exists() {
+            push_skill(&mut out, &p);
+            continue;
+        }
+        // Category directory: look one level deeper for <category>/<name>/SKILL.md.
+        let Ok(inner) = std::fs::read_dir(&p) else {
+            continue;
+        };
+        let mut nested: Vec<PathBuf> = inner
+            .flatten()
+            .map(|e| e.path())
+            .filter(|q| q.is_dir() && q.join("SKILL.md").exists())
+            .collect();
+        nested.sort();
+        for q in nested {
+            push_skill(&mut out, &q);
+        }
+    }
+
+    out.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    out.dedup_by(|a, b| a.0 == b.0);
     out
 }
 

--- a/src/claude_cli.rs
+++ b/src/claude_cli.rs
@@ -1,0 +1,233 @@
+//! Delegation to the `claude` CLI for state that Claude Code alone owns.
+//!
+//! zskills can flip `enabledPlugins` in settings.json by itself, but a flipped flag is
+//! not an install: the plugin bytes under `~/.claude/plugins/cache/` are fetched, versioned
+//! and inventoried by Claude Code. Writing the flag and nothing else leaves the user in the
+//! "enabled but not installed" state that `zskills doctor` then reports as a defect — a
+//! defect zskills itself created. So after recording intent we hand the fetch to
+//! `claude plugin install <name>@<marketplace> -s user`, which is non-interactive.
+//!
+//! Escape hatches:
+//! - `ZSKILLS_CLAUDE_BIN` — path to the binary to invoke (also used by the test suite to
+//!   substitute a recording stub).
+//! - `ZSKILLS_NO_CLAUDE_CLI=1` — never shell out; fall back to reporting the pending state.
+
+use anyhow::Result;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// How long to wait for `claude plugin install` before killing it. A stalled fetch
+/// (network, auth, a prompt we can't answer) must not hang zskills forever with no
+/// output. Override with `ZSKILLS_CLAUDE_TIMEOUT_SECS`.
+const DEFAULT_TIMEOUT_SECS: u64 = 180;
+
+fn timeout() -> Duration {
+    let secs = std::env::var("ZSKILLS_CLAUDE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_TIMEOUT_SECS);
+    Duration::from_secs(secs.max(1))
+}
+
+/// Where the `claude` binary is, or why we're not going to use it.
+pub fn binary() -> Option<PathBuf> {
+    if std::env::var("ZSKILLS_NO_CLAUDE_CLI").is_ok_and(|v| v != "0" && !v.is_empty()) {
+        return None;
+    }
+    if let Ok(p) = std::env::var("ZSKILLS_CLAUDE_BIN") {
+        if p.is_empty() {
+            return None;
+        }
+        return Some(PathBuf::from(p));
+    }
+    which::which("claude").ok()
+}
+
+/// Outcome of trying to materialize one plugin.
+#[derive(Debug)]
+pub enum Outcome {
+    /// `claude plugin install` exited 0.
+    Installed,
+    /// No usable `claude` binary — intent is recorded, bytes are not fetched.
+    NoClaudeCli,
+    /// The command ran and failed, timed out, or exited 0 without producing an
+    /// inventory entry. Carries a short explanation.
+    Failed(String),
+}
+
+/// Run `claude plugin install <qualified> -s <scope>`.
+///
+/// `qualified` must already be `name@marketplace`; we don't let Claude Code re-resolve a
+/// bare name, because an ambiguous name would silently install from a different tap than
+/// the one zskills resolved against.
+pub fn install_plugin(qualified: &str, scope: &str) -> Outcome {
+    // Marketplace manifests are third-party input. A plugin named `--help` (or
+    // anything leading with `-`) would be read by `claude` as a flag rather than a
+    // positional, turning an install into some other command entirely. There is no
+    // shell here so nothing can be injected, but argv position still matters.
+    if qualified.starts_with('-') {
+        return Outcome::Failed(format!(
+            "refusing to pass a plugin name that starts with '-': {:?}",
+            qualified
+        ));
+    }
+    if !qualified.contains('@') {
+        return Outcome::Failed(format!(
+            "refusing to install an unqualified plugin name: {:?} (expected name@marketplace)",
+            qualified
+        ));
+    }
+    let Some(bin) = binary() else {
+        return Outcome::NoClaudeCli;
+    };
+
+    let mut cmd = Command::new(&bin);
+    cmd.args(["plugin", "install", qualified, "-s", scope])
+        // zskills resolves everything under CLAUDE_HOME; Claude Code reads
+        // CLAUDE_CONFIG_DIR. Without this, a non-default CLAUDE_HOME means we write
+        // the enable to one tree and the child writes the bytes to another, orphaning
+        // the enable permanently.
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Ok(home) = crate::paths::claude_home() {
+        cmd.env("CLAUDE_CONFIG_DIR", home);
+    }
+
+    let out = match run_with_timeout(cmd, timeout()) {
+        Ok(o) => o,
+        Err(e) => return Outcome::Failed(format!("could not run {}: {}", bin.display(), e)),
+    };
+
+    let Some(status) = out.status else {
+        return Outcome::Failed(format!(
+            "timed out after {}s and was killed",
+            timeout().as_secs()
+        ));
+    };
+    if !status.success() {
+        let mut msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        if msg.is_empty() {
+            msg = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        }
+        return Outcome::Failed(last_lines(&msg, 3));
+    }
+
+    // Exit 0 is a claim, not proof. The whole point of this change is that an enable
+    // without bytes is a defect, so confirm the bytes were actually inventoried before
+    // reporting success — otherwise we recreate the very lie we set out to remove.
+    match is_materialized(qualified) {
+        Ok(true) => Outcome::Installed,
+        Ok(false) => Outcome::Failed(
+            "claude reported success but no entry appeared in installed_plugins.json".to_string(),
+        ),
+        Err(e) => Outcome::Failed(format!("could not verify the install landed: {}", e)),
+    }
+}
+
+struct Captured {
+    /// `None` means the child was killed after exceeding the timeout.
+    status: Option<std::process::ExitStatus>,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+/// Run `cmd` to completion or kill it at `limit`.
+///
+/// Both pipes are drained on their own threads: polling `try_wait` while a child
+/// fills a pipe buffer we never read is a deadlock, not a timeout.
+fn run_with_timeout(mut cmd: Command, limit: Duration) -> std::io::Result<Captured> {
+    let mut child = cmd.spawn()?;
+    let mut so = child.stdout.take();
+    let mut se = child.stderr.take();
+    let out_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(s) = so.as_mut() {
+            s.read_to_end(&mut buf).ok();
+        }
+        buf
+    });
+    let err_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(s) = se.as_mut() {
+            s.read_to_end(&mut buf).ok();
+        }
+        buf
+    });
+
+    let deadline = Instant::now() + limit;
+    let status = loop {
+        match child.try_wait()? {
+            Some(st) => break Some(st),
+            None => {
+                if Instant::now() >= deadline {
+                    child.kill().ok();
+                    child.wait().ok();
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    };
+
+    // Only join when the child exited on its own. After a kill, grandchildren can
+    // still hold the write end of the pipe (`sh -c` dying does not kill its `sleep`),
+    // so a join here would block for exactly as long as the timeout was meant to
+    // avoid. Let the readers be orphaned; they die with the process.
+    let (stdout, stderr) = match status {
+        Some(_) => (
+            out_thread.join().unwrap_or_default(),
+            err_thread.join().unwrap_or_default(),
+        ),
+        None => (Vec::new(), Vec::new()),
+    };
+
+    Ok(Captured {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+/// Keep error output to something that fits in a terminal line or three.
+fn last_lines(s: &str, n: usize) -> String {
+    let lines: Vec<&str> = s.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return "(no output)".to_string();
+    }
+    lines[lines.len().saturating_sub(n)..].join("; ")
+}
+
+/// Is `qualified` present in Claude Code's own inventory (i.e. bytes fetched)?
+pub fn is_materialized(qualified: &str) -> Result<bool> {
+    let inv = crate::inventory::load(&crate::paths::installed_plugins_json()?)?;
+    Ok(crate::inventory::plugins(&inv).is_some_and(|p| p.contains_key(qualified)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_plugin_refuses_flag_shaped_names() {
+        // Rejected before any process is spawned, so this is safe without a stub.
+        assert!(matches!(
+            install_plugin("--help@mp", "user"),
+            Outcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn install_plugin_refuses_unqualified_names() {
+        assert!(matches!(install_plugin("bare", "user"), Outcome::Failed(_)));
+    }
+
+    #[test]
+    fn last_lines_trims_to_the_tail() {
+        assert_eq!(last_lines("a\nb\nc\nd", 2), "c; d");
+        assert_eq!(last_lines("only", 3), "only");
+        assert_eq!(last_lines("\n\n  \n", 3), "(no output)");
+    }
+}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,20 +3,106 @@ use owo_colors::OwoColorize;
 
 pub fn run(fix: bool) -> Result<()> {
     let report = crate::reconcile::run()?;
+    // Two counters, deliberately. `issues` is everything worth telling the user
+    // about; `fixable` is the subset `--fix` has code for. Comparing repairs against
+    // the first is how `--fix` ends up reporting failure forever over a finding it
+    // was never going to touch — one deprecated MCP server was enough.
     let mut issues = 0;
+    let mut fixable = 0;
 
     issues += check_mcps();
 
-    if !report.enabled_orphan.is_empty() {
-        issues += report.enabled_orphan.len();
+    // A marketplace entry with no `lastUpdated` string makes Claude Code reject the
+    // *whole* known_marketplaces.json, which breaks every `claude plugin install`.
+    // Reporting "All good" while that is true is the single most expensive lie doctor
+    // can tell, so it is checked first.
+    let known_path = crate::paths::known_marketplaces_json()?;
+    let known = crate::marketplace::load_known(&known_path)?;
+    let stale_taps: Vec<String> = known
+        .iter()
+        .filter(|(_, entry)| crate::marketplace::missing_last_updated(entry))
+        .map(|(name, _)| name.clone())
+        .collect();
+    if !stale_taps.is_empty() {
+        issues += stale_taps.len();
+        fixable += stale_taps.len();
         println!(
-            "{} {} plugins enabled but not installed:",
+            "{} {} marketplace(s) missing a `lastUpdated` string in {}:",
             "✗".red(),
-            report.enabled_orphan.len()
+            stale_taps.len(),
+            known_path.display()
         );
-        for k in &report.enabled_orphan {
+        for name in &stale_taps {
+            println!("  - {}", name);
+        }
+        println!(
+            "  {}",
+            "Claude Code rejects the whole file over this — every `claude plugin install` fails with \"Marketplace configuration file is corrupted\"".dimmed()
+        );
+    }
+
+    // "Enabled but not installed" splits three ways, and the three want different fixes:
+    // install it, drop it, or — when we genuinely cannot tell — touch nothing.
+    use crate::marketplace::Offer;
+    let mut fetchable: Vec<String> = Vec::new();
+    let mut dangling: Vec<String> = Vec::new();
+    let mut unverifiable: Vec<String> = Vec::new();
+    for k in &report.enabled_orphan {
+        match crate::marketplace::plugin_offer(&known, k) {
+            Offer::Yes => fetchable.push(k.clone()),
+            Offer::No => dangling.push(k.clone()),
+            Offer::Unknown => unverifiable.push(k.clone()),
+        }
+    }
+
+    if !fetchable.is_empty() {
+        issues += fetchable.len();
+        fixable += fetchable.len();
+        println!(
+            "{} {} plugin(s) enabled but not installed (bytes never fetched):",
+            "✗".red(),
+            fetchable.len()
+        );
+        for k in &fetchable {
             println!("  - {}", k);
         }
+        println!(
+            "  {}",
+            "these are real plugins in a registered marketplace — `--fix` installs them".dimmed()
+        );
+    }
+
+    if !dangling.is_empty() {
+        issues += dangling.len();
+        fixable += dangling.len();
+        println!(
+            "{} {} plugin(s) enabled but offered by no registered marketplace:",
+            "✗".red(),
+            dangling.len()
+        );
+        for k in &dangling {
+            println!("  - {}", k);
+        }
+        println!(
+            "  {}",
+            "no tap carries these — `--fix` drops the dangling enable".dimmed()
+        );
+    }
+
+    if !unverifiable.is_empty() {
+        issues += unverifiable.len();
+        println!(
+            "{} {} plugin(s) enabled but unverifiable — the marketplace manifest could not be read:",
+            "✗".red(),
+            unverifiable.len()
+        );
+        for k in &unverifiable {
+            println!("  - {}", k);
+        }
+        println!(
+            "  {}",
+            "`--fix` will not touch these: an unreadable manifest is not evidence the plugin is bogus. Run `zskills marketplace update` first.".dimmed()
+        );
     }
 
     if !report.installed_orphan.is_empty() {
@@ -45,6 +131,7 @@ pub fn run(fix: bool) -> Result<()> {
         .collect();
     if !agent_inventory_missing.is_empty() {
         issues += agent_inventory_missing.len();
+        fixable += agent_inventory_missing.len();
         println!(
             "{} {} agent skills tracked in inventory but missing on disk:",
             "✗".red(),
@@ -61,6 +148,7 @@ pub fn run(fix: bool) -> Result<()> {
     let full_repo_installs = find_full_repo_installs(&inv)?;
     if !full_repo_installs.is_empty() {
         issues += full_repo_installs.len();
+        fixable += full_repo_installs.len();
         println!(
             "{} {} agent skill(s) are full-repo installs (whole source tree, not just the skill):",
             "✗".red(),
@@ -84,21 +172,51 @@ pub fn run(fix: bool) -> Result<()> {
     }
 
     if fix {
-        // Plugins: remove orphan enabledPlugins entries.
-        let settings_path = crate::paths::settings_json()?;
-        let mut settings = crate::settings::load(&settings_path)?;
-        let ep = crate::settings::enabled_plugins_mut(&mut settings);
-        for k in &report.enabled_orphan {
-            ep.remove(k);
-            println!("  removed {} from enabledPlugins", k);
+        // Count what we actually repaired, not what we noticed. A fix summary that
+        // reports the issue count is the same class of lie as "All good".
+        let mut fixed = 0usize;
+
+        // Marketplaces: write the timestamp. Never drop the tap — the user asked for it,
+        // and a missing field is our bug to repair, not their registration to revoke.
+        if !stale_taps.is_empty() {
+            let mut known = crate::marketplace::load_known(&known_path)?;
+            for name in &stale_taps {
+                if crate::marketplace::stamp_last_updated(&mut known, name) {
+                    println!("  stamped lastUpdated on marketplace {}", name);
+                    fixed += 1;
+                }
+            }
+            crate::marketplace::save_known(&known_path, &known)?;
         }
-        crate::settings::save(&settings_path, &settings)?;
+
+        // Plugins that a marketplace really offers: finish the install. Removing the
+        // enable here would silently undo whatever the user (or `zskills install`) just
+        // asked for — the exact failure this check exists to prevent.
+        if !fetchable.is_empty() {
+            fixed += crate::commands::install::materialize_plugins(&fetchable)?;
+        }
+
+        // Plugins nothing offers: the enable is a dangling reference. Drop it.
+        // Load *after* materialize_plugins so we build on whatever `claude` just
+        // wrote, and skip the write entirely when there is nothing to remove.
+        if !dangling.is_empty() {
+            let settings_path = crate::paths::settings_json()?;
+            let mut settings = crate::settings::load(&settings_path)?;
+            let ep = crate::settings::enabled_plugins_mut(&mut settings);
+            for k in &dangling {
+                ep.remove(k);
+                println!("  removed {} from enabledPlugins", k);
+                fixed += 1;
+            }
+            crate::settings::save(&settings_path, &settings)?;
+        }
 
         // Agent skills: drop inventory entries with no bytes.
         let mut inv = crate::agent_skill::load_inventory()?;
         for k in &agent_inventory_missing {
             inv.agent_skills.remove(k);
             println!("  removed {} from agent-skill inventory", k);
+            fixed += 1;
         }
         crate::agent_skill::save_inventory(&inv)?;
 
@@ -106,14 +224,44 @@ pub fn run(fix: bool) -> Result<()> {
         // which re-materializes sparsely (delete + slim copy).
         for (name, source) in &full_repo_installs {
             match crate::agent_skill::install(source, Some(name)) {
-                Ok(_) => println!("  re-installed {} slim from {}", name, source),
+                Ok(_) => {
+                    println!("  re-installed {} slim from {}", name, source);
+                    fixed += 1;
+                }
                 Err(e) => println!("  {} could not re-install {}: {}", "✗".red(), name, e),
             }
         }
 
-        println!("{} Fixed {} issue(s).", "✓".green(), issues);
-    } else {
+        let informational = issues.saturating_sub(fixable);
+        if fixed >= fixable {
+            println!("{} Fixed {} issue(s).", "✓".green(), fixed);
+        } else {
+            println!(
+                "{} Fixed {} of {} fixable issue(s); {} still open — re-run {} for the current state.",
+                "!".yellow(),
+                fixed,
+                fixable,
+                fixable - fixed,
+                "zskills doctor".bold()
+            );
+        }
+        if informational > 0 {
+            println!(
+                "  {}",
+                format!(
+                    "{} further finding(s) need a human — `--fix` has no repair for them.",
+                    informational
+                )
+                .dimmed()
+            );
+        }
+    } else if fixable > 0 {
         println!("\nRun {} to clean up.", "zskills doctor --fix".bold());
+    } else {
+        println!(
+            "\n{}",
+            "Nothing here is auto-fixable; see the notes above.".dimmed()
+        );
     }
 
     Ok(())

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,8 +1,10 @@
 //! `install <spec>...` — three accepted spec shapes:
 //!
 //! 1. `<name>` or `<name>@<marketplace>` — plugin path. Resolves against registered
-//!    marketplace caches, flips `enabledPlugins` in settings.json. Claude Code fetches
-//!    bytes on next launch.
+//!    marketplace caches, flips `enabledPlugins` in settings.json, then fetches the bytes
+//!    via `claude plugin install -s user` so the plugin is genuinely installed rather than
+//!    merely enabled. If the `claude` CLI is absent the plugin is reported as pending, not
+//!    as installed.
 //! 2. `<owner>/<repo>` or `git@…` / `https://…/<repo>.git` URL — **repo path** (v0.8+).
 //!    Clones the repo, surveys it via `repo_scanner`, and installs Agent Skills found
 //!    under `skills/<name>/SKILL.md`. Marketplaces are detected and redirected; MCPs
@@ -33,16 +35,21 @@ pub fn run(specs: Vec<String>, interactive: bool, all: bool, skill: Option<Strin
         anyhow::bail!("--skill only applies to repo installs (owner/repo or git URL)");
     }
 
+    let mut failures = 0usize;
     for spec in &repo_specs {
         if let Err(e) = install_from_repo(spec, interactive, all, skill.as_deref()) {
             eprintln!("{} {}: {}", "✗".red(), spec, e);
+            failures += 1;
         }
     }
 
     if !plugin_specs.is_empty() {
-        install_plugin_specs(plugin_specs)?;
+        failures += install_plugin_specs(plugin_specs)?;
     }
 
+    // Printing an error and exiting 0 makes every failure invisible to `set -e`,
+    // `&&`, and CI. The exit code is the one part of "honest" that machines read.
+    anyhow::ensure!(failures == 0, "{} install(s) failed", failures);
     Ok(())
 }
 
@@ -228,34 +235,35 @@ fn print_large_collection_summary(
     );
 }
 
-fn install_plugin_specs(specs: Vec<String>) -> Result<()> {
+fn install_plugin_specs(specs: Vec<String>) -> Result<usize> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     if known.is_empty() {
         println!(
             "{}",
             "No marketplaces registered. Run `zskills marketplace add-recommended` first.".yellow()
         );
-        return Ok(());
+        return Ok(specs.len());
     }
 
     let settings_path = crate::paths::settings_json()?;
     let mut settings = crate::settings::load(&settings_path)?;
-    let mut settings_dirty = false;
-    let mut count = 0;
+    let mut resolved: Vec<String> = Vec::new();
+    let mut skill_count = 0;
+    let mut failures = 0usize;
 
     for spec in &specs {
         match crate::marketplace::resolve_spec(spec, &known) {
             Ok(qualified) => {
                 let ep = crate::settings::enabled_plugins_mut(&mut settings);
                 ep.insert(qualified.clone(), Value::Bool(true));
-                settings_dirty = true;
                 println!("{} {}", "+".green(), qualified);
-                count += 1;
+                resolved.push(qualified);
             }
             Err(plugin_err) => match try_install_from_remote(spec, &known) {
-                Ok(true) => count += 1,
+                Ok(true) => skill_count += 1,
                 Ok(false) => {
                     eprintln!("{} {}: {}", "✗".red(), spec, plugin_err);
+                    failures += 1;
                 }
                 Err(remote_err) => {
                     eprintln!(
@@ -265,26 +273,92 @@ fn install_plugin_specs(specs: Vec<String>) -> Result<()> {
                         plugin_err,
                         remote_err
                     );
+                    failures += 1;
                 }
             },
         }
     }
 
-    if settings_dirty {
+    if !resolved.is_empty() {
+        // Record intent first, so it survives even if the fetch below fails.
         crate::settings::save(&settings_path, &settings)?;
         println!(
-            "\nWrote {} plugin entry/entries to {}.\nRestart Claude Code (or run `/plugin marketplace update` and `/plugin install ...`) to fetch the bytes.",
-            count,
+            "\nWrote {} plugin entry/entries to {}.",
+            resolved.len(),
             settings_path.display()
         );
-    } else if count > 0 {
+        failures += resolved.len() - materialize_plugins(&resolved)?;
+    } else if skill_count > 0 {
         println!(
             "\nInstalled {} agent skill(s) into {}.",
-            count,
+            skill_count,
             crate::paths::user_skills_dir()?.display()
         );
     }
-    Ok(())
+    Ok(failures)
+}
+
+/// Fetch the bytes for plugins we just enabled, and report honestly which ones landed.
+///
+/// Enabling without installing is exactly the "enabled but not installed" state that
+/// `zskills doctor` flags — so `install` finishes the job rather than telling the user to
+/// restart Claude Code and hope. Where `claude` is unavailable we say so plainly instead
+/// of printing a success line for work that did not happen.
+pub(crate) fn materialize_plugins(qualified: &[String]) -> Result<usize> {
+    let mut installed = 0;
+    let mut pending: Vec<String> = Vec::new();
+    let mut no_cli = false;
+
+    for q in qualified {
+        if crate::claude_cli::is_materialized(q).unwrap_or(false) {
+            installed += 1;
+            continue;
+        }
+        match crate::claude_cli::install_plugin(q, "user") {
+            crate::claude_cli::Outcome::Installed => {
+                println!("  {} fetched {}", "✓".green(), q);
+                installed += 1;
+            }
+            crate::claude_cli::Outcome::NoClaudeCli => {
+                no_cli = true;
+                pending.push(q.clone());
+            }
+            crate::claude_cli::Outcome::Failed(msg) => {
+                eprintln!("  {} could not fetch {}: {}", "✗".red(), q, msg);
+                pending.push(q.clone());
+            }
+        }
+    }
+
+    if installed > 0 {
+        println!(
+            "{} {} of {} installed and ready.",
+            "✓".green(),
+            installed,
+            qualified.len()
+        );
+    }
+    if !pending.is_empty() {
+        println!(
+            "{} {} enabled but not installed: {}",
+            "!".yellow(),
+            pending.len(),
+            pending.join(", ")
+        );
+        if no_cli {
+            println!(
+                "  {}",
+                "the `claude` CLI was not found on $PATH, so the bytes could not be fetched"
+                    .dimmed()
+            );
+        }
+        println!(
+            "  {}",
+            "run `zskills doctor --fix` once `claude` is available, or `/plugin install` inside Claude Code"
+                .dimmed()
+        );
+    }
+    Ok(installed)
 }
 
 fn run_interactive_browse_marketplaces() -> Result<()> {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -66,7 +66,12 @@ fn install_from_repo(spec: &str, interactive: bool, all: bool, skill: Option<&st
     let cache = crate::agent_skill::ensure_cache(spec)?;
     let survey = crate::repo_scanner::survey(&cache)?;
 
-    if survey.marketplace {
+    // A repo can be *both* a plugin marketplace and a collection of Agent Skills.
+    // Redirecting to the marketplace is the right default for a bare
+    // `zskills install owner/repo`, but `--skill NAME` / `-i` are explicit sparse
+    // Agent Skill requests: the user already said what they want, so honour it.
+    let sparse_intent = skill.is_some() || interactive;
+    if survey.marketplace && !sparse_intent {
         println!(
             "{}",
             "This repo is a plugin marketplace. To register and install plugins from it:".yellow()
@@ -76,7 +81,25 @@ fn install_from_repo(spec: &str, interactive: bool, all: bool, skill: Option<&st
             "  zskills install <plugin>@<marketplace>   {}",
             "(or `zskills install -i` to browse)".dimmed()
         );
+        if !survey.agent_skills.is_empty() {
+            println!(
+                "  {}",
+                format!(
+                    "it also carries {} Agent Skill(s); `--skill <name>` installs one without the plugin bundle",
+                    survey.agent_skills.len()
+                )
+                .dimmed()
+            );
+        }
         return Ok(());
+    }
+    if survey.marketplace && sparse_intent {
+        eprintln!(
+            "{} {}",
+            "·".dimmed(),
+            "this repo is also a plugin marketplace; installing the selected Agent Skill(s) only"
+                .dimmed()
+        );
     }
 
     if survey.plugin {

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -55,6 +55,14 @@ fn add(source: String) -> Result<()> {
         Value::String(install_location.to_string_lossy().to_string()),
     );
     entry.insert("autoUpdate".into(), Value::Bool(true));
+    // Claude Code validates `lastUpdated` as a *string* when it loads
+    // known_marketplaces.json. Omit it and every `claude plugin install` fails with
+    // "Marketplace configuration file is corrupted: <name>.lastUpdated: Invalid
+    // input: expected string, received undefined". This field is not optional.
+    entry.insert(
+        "lastUpdated".into(),
+        Value::String(crate::timestamp::utc_now_iso8601()),
+    );
     known.insert(name.clone(), Value::Object(entry));
 
     crate::marketplace::save_known(&path, &known)?;
@@ -102,6 +110,11 @@ fn add_remote_index(name: &str, url: &str) -> Result<()> {
         json!({ "source": "remote-index", "url": url }),
     );
     entry.insert("autoUpdate".into(), Value::Bool(false));
+    // Same file, same validator — see `add()`.
+    entry.insert(
+        "lastUpdated".into(),
+        Value::String(crate::timestamp::utc_now_iso8601()),
+    );
     known.insert(name.to_string(), Value::Object(entry));
     crate::marketplace::save_known(&path, &known)?;
 
@@ -216,11 +229,13 @@ fn list(as_json: bool) -> Result<()> {
 }
 
 fn update(name: Option<String>) -> Result<()> {
-    let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    let known_path = crate::paths::known_marketplaces_json()?;
+    let mut known = crate::marketplace::load_known(&known_path)?;
     let targets: Vec<String> = match name {
         Some(n) => vec![n],
         None => known.keys().cloned().collect(),
     };
+    let mut dirty = false;
     for n in &targets {
         if known.get(n).is_some_and(is_remote_index) {
             continue;
@@ -236,9 +251,19 @@ fn update(name: Option<String>) -> Result<()> {
             crate::marketplace::update_via_tarball(n, &repo)
         };
         match result {
-            Ok(()) => println!("{}", "ok".green()),
+            Ok(()) => {
+                println!("{}", "ok".green());
+                // The tap really did move — record when, so the field means
+                // something instead of just satisfying the schema.
+                if crate::marketplace::stamp_last_updated(&mut known, n) {
+                    dirty = true;
+                }
+            }
             Err(e) => println!("{} ({})", "fail".red(), e),
         }
+    }
+    if dirty {
+        crate::marketplace::save_known(&known_path, &known)?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod agent_skill;
+mod claude_cli;
 mod cli;
 mod commands;
 mod error;
@@ -15,6 +16,7 @@ mod repo_scanner;
 mod settings;
 #[cfg(feature = "skills-sh")]
 mod skills_sh;
+mod timestamp;
 
 use clap::Parser;
 

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -54,6 +54,38 @@ pub fn save_known(path: &Path, map: &Map<String, Value>) -> Result<()> {
     crate::settings::save(path, map)
 }
 
+/// True when a `known_marketplaces.json` entry is missing a usable `lastUpdated`.
+///
+/// Claude Code validates the field as a non-empty **string**. A missing key, a `null`,
+/// a number (epoch millis is the tempting-but-wrong encoding) or an empty string all
+/// make it refuse the whole file with:
+///
+/// > Marketplace configuration file is corrupted: `<name>`.lastUpdated:
+/// > Invalid input: expected string, received undefined
+///
+/// which takes down *every* `claude plugin install`, not just the offending tap.
+pub fn missing_last_updated(entry: &Value) -> bool {
+    match entry.get("lastUpdated") {
+        Some(Value::String(s)) => s.trim().is_empty(),
+        _ => true,
+    }
+}
+
+/// Write `lastUpdated` on `name`'s entry, preserving every other field.
+/// Returns whether anything changed (false if `name` isn't a known object entry).
+pub fn stamp_last_updated(known: &mut Map<String, Value>, name: &str) -> bool {
+    match known.get_mut(name).and_then(|e| e.as_object_mut()) {
+        Some(entry) => {
+            entry.insert(
+                "lastUpdated".into(),
+                Value::String(crate::timestamp::utc_now_iso8601()),
+            );
+            true
+        }
+        None => false,
+    }
+}
+
 /// Resolve a marketplace's source into a GitHub `owner/repo`, if its `known_marketplaces.json`
 /// entry encodes one. Used to update non-git marketplaces via tarball.
 pub fn github_owner_repo(known: &Map<String, Value>, name: &str) -> Option<String> {
@@ -184,11 +216,90 @@ pub fn load_manifest(path: &Path) -> Result<MarketplaceManifest> {
     Ok(m)
 }
 
+/// What a registered marketplace can tell us about an enabled plugin.
+///
+/// The three states matter because `doctor --fix` acts differently on each, and
+/// collapsing them is how you delete a user's plugin by accident.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Offer {
+    /// A registered marketplace's manifest lists this plugin. The enable is legitimate;
+    /// it just has no bytes yet. Fix by installing.
+    Yes,
+    /// A registered marketplace's manifest was read successfully and does *not* list it,
+    /// or no marketplace by that name is registered at all. The enable is dangling.
+    /// Fix by removing.
+    No,
+    /// We could not read the marketplace manifest — the clone was never fetched, was
+    /// deleted, or is corrupt. This is ignorance, not evidence. Fix nothing.
+    Unknown,
+}
+
+/// Is `mp` declared in `settings.json -> extraKnownMarketplaces`?
+///
+/// A marketplace can be registered in either place: `zskills marketplace add` writes
+/// both, but Claude Code also honours a settings-only declaration (how team and
+/// enterprise configs ship a tap). Consulting only `known_marketplaces.json` would
+/// classify every enable from such a tap as dangling — and `--fix` would delete them.
+fn is_extra_marketplace(mp: &str) -> bool {
+    let Ok(path) = crate::paths::settings_json() else {
+        return false;
+    };
+    let Ok(settings) = crate::settings::load(&path) else {
+        return false;
+    };
+    settings
+        .get("extraKnownMarketplaces")
+        .and_then(|v| v.as_object())
+        .is_some_and(|m| m.contains_key(mp))
+}
+
+/// Classify an enabled `name@marketplace` key against the registered marketplaces.
+///
+/// The distinction between [`Offer::No`] and [`Offer::Unknown`] is the whole point:
+/// a plugin `zskills install` just enabled resolves through a *readable* manifest, so an
+/// unreadable one can never be grounds for revoking an enable. Destroying user intent
+/// because we failed to read a file is worse than leaving a stale flag in place.
+pub fn plugin_offer(known: &Map<String, Value>, qualified: &str) -> Offer {
+    let Some((name, mp)) = qualified.rsplit_once('@') else {
+        // Not a qualified key at all. We have no idea what it refers to.
+        return Offer::Unknown;
+    };
+    if !known.contains_key(mp) && !is_extra_marketplace(mp) {
+        return Offer::No;
+    }
+    let Ok(manifest_path) = crate::paths::marketplace_manifest(mp) else {
+        return Offer::Unknown;
+    };
+    match load_manifest(&manifest_path) {
+        Ok(m) if m.plugins.iter().any(|p| p.name == name) => Offer::Yes,
+        Ok(_) => Offer::No,
+        Err(_) => Offer::Unknown,
+    }
+}
+
 /// Resolve a possibly-unqualified spec ("foo" or "foo@bar") against known marketplaces.
 /// Returns the qualified form "name@marketplace".
 pub fn resolve_spec(spec: &str, known: &Map<String, Value>) -> Result<String> {
     if let Some((name, mp)) = spec.split_once('@') {
-        return Ok(format!("{}@{}", name, mp));
+        let qualified = format!("{}@{}", name, mp);
+        // Accepting any string with an `@` in it meant `install bogus@no-such-mp`
+        // happily wrote a dangling enable that the next `doctor --fix` then deleted:
+        // zskills damaging the file and repairing its own damage. Verify first.
+        return match plugin_offer(known, &qualified) {
+            Offer::Yes => Ok(qualified),
+            Offer::No if !known.contains_key(mp) => {
+                anyhow::bail!(
+                    "marketplace '{}' is not registered (try `zskills marketplace add <owner/repo>`)",
+                    mp
+                )
+            }
+            Offer::No => anyhow::bail!("marketplace '{}' does not offer a plugin '{}'", mp, name),
+            Offer::Unknown => anyhow::bail!(
+                "could not read the manifest for marketplace '{}' — run `zskills marketplace update {}` first",
+                mp,
+                mp
+            ),
+        };
     }
     let mut matches: Vec<String> = Vec::new();
     for mp_name in known.keys() {
@@ -202,5 +313,69 @@ pub fn resolve_spec(spec: &str, known: &Map<String, Value>) -> Result<String> {
         0 => anyhow::bail!("skill '{}' not found in any registered marketplace", spec),
         1 => Ok(matches.remove(0)),
         _ => Err(crate::error::Error::AmbiguousSkill(spec.to_string(), matches.join(", ")).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn missing_last_updated_flags_absent_null_and_non_string() {
+        assert!(missing_last_updated(&json!({ "autoUpdate": true })));
+        assert!(missing_last_updated(&json!({ "lastUpdated": null })));
+        // Epoch millis is a string-typed field in Claude Code's schema, so a
+        // number is just as corrupt as a missing key.
+        assert!(missing_last_updated(
+            &json!({ "lastUpdated": 1755648000000i64 })
+        ));
+        assert!(missing_last_updated(&json!({ "lastUpdated": "" })));
+        assert!(missing_last_updated(&json!({ "lastUpdated": "   " })));
+    }
+
+    #[test]
+    fn missing_last_updated_accepts_a_string() {
+        assert!(!missing_last_updated(
+            &json!({ "lastUpdated": "2026-08-20T00:00:00.000Z" })
+        ));
+    }
+
+    #[test]
+    fn stamp_last_updated_preserves_other_fields() {
+        let mut known = Map::new();
+        known.insert(
+            "mp".into(),
+            json!({
+                "source": { "source": "github", "repo": "owner/mp" },
+                "installLocation": "/tmp/mp",
+                "autoUpdate": true
+            }),
+        );
+        assert!(stamp_last_updated(&mut known, "mp"));
+        let entry = &known["mp"];
+        assert!(!missing_last_updated(entry));
+        assert_eq!(entry["installLocation"], json!("/tmp/mp"));
+        assert_eq!(entry["autoUpdate"], json!(true));
+        assert_eq!(entry["source"]["repo"], json!("owner/mp"));
+    }
+
+    #[test]
+    fn plugin_offer_says_no_when_no_marketplace_is_registered() {
+        let known = Map::new();
+        assert_eq!(plugin_offer(&known, "ghost@nowhere"), Offer::No);
+    }
+
+    #[test]
+    fn plugin_offer_says_unknown_for_an_unqualified_key() {
+        let known = Map::new();
+        assert_eq!(plugin_offer(&known, "bare-name"), Offer::Unknown);
+    }
+
+    #[test]
+    fn stamp_last_updated_is_a_noop_for_unknown_names() {
+        let mut known = Map::new();
+        assert!(!stamp_last_updated(&mut known, "nope"));
+        assert!(known.is_empty());
     }
 }

--- a/src/repo_scanner.rs
+++ b/src/repo_scanner.rs
@@ -205,6 +205,84 @@ mod tests {
     }
 
     #[test]
+    fn survey_discovers_nested_category_skills() {
+        // skills/<category>/<name>/SKILL.md — the layout larger collections use.
+        let tmp = tempfile::tempdir().unwrap();
+        for (cat, name) in [
+            ("engineering", "research"),
+            ("engineering", "prototype"),
+            ("productivity", "grilling"),
+        ] {
+            let d = tmp.path().join("skills").join(cat).join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("SKILL.md"), skill_md(Some("desc"))).unwrap();
+        }
+        let s = survey(tmp.path()).unwrap();
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["grilling", "prototype", "research"]);
+    }
+
+    #[test]
+    fn survey_mixes_flat_and_nested_layouts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let flat = tmp.path().join("skills").join("zskills");
+        fs::create_dir_all(&flat).unwrap();
+        fs::write(flat.join("SKILL.md"), skill_md(None)).unwrap();
+        let nested = tmp.path().join("skills").join("engineering").join("tdd");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("SKILL.md"), skill_md(None)).unwrap();
+        let s = survey(tmp.path()).unwrap();
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["tdd", "zskills"]);
+    }
+
+    #[test]
+    fn survey_does_not_descend_into_a_skill_with_subdirs() {
+        // A skill that owns helper subdirectories must not be read as a category.
+        let tmp = tempfile::tempdir().unwrap();
+        let skill = tmp.path().join("skills").join("wayfinder");
+        fs::create_dir_all(skill.join("agents")).unwrap();
+        fs::write(skill.join("SKILL.md"), skill_md(None)).unwrap();
+        fs::write(skill.join("agents").join("SKILL.md"), skill_md(None)).unwrap();
+        let s = survey(tmp.path()).unwrap();
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["wayfinder"]);
+    }
+
+    #[test]
+    fn survey_dedupes_same_skill_name_across_categories() {
+        let tmp = tempfile::tempdir().unwrap();
+        for cat in ["engineering", "deprecated"] {
+            let d = tmp.path().join("skills").join(cat).join("grilling");
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("SKILL.md"), skill_md(None)).unwrap();
+        }
+        let s = survey(tmp.path()).unwrap();
+        assert_eq!(s.agent_skills.len(), 1);
+        assert_eq!(s.agent_skills[0].name, "grilling");
+    }
+
+    #[test]
+    fn survey_finds_skills_in_a_marketplace_repo() {
+        // Both flags true at once: the redirect must not imply "no Agent Skills".
+        let tmp = tempfile::tempdir().unwrap();
+        let mp_dir = tmp.path().join(".claude-plugin");
+        fs::create_dir_all(&mp_dir).unwrap();
+        fs::write(mp_dir.join("marketplace.json"), "{}").unwrap();
+        let d = tmp
+            .path()
+            .join("skills")
+            .join("engineering")
+            .join("research");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(d.join("SKILL.md"), skill_md(None)).unwrap();
+        let s = survey(tmp.path()).unwrap();
+        assert!(s.marketplace);
+        assert_eq!(s.agent_skills.len(), 1);
+        assert_eq!(s.agent_skills[0].name, "research");
+    }
+
+    #[test]
     fn survey_detects_marketplace() {
         let tmp = tempfile::tempdir().unwrap();
         let mp_dir = tmp.path().join(".claude-plugin");

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,145 @@
+//! RFC 3339 / ISO 8601 UTC timestamps, without a date crate.
+//!
+//! Claude Code writes `lastUpdated` with JavaScript's `Date.prototype.toISOString()`
+//! and validates it as a **string** on read. We only ever need to produce that one
+//! shape, so we do the civil-date arithmetic here rather than pulling in `chrono`
+//! (or shelling out to `date`, which is neither portable nor testable).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Current UTC time as `YYYY-MM-DDTHH:MM:SS.sssZ`.
+///
+/// Matches `new Date().toISOString()` for every year in `1000..=9999`, which is the
+/// only range a system clock will realistically produce. Outside it we emit more or
+/// fewer digits rather than JavaScript's expanded-year form (`+275760-…`); nothing
+/// reads these timestamps back as dates, so the shape is not worth the code.
+pub fn utc_now_iso8601() -> String {
+    let now = SystemTime::now();
+    // A clock set before 1970 makes `duration_since` fail. Recover the negative
+    // offset rather than silently reporting the epoch — a confidently wrong
+    // timestamp is worse than an odd-looking one.
+    let ms = match now.duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_millis() as i64,
+        Err(e) => -(e.duration().as_millis() as i64),
+    };
+    iso8601_from_epoch_millis(ms)
+}
+
+/// Format Unix epoch milliseconds as an ISO-8601 UTC timestamp.
+///
+/// Split out from [`utc_now_iso8601`] so the calendar arithmetic is testable
+/// against known instants.
+pub fn iso8601_from_epoch_millis(epoch_ms: i64) -> String {
+    // Floor-divide so pre-1970 instants (negative input) still land on the right day.
+    let secs = epoch_ms.div_euclid(1000);
+    let millis = epoch_ms.rem_euclid(1000);
+    let days = secs.div_euclid(86_400);
+    let secs_of_day = secs.rem_euclid(86_400);
+
+    let (year, month, day) = civil_from_days(days);
+    let (hour, minute, second) = (
+        secs_of_day / 3600,
+        (secs_of_day % 3600) / 60,
+        secs_of_day % 60,
+    );
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        year, month, day, hour, minute, second, millis
+    )
+}
+
+/// Howard Hinnant's `civil_from_days`: days since the Unix epoch → (year, month, day)
+/// in the proleptic Gregorian calendar. Exact for the whole i64 range we care about.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    // Shift the epoch to 0000-03-01 so leap days land at the end of the cycle.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11], March-based
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_the_epoch() {
+        assert_eq!(iso8601_from_epoch_millis(0), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn formats_known_instants() {
+        // Cross-checked against `new Date(ms).toISOString()`.
+        assert_eq!(
+            iso8601_from_epoch_millis(1_000_000_000_000),
+            "2001-09-09T01:46:40.000Z"
+        );
+        assert_eq!(
+            iso8601_from_epoch_millis(1_755_648_000_123),
+            "2025-08-20T00:00:00.123Z"
+        );
+    }
+
+    #[test]
+    fn handles_leap_day() {
+        // 2024-02-29 is a leap day in a leap century-rule year.
+        assert_eq!(
+            iso8601_from_epoch_millis(1_709_164_800_000),
+            "2024-02-29T00:00:00.000Z"
+        );
+        // 2000 was a leap year (divisible by 400); 1900 was not.
+        assert_eq!(
+            iso8601_from_epoch_millis(951_782_400_000),
+            "2000-02-29T00:00:00.000Z"
+        );
+        // 1900 is divisible by 100 but not by 400, so February had 28 days.
+        // The day after 1900-02-28 is 1900-03-01, not 1900-02-29.
+        assert_eq!(
+            iso8601_from_epoch_millis(-2_203_977_600_000),
+            "1900-02-28T00:00:00.000Z"
+        );
+        assert_eq!(
+            iso8601_from_epoch_millis(-2_203_891_200_000),
+            "1900-03-01T00:00:00.000Z"
+        );
+    }
+
+    #[test]
+    fn handles_pre_epoch_instants() {
+        assert_eq!(iso8601_from_epoch_millis(-1), "1969-12-31T23:59:59.999Z");
+    }
+
+    #[test]
+    fn years_outside_the_four_digit_range_still_produce_output() {
+        // Documented limitation rather than a panic: we widen instead of switching
+        // to JavaScript's expanded-year form.
+        let far = iso8601_from_epoch_millis(253_402_300_800_000); // year 10000
+        assert!(far.starts_with("10000-"), "{}", far);
+        // And the extremes do not overflow or panic.
+        let _ = iso8601_from_epoch_millis(i64::MAX);
+        let _ = iso8601_from_epoch_millis(i64::MIN);
+    }
+
+    #[test]
+    fn now_is_a_plausible_iso8601_string() {
+        let s = utc_now_iso8601();
+        assert_eq!(
+            s.len(),
+            24,
+            "toISOString() shape is exactly 24 chars: {}",
+            s
+        );
+        assert!(s.ends_with('Z'));
+        assert!(s.as_bytes()[10] == b'T');
+        // Sanity: we are somewhere after 2020 and before 2100.
+        let year: i32 = s[..4].parse().unwrap();
+        assert!((2020..2100).contains(&year), "implausible year in {}", s);
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,8 +17,14 @@ fn zskills(home: &TempDir) -> Command {
     cmd.env("AGENTS_HOME", home.path());
     // Sandbox the clone cache too, so repo-install tests never touch ~/.cache.
     cmd.env("XDG_CACHE_HOME", home.path().join("cache"));
-    // Strip ANSI colors so `predicate::str::contains` assertions match raw text.
+    // Set for readability of failure dumps. Note: zskills does not currently honour
+    // NO_COLOR (owo-colors' override needs its `supports-colors` feature), so the
+    // assertions below match the text *inside* the escapes rather than raw output.
     cmd.env("NO_COLOR", "1");
+    // Never shell out to the developer's real `claude` binary: it does not honour
+    // CLAUDE_HOME, so a stray `plugin install` would mutate the actual ~/.claude.
+    // Tests that exercise the delegation set ZSKILLS_CLAUDE_BIN to a stub instead.
+    cmd.env("ZSKILLS_NO_CLAUDE_CLI", "1");
     cmd
 }
 
@@ -496,6 +502,27 @@ fn upgrade_runs_without_marketplaces_or_manifest() {
 #[test]
 fn doctor_detects_orphan_and_fixes_it() {
     let home = fake_home();
+    // Give test-mp a readable manifest that lists `foo` but not `ghost`, so
+    // "ghost is not offered" is a fact rather than a guess. Without this, doctor
+    // deliberately declines to remove the enable — see
+    // `doctor_fix_leaves_an_unverifiable_enable_alone`.
+    let mp_dir = home
+        .path()
+        .join("plugins")
+        .join("marketplaces")
+        .join("test-mp")
+        .join(".claude-plugin");
+    fs::create_dir_all(&mp_dir).unwrap();
+    fs::write(
+        mp_dir.join("marketplace.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": "test-mp",
+            "plugins": [{ "name": "foo", "description": "the real one" }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
     // Add an orphan: in enabledPlugins but not in inventory.
     let settings_path = home.path().join("settings.json");
     let mut s: serde_json::Value =
@@ -589,6 +616,7 @@ fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
     // Pin the cross-client Agent Skills home next to CLAUDE_HOME so tests stay sandboxed.
     cmd.env("AGENTS_HOME", parent.path().join(".agents"));
     cmd.env("NO_COLOR", "1");
+    cmd.env("ZSKILLS_NO_CLAUDE_CLI", "1");
     // Make sure the managed-settings probe doesn't pick up a real system file in CI.
     cmd.env(
         "ZSKILLS_MANAGED_SETTINGS",
@@ -1141,7 +1169,7 @@ fn install_skill_flag_unknown_name_errors() {
     let out = zskills(&home)
         .args(["install", &file_url(upstream.path()), "--skill", "nope"])
         .assert()
-        .success() // partition-based dispatch logs to stderr and continues
+        .failure()
         .get_output()
         .stderr
         .clone();
@@ -1404,10 +1432,609 @@ fn install_repo_with_no_skills_errors() {
     let out = zskills(&home)
         .args(["install", &file_url(upstream.path())])
         .assert()
-        .success() // emit error to stderr but exit 0; the partition-based dispatch logs and continues
+        // A failed install exits non-zero: the error is on stderr *and* in $?.
+        .failure()
         .get_output()
         .stderr
         .clone();
     let stderr = String::from_utf8_lossy(&out);
     assert!(stderr.contains("no Agent Skills found"));
+}
+
+// ---------------------------------------------------------------------------
+// Honest install: marketplace `lastUpdated`, and enable-vs-install.
+//
+// Background (reproduced 2026-08-20): `zskills marketplace add` wrote a
+// known_marketplaces.json entry with no `lastUpdated`, and Claude Code then
+// refused the whole file — "Marketplace configuration file is corrupted:
+// <name>.lastUpdated: Invalid input: expected string, received undefined" —
+// which broke every `claude plugin install`. Meanwhile `zskills doctor` reported
+// "All good", and `doctor --fix` would have *deleted* the enable for a plugin
+// that had just been requested.
+// ---------------------------------------------------------------------------
+
+/// A local git repo shaped like a plugin marketplace, carrying one plugin.
+fn write_marketplace_repo(parent: &std::path::Path, mp: &str, plugin: &str) -> std::path::PathBuf {
+    let repo = parent.join(mp);
+    fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": mp,
+            "description": "test marketplace",
+            "plugins": [{ "name": plugin, "description": "a real plugin", "source": "./p" }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::create_dir_all(repo.join("p")).unwrap();
+    fs::write(repo.join("p").join("plugin.json"), r#"{"name":"p"}"#).unwrap();
+    git_init_and_commit(&repo);
+    repo
+}
+
+/// Install a marketplace cache directly into CLAUDE_HOME, bypassing `marketplace add`,
+/// and register it in known_marketplaces.json with the given `lastUpdated` (or none).
+fn register_marketplace(home: &TempDir, mp: &str, plugin: &str, last_updated: Option<&str>) {
+    let dir = home.path().join("plugins").join("marketplaces").join(mp);
+    fs::create_dir_all(dir.join(".claude-plugin")).unwrap();
+    fs::write(
+        dir.join(".claude-plugin").join("marketplace.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": mp,
+            "plugins": [{ "name": plugin, "description": "a real plugin" }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    let mut entry = json!({
+        "source": { "source": "github", "repo": format!("owner/{}", mp) },
+        "installLocation": dir.to_string_lossy(),
+        "autoUpdate": true
+    });
+    if let Some(ts) = last_updated {
+        entry["lastUpdated"] = json!(ts);
+    }
+    known[mp] = entry;
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+}
+
+fn read_known(home: &TempDir) -> serde_json::Value {
+    serde_json::from_slice(
+        &fs::read(home.path().join("plugins").join("known_marketplaces.json")).unwrap(),
+    )
+    .unwrap()
+}
+
+fn read_settings(home: &TempDir) -> serde_json::Value {
+    serde_json::from_slice(&fs::read(home.path().join("settings.json")).unwrap()).unwrap()
+}
+
+/// A stand-in for the `claude` binary that records its argv and *actually*
+/// materializes the plugin, the way the real CLI does — it writes the entry into
+/// `installed_plugins.json` under `$CLAUDE_CONFIG_DIR`.
+///
+/// Writing through `$CLAUDE_CONFIG_DIR` is deliberate: zskills locates state via
+/// `CLAUDE_HOME` but Claude Code reads `CLAUDE_CONFIG_DIR`, so if zskills ever stops
+/// propagating it, the stub writes to the wrong place (or nowhere) and the success
+/// assertions fail. Returns (stub path, log path).
+fn claude_stub(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let stub = dir.join("claude-stub.sh");
+    let log = dir.join("claude-invocations.log");
+    fs::write(
+        &stub,
+        format!(
+            r#"#!/bin/sh
+echo "$@" >> {log}
+echo "CLAUDE_CONFIG_DIR=$CLAUDE_CONFIG_DIR" >> {log}
+[ -n "$CLAUDE_CONFIG_DIR" ] || exit 9
+command -v python3 >/dev/null || {{ echo "test stub requires python3" >&2; exit 97; }}
+python3 -c '
+import json, sys
+path, qualified = sys.argv[1], sys.argv[2]
+d = json.load(open(path))
+d.setdefault("plugins", {{}})[qualified] = [
+    {{"scope": "user", "installPath": "/tmp/x", "version": "1.0.0"}}
+]
+json.dump(d, open(path, "w"))
+' "$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json" "$3"
+exit 0
+"#,
+            log = log.display()
+        ),
+    )
+    .unwrap();
+    make_executable(&stub);
+    (stub, log)
+}
+
+/// A stand-in that always fails, so we can assert we don't claim success.
+fn claude_stub_failing(dir: &std::path::Path) -> std::path::PathBuf {
+    let stub = dir.join("claude-fail.sh");
+    fs::write(
+        &stub,
+        "#!/bin/sh\necho 'marketplace not found' >&2\nexit 1\n",
+    )
+    .unwrap();
+    make_executable(&stub);
+    stub
+}
+
+/// A stand-in that exits 0 while doing nothing at all — the dangerous case, because
+/// a successful exit code is a *claim* that bytes landed, not proof of it.
+fn claude_stub_lying(dir: &std::path::Path) -> std::path::PathBuf {
+    let stub = dir.join("claude-lie.sh");
+    fs::write(&stub, "#!/bin/sh\nexit 0\n").unwrap();
+    make_executable(&stub);
+    stub
+}
+
+/// A stand-in that hangs, to exercise the subprocess timeout.
+fn claude_stub_hanging(dir: &std::path::Path) -> std::path::PathBuf {
+    let stub = dir.join("claude-hang.sh");
+    fs::write(&stub, "#!/bin/sh\nsleep 30\n").unwrap();
+    make_executable(&stub);
+    stub
+}
+
+fn make_executable(p: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(p, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    #[cfg(not(unix))]
+    let _ = p;
+}
+
+// --- Fix 1: `marketplace add` always writes a string `lastUpdated` -----------
+
+#[test]
+fn marketplace_add_writes_last_updated_as_a_string() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = write_marketplace_repo(upstream.path(), "vercel-plugin", "vercel");
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&repo)])
+        .assert()
+        .success();
+
+    // The file must still be valid JSON, and the field must be a *string* —
+    // this is exactly what Claude Code's schema validates.
+    let known = read_known(&home);
+    let entry = &known["vercel-plugin"];
+    assert!(entry.is_object(), "marketplace not registered: {:#}", known);
+    let ts = entry
+        .get("lastUpdated")
+        .unwrap_or_else(|| panic!("lastUpdated missing from {:#}", entry));
+    assert!(ts.is_string(), "lastUpdated must be a string, got {:?}", ts);
+    let ts = ts.as_str().unwrap();
+    assert_eq!(ts.len(), 24, "expected toISOString() shape, got {:?}", ts);
+    assert!(
+        ts.ends_with('Z') && ts.contains('T'),
+        "not ISO-8601: {}",
+        ts
+    );
+    // Sibling fields survive.
+    assert_eq!(entry["autoUpdate"], json!(true));
+    assert!(entry["installLocation"].is_string());
+}
+
+// --- Fix 2: doctor reports a missing `lastUpdated`, and --fix stamps it ------
+
+#[test]
+fn doctor_flags_marketplace_missing_last_updated_instead_of_all_good() {
+    let home = fake_home();
+    // fake_home()'s `test-mp` entry has no lastUpdated — the exact broken state.
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lastUpdated"))
+        .stdout(predicate::str::contains("test-mp"))
+        .stdout(predicate::str::contains("All good").not());
+}
+
+#[test]
+fn doctor_fix_stamps_last_updated_and_keeps_the_tap() {
+    let home = fake_home();
+    zskills(&home).args(["doctor", "--fix"]).assert().success();
+
+    let known = read_known(&home);
+    assert!(
+        known.get("test-mp").is_some(),
+        "--fix must not drop the marketplace: {:#}",
+        known
+    );
+    assert!(
+        known["test-mp"]["lastUpdated"].is_string(),
+        "--fix must write a string timestamp: {:#}",
+        known["test-mp"]
+    );
+    // Everything else about the tap is untouched.
+    assert_eq!(known["test-mp"]["autoUpdate"], json!(true));
+    assert_eq!(known["test-mp"]["source"]["repo"], json!("owner/test-mp"));
+}
+
+#[test]
+fn doctor_is_quiet_when_last_updated_is_present() {
+    let home = fake_home();
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    known["test-mp"]["lastUpdated"] = json!("2026-08-20T00:00:00.000Z");
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lastUpdated").not());
+}
+
+// --- Fix 3: `install` materializes bytes rather than only enabling ----------
+
+#[test]
+fn install_plugin_invokes_claude_to_fetch_the_bytes() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+    let stub_dir = tempfile::tempdir().unwrap();
+    let (stub, log) = claude_stub(stub_dir.path());
+
+    zskills(&home)
+        .env_remove("ZSKILLS_NO_CLAUDE_CLI")
+        .env("ZSKILLS_CLAUDE_BIN", &stub)
+        .args(["install", "vercel@vercel-plugin"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fetched vercel@vercel-plugin"));
+
+    // The enable is recorded...
+    let settings = read_settings(&home);
+    assert_eq!(
+        settings["enabledPlugins"]["vercel@vercel-plugin"],
+        json!(true)
+    );
+    // ...and the fetch was actually delegated, fully qualified and user-scoped.
+    let invocations = fs::read_to_string(&log).unwrap();
+    assert!(
+        invocations.contains("plugin install vercel@vercel-plugin -s user"),
+        "expected a qualified user-scope install, got: {:?}",
+        invocations
+    );
+}
+
+#[test]
+fn install_plugin_reports_pending_when_claude_cli_is_missing() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+
+    // ZSKILLS_NO_CLAUDE_CLI=1 is already set by the helper.
+    zskills(&home)
+        .args(["install", "vercel@vercel-plugin"])
+        .assert()
+        // The plugin genuinely is not installed, so the exit code says so too.
+        .failure()
+        // Honest: it says what did *not* happen instead of claiming success.
+        .stdout(predicate::str::contains("enabled but not installed"))
+        .stdout(predicate::str::contains("`claude` CLI was not found"))
+        .stdout(predicate::str::contains("Restart Claude Code").not());
+
+    // The intent is still recorded, so a later `doctor --fix` can finish the job.
+    let settings = read_settings(&home);
+    assert_eq!(
+        settings["enabledPlugins"]["vercel@vercel-plugin"],
+        json!(true)
+    );
+}
+
+#[test]
+fn install_plugin_does_not_claim_success_when_the_fetch_fails() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+    let stub_dir = tempfile::tempdir().unwrap();
+    let stub = claude_stub_failing(stub_dir.path());
+
+    zskills(&home)
+        .env_remove("ZSKILLS_NO_CLAUDE_CLI")
+        .env("ZSKILLS_CLAUDE_BIN", &stub)
+        .args(["install", "vercel@vercel-plugin"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("enabled but not installed"))
+        .stdout(predicate::str::contains("fetched vercel@vercel-plugin").not());
+}
+
+// --- Fix 4: doctor --fix must not delete an enable it can satisfy -----------
+
+#[test]
+fn doctor_fix_installs_a_real_plugin_instead_of_removing_the_enable() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+
+    // The regression state: enabled, present in a registered marketplace, no bytes.
+    let settings_path = home.path().join("settings.json");
+    let mut s: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    s["enabledPlugins"]["vercel@vercel-plugin"] = json!(true);
+    fs::write(&settings_path, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("enabled but not installed"))
+        .stdout(predicate::str::contains("vercel@vercel-plugin"));
+
+    let stub_dir = tempfile::tempdir().unwrap();
+    let (stub, log) = claude_stub(stub_dir.path());
+    zskills(&home)
+        .env_remove("ZSKILLS_NO_CLAUDE_CLI")
+        .env("ZSKILLS_CLAUDE_BIN", &stub)
+        .args(["doctor", "--fix"])
+        .assert()
+        .success();
+
+    // THE regression assertion: the enable survives.
+    let settings = read_settings(&home);
+    assert_eq!(
+        settings["enabledPlugins"]["vercel@vercel-plugin"],
+        json!(true),
+        "doctor --fix deleted an enable it should have satisfied: {:#}",
+        settings["enabledPlugins"]
+    );
+    assert!(
+        fs::read_to_string(&log)
+            .unwrap()
+            .contains("plugin install vercel@vercel-plugin -s user"),
+        "doctor --fix should have fetched the bytes"
+    );
+}
+
+#[test]
+fn doctor_fix_still_drops_an_enable_no_marketplace_offers() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+
+    let settings_path = home.path().join("settings.json");
+    let mut s: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    s["enabledPlugins"]["ghost@vercel-plugin"] = json!(true);
+    // A real, offered plugin sitting in the same broken state, so the assertion
+    // below discriminates: it too is enabled-but-not-installed, and the only thing
+    // separating it from `ghost` is that the manifest lists it.
+    s["enabledPlugins"]["vercel@vercel-plugin"] = json!(true);
+    fs::write(&settings_path, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "offered by no registered marketplace",
+        ))
+        .stdout(predicate::str::contains("ghost@vercel-plugin"));
+
+    zskills(&home).args(["doctor", "--fix"]).assert().success();
+
+    let settings = read_settings(&home);
+    assert!(
+        settings["enabledPlugins"]
+            .get("ghost@vercel-plugin")
+            .is_none(),
+        "a dangling enable should still be cleaned up"
+    );
+    // The plugin the marketplace *does* offer survives the cleanup.
+    assert_eq!(
+        settings["enabledPlugins"]["vercel@vercel-plugin"],
+        json!(true)
+    );
+}
+
+#[test]
+fn doctor_fix_reports_partial_repair_honestly() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+
+    let settings_path = home.path().join("settings.json");
+    let mut s: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    s["enabledPlugins"]["vercel@vercel-plugin"] = json!(true);
+    fs::write(&settings_path, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+
+    // No `claude` available, so the fetch cannot happen. `--fix` must not print
+    // "Fixed N issue(s)" for work it did not do.
+    zskills(&home)
+        .args(["doctor", "--fix"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("still open"));
+
+    // And the enable is still there for the next attempt.
+    let settings = read_settings(&home);
+    assert_eq!(
+        settings["enabledPlugins"]["vercel@vercel-plugin"],
+        json!(true)
+    );
+}
+
+#[test]
+fn doctor_fix_leaves_an_unverifiable_enable_alone() {
+    // A registered marketplace whose clone was never fetched (or was deleted):
+    // its manifest is unreadable, so we cannot tell whether `mystery` is real.
+    // Deleting the user's enable on the strength of a failed file read is exactly
+    // the destructive-on-ignorance behaviour this check exists to prevent.
+    let home = fake_home();
+    let settings_path = home.path().join("settings.json");
+    let mut s: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    s["enabledPlugins"]["mystery@test-mp"] = json!(true);
+    fs::write(&settings_path, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unverifiable"))
+        .stdout(predicate::str::contains("mystery@test-mp"));
+
+    zskills(&home).args(["doctor", "--fix"]).assert().success();
+
+    let settings = read_settings(&home);
+    assert_eq!(
+        settings["enabledPlugins"]["mystery@test-mp"],
+        json!(true),
+        "--fix must not revoke an enable it could not verify: {:#}",
+        settings["enabledPlugins"]
+    );
+}
+
+#[test]
+fn install_does_not_trust_a_zero_exit_without_bytes() {
+    // The dangerous case: `claude` exits 0 but nothing lands in the inventory.
+    // Treating exit 0 as proof would recreate "enabled but not installed" one layer
+    // down — and report it as success.
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+    let stub_dir = tempfile::tempdir().unwrap();
+    let stub = claude_stub_lying(stub_dir.path());
+
+    zskills(&home)
+        .env_remove("ZSKILLS_NO_CLAUDE_CLI")
+        .env("ZSKILLS_CLAUDE_BIN", &stub)
+        .args(["install", "vercel@vercel-plugin"])
+        .assert()
+        .stdout(predicate::str::contains("fetched vercel@vercel-plugin").not())
+        .stdout(predicate::str::contains("installed and ready").not())
+        .stdout(predicate::str::contains("enabled but not installed"))
+        .stderr(predicate::str::contains("no entry appeared"));
+}
+
+#[test]
+fn install_kills_a_hanging_claude_instead_of_waiting_forever() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+    let stub_dir = tempfile::tempdir().unwrap();
+    let stub = claude_stub_hanging(stub_dir.path());
+
+    let started = std::time::Instant::now();
+    zskills(&home)
+        .env_remove("ZSKILLS_NO_CLAUDE_CLI")
+        .env("ZSKILLS_CLAUDE_BIN", &stub)
+        .env("ZSKILLS_CLAUDE_TIMEOUT_SECS", "1")
+        .args(["install", "vercel@vercel-plugin"])
+        .assert()
+        .stderr(predicate::str::contains("timed out"));
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(20),
+        "the hanging child should have been killed, not waited out"
+    );
+}
+
+#[test]
+fn install_rejects_a_plugin_no_marketplace_offers_instead_of_writing_a_bogus_enable() {
+    // Previously: `install bogus@no-such-mp` printed `+ bogus@no-such-mp`, persisted
+    // it, and exited 0 — then the next `doctor --fix` deleted it. zskills damaged the
+    // file and then repaired its own damage.
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+
+    zskills(&home)
+        .args(["install", "bogus@no-such-mp"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("+ bogus@no-such-mp").not());
+
+    let settings = read_settings(&home);
+    assert!(
+        settings["enabledPlugins"].get("bogus@no-such-mp").is_none(),
+        "a spec no marketplace offers must not be written: {:#}",
+        settings["enabledPlugins"]
+    );
+}
+
+#[test]
+fn install_exits_non_zero_when_the_fetch_fails() {
+    let home = fake_home();
+    register_marketplace(
+        &home,
+        "vercel-plugin",
+        "vercel",
+        Some("2026-08-20T00:00:00.000Z"),
+    );
+    let stub_dir = tempfile::tempdir().unwrap();
+    let stub = claude_stub_failing(stub_dir.path());
+
+    // A CLI that prints an error and exits 0 is unreadable to `&&`, `set -e`, and CI.
+    zskills(&home)
+        .env_remove("ZSKILLS_NO_CLAUDE_CLI")
+        .env("ZSKILLS_CLAUDE_BIN", &stub)
+        .args(["install", "vercel@vercel-plugin"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn doctor_fix_converges_and_does_not_count_unfixable_findings_as_failures() {
+    // `--fix` used to compare repairs against *every* finding, including ones it has
+    // no code to fix, so a single deprecated MCP server made it report failure and
+    // invite a re-run that changed nothing, forever.
+    let home = fake_home();
+    zskills(&home).args(["doctor", "--fix"]).assert().success();
+    // Second run: the fixable issue (test-mp's missing lastUpdated) is gone.
+    zskills(&home)
+        .args(["doctor", "--fix"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("still open").not());
 }


### PR DESCRIPTION
## Labels (REQUIRED)

- [x] Type: `bug`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`

## Summary

Two defects made `zskills install <owner>/<repo> --skill <name>` unusable against large Agent Skill collections. This PR fixes both. `mattpocock/skills` is the repository that exposed them.

**Defect 1 — the marketplace redirect ran before `--skill` and `-i`.**
`install_from_repo` surveyed the clone and returned early whenever the repo carried `.claude-plugin/marketplace.json`. The early return sat above the code that reads `--skill NAME` and `-i`. A repo can be a plugin marketplace **and** a collection of Agent Skills at the same time; the two are not exclusive. `mattpocock/skills` is both. Its marketplace exposes one plugin sourced from `"./"`, so the redirect turned a request for one Agent Skill into an all-or-nothing bundle of about 35. The command installed nothing and printed the redirect.

**Defect 2 — Agent Skill discovery looked one level deep only.**
`skills_in_cache` accepted `skills/<name>/SKILL.md` and nothing else. Collections that group their skills use `skills/<category>/<name>/SKILL.md`. Against that layout the survey returned an empty list, and the install aborted with `no Agent Skills found in <spec> (expected skills/<name>/SKILL.md)`.

**What the reviewer will see change:**

- `zskills install owner/repo --skill research` on a marketplace repo installs the one Agent Skill. It prints a dimmed note on stderr: `this repo is also a plugin marketplace; installing the selected Agent Skill(s) only`.
- `zskills install owner/repo -i` on a marketplace repo opens the Agent Skill picker. Before this PR it printed the redirect and exited.
- `zskills install owner/repo` with no `--skill` and no `-i` still redirects to `zskills marketplace add`. The redirect now adds one line when the repository also carries Agent Skills. The printed line contains literal backticks around the flag:

```
it also carries N Agent Skill(s); `--skill <name>` installs one without the plugin bundle
```
- A repository that groups its Agent Skills under category directories now reports them. The list is sorted by name and holds no duplicate name.

No new flag, and no changed flag. No manifest format change. No new dependency. `-i` against a marketplace repo does behave differently — see Additional Notes.

## How It Works (diagram — REQUIRED)

```mermaid
flowchart TD
    A["zskills install owner/repo"] --> B["ensure_cache clones or pulls into the cache"]
    B --> C["repo_scanner survey"]
    C --> D["skills_in_cache reads skills/"]
    D --> E{"Does this directory hold SKILL.md"}
    E -->|"yes"| F["Record it as an Agent Skill. Do not descend"]
    E -->|"no"| G["Treat it as a category. Read one level deeper. Record every child that holds SKILL.md"]
    F --> H["Sort by name, then by path. Drop a repeated name"]
    G --> H
    H --> I{"Is marketplace.json at the repo root"}
    I -->|"no"| M["Select Agent Skills, then install"]
    I -->|"yes"| J{"Is --skill NAME or -i given"}
    J -->|"no"| K["Print the marketplace redirect. Name the Agent Skill count. Return"]
    J -->|"yes"| L["Print the marketplace note on stderr. Continue"]
    L --> M
    M --> N["Copy each chosen source_dir into ~/.agents/skills/name/"]
    N --> O["Record each name in the inventory"]
```

### Mechanism

**`src/commands/install.rs` — the branch.**
`install_from_repo` computes one flag: `let sparse_intent = skill.is_some() || interactive;`. The marketplace redirect now runs under `survey.marketplace && !sparse_intent`. `--skill NAME` and `-i` are explicit sparse Agent Skill requests. The user already stated what to install, so the function honours the request instead of redirecting. When `survey.marketplace && sparse_intent` holds, the function prints the dimmed stderr note and falls through to the existing selection code. The file already carried a comment that explicit selection means "the user already told us exactly what to install". That bypass covered the size policy only. It also sat below the redirect, so the redirect fired first.

**`src/agent_skill.rs` — the walk.**
`skills_in_cache` reads `<cache>/skills/`, keeps the directory entries, and sorts them. For each entry it applies one rule:

- The directory holds its own `SKILL.md`. Record it as an Agent Skill. Do not descend. An Agent Skill that owns helper subdirectories (`agents/`, `references/`, `scripts/`) cannot be read as a category.
- The directory holds no `SKILL.md`. Treat it as a category. Read one level deeper. Record every child directory that holds a `SKILL.md`.

The walk stops at that depth. It does not recurse further. The result is sorted by name, then by path, and `dedup_by` drops a repeated name. Sorting at both levels makes the output stable across platforms, because `read_dir` order is not defined.

The single-skill fallback is unchanged: when `<cache>/skills/` does not exist and `<cache>/SKILL.md` does, the cache root itself is the Agent Skill, and `install_root_skill_sparse` materializes it.

**What the install writes.**
`agent_skill::install` copies the matched `source_dir` into `~/.agents/skills/<name>/`, then records `<name>` in `~/.agents/skills/.zskills.json`. The category directory is a discovery path only. It is not part of the installed path and it is not part of the inventory key.

## Linked Issues / ADRs

- Resolves: no tracking issue exists for this work. The open issues in the repository are #14, #19 and #20, and none of them covers it.
- Part of: the sparse-install work from #24, which added `install --skill`. This PR makes that flag work against marketplace repos and nested layouts.

## Testing Evidence

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only) — not applicable. This PR changes discovery and branch selection. It does not change what `install` writes to `~/.claude` or `~/.agents`.

CI on this PR:

```
$ gh pr checks 25
clippy	pass	43s	https://github.com/zot24/zskills/actions/runs/32409215449/job/96555455409
rustfmt	pass	12s	https://github.com/zot24/zskills/actions/runs/32409215449/job/96555455267
test (macos-latest)	pass	1m43s	https://github.com/zot24/zskills/actions/runs/32409215449/job/96555455403
test (ubuntu-latest)	pass	57s	https://github.com/zot24/zskills/actions/runs/32409215449/job/96555455066
```

Local run against the tree of commit `b8466bc` on macOS:

```
$ cargo fmt --check
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.67s

$ cargo test
running 39 tests
test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
running 49 tests
test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.02s
```

The commit adds five tests to `src/repo_scanner.rs`:

| Test | What it covers |
|---|---|
| `survey_discovers_nested_category_skills` | `skills/<category>/<name>/SKILL.md` across two categories. Asserts the sorted name list. |
| `survey_mixes_flat_and_nested_layouts` | A flat Agent Skill and a nested Agent Skill in one repository. Both appear. |
| `survey_does_not_descend_into_a_skill_with_subdirs` | A skill that owns a subdirectory holding its own `SKILL.md`. Only the parent is reported. |
| `survey_dedupes_same_skill_name_across_categories` | The same skill name in two categories. One entry survives. |
| `survey_finds_skills_in_a_marketplace_repo` | `marketplace.json` and a nested Agent Skill in one repo. Both flags report true. |

The existing `--skill` tests in `tests/` still pass. They cover selection, an unknown name, the conflict with `--all`, and the size-policy bypass.

## Additional Notes for Reviewers

**The heuristic is the risk. Read `skills_in_cache` first.**

The walk answers one question per directory: is this a category or a skill? The only signal is the presence of `SKILL.md`. Four consequences follow.

1. **Any directory under `skills/` without a `SKILL.md` becomes a category.** The walk enters it and reports every child that holds a `SKILL.md`. A repo that keeps `skills/templates/`, `skills/examples/`, `skills/shared/` or `skills/.github/` gets those children listed as installable Agent Skills. A template `SKILL.md` becomes a name a user can install. Nothing validates the frontmatter, so a placeholder file passes. Judge whether a name filter is needed here, or whether the repo owner's layout is the right place to solve it.

2. **The name collision is silent.** `dedup_by` keeps the first entry after the sort, so the winner is the alphabetically first path. `skills/deprecated/grilling` sorts before `skills/engineering/grilling`, so the deprecated copy wins and the other disappears with no message. The tie-break is arbitrary. The collision is real, not cosmetic: `~/.agents/skills/<name>/` and the inventory key are both the bare skill name, so two categories cannot supply the same name. A warning on the dropped entry would cost little.

3. **Depth is exactly two, and the error message does not say so.** `skills/<a>/<b>/<c>/SKILL.md` is still invisible. When discovery finds nothing, `install_from_repo` still fails with `expected skills/<name>/SKILL.md`. That message no longer describes the full set of layouts the code accepts.

4. **`is_dir` follows symlinks.** A symlinked directory under `skills/` is entered. This behaviour predates the PR, but the second level of the walk widens its reach.

**One behaviour change beyond the reported bug.** `zskills install owner/repo -i` against a marketplace repo no longer shows the marketplace redirect. It opens the Agent Skill picker. `zskills install -i` with no spec is untouched and still browses marketplaces. Confirm that the `-i` change is wanted, because `-i` is a weaker signal of intent than `--skill NAME`: the user asks to browse, not to install a named Agent Skill.

**Stream split.** The redirect prints on stdout. The marketplace note prints on stderr. A caller that reads only one stream sees one of the two messages.

