### PR TITLE
docs: adopt the house PR standard — template, STE100 card, labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,75 @@
+<!--
+WRITE THIS DESCRIPTION IN ASD-STE100 (Simplified Technical English). HARD RULE.
+
+  One idea per sentence · the same word for the same thing (plugin, marketplace,
+  Agent Skill, MCP server, manifest, inventory — no synonyms in one PR) · active
+  voice, imperative in steps · no filler (basically, simply, just, in order to) ·
+  exact technical names (known_marketplaces.json, enabledPlugins, ~/.agents/skills/).
+
+Produce this body in a FORKED CHAT, not in the conversation that wrote the code
+— that conversation already understands the change and writes for itself. Fork
+it, hand the fork the diff summary + the mermaid text + the linked issues, let it
+write the description SO A COMMON REVIEWER UNDERSTANDS THE CHANGE and post it,
+then drop the fork and continue the main chat.
+
+The description does NOT have to be short. Give the reviewer the context, the
+mechanism, and the risk. STE100 makes the text clear; it does not cap length.
+Cut filler, not information.
+
+Card: docs/guides/PR_DESCRIPTION_STANDARD.md
+-->
+
+## Labels (REQUIRED)
+<!--
+Every PR carries four labels. Set them with `gh pr edit <n> --add-label "..."`.
+A PR without all four is not ready for review.
+-->
+- [ ] Type: `bug` | `enhancement` | `documentation`
+- [ ] Priority: `priority:critical` | `priority:high` | `priority:medium`
+- [ ] Size: `t-shirt:small` | `t-shirt:medium` | `t-shirt:big`
+- [ ] Area: `area:cli` | `area:dx` | `area:docs` (more than one is allowed)
+
+## Summary
+- 
+
+## How It Works (diagram — REQUIRED)
+<!--
+Every PR MUST include a mermaid diagram of how the change works: data flow,
+sequence of calls, or architecture of the pieces touched. GitHub renders
+```mermaid blocks natively as images. Pick the type that fits —
+sequenceDiagram (call flows), flowchart (branching logic). Scope it to the
+pieces this PR touches.
+
+MERMAID THAT BREAKS GITHUB SILENTLY — no `;` inside note or message text, no
+HTML (<br/>) in a participant alias, no bare `%%` line (use `%% ---`). GitHub
+renders unparseable mermaid as a plain code block with no error, and no CI job
+ever reads this description. Open the PR page and look at the diagram.
+-->
+
+```mermaid
+flowchart LR
+    A[Replace] --> B[this] --> C[diagram]
+```
+
+## Linked Issues / ADRs
+- Resolves: <!-- e.g., #123 -->
+- Part of: <!-- e.g., #456 -->
+
+## Testing Evidence
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+- [ ] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)
+
+```
+<insert command output>
+```
+
+<!--
+zskills writes to the user's real ~/.claude and ~/.agents. If this PR changes a
+command that writes state, exercise it with CLAUDE_HOME and AGENTS_HOME pointed
+at a temporary directory, and paste the before/after of the files it touched.
+-->
+
+## Additional Notes for Reviewers
+- 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# AGENTS.md — zskills
+
+Rules for any agent working in this repository: Claude Code, Grok, Codex, or a human following the
+same checklist. `CLAUDE.md` points here; this file is the source of truth.
+
+zskills is a Rust CLI that manages plugins, Agent Skills, and MCP servers for agentic coding CLIs.
+It writes to the user's real `~/.claude/` and `~/.agents/`. Treat every state-changing command as
+something that can damage a working machine.
+
+---
+
+## 1. Vocabulary
+
+Use these words, and no synonym for them:
+
+| Term | Means |
+|---|---|
+| `plugin` | Distributed by a marketplace. Lives in `~/.claude/plugins/`. Enabled in `settings.json` → `enabledPlugins`. |
+| `marketplace` | A registered source of plugins. Recorded in `~/.claude/plugins/known_marketplaces.json`. Never call it a tap or a registry in a PR. |
+| `Agent Skill` | A `SKILL.md` directory. Lives in `~/.agents/skills/`. Not a plugin. |
+| `MCP server` | Declared in `~/.claude.json`, `<project>/.mcp.json`, or a settings file. |
+| `manifest` | The user's `skills.toml`. |
+| `inventory` | What is recorded as installed: `installed_plugins.json` for plugins, `.zskills.json` for Agent Skills. |
+| `scope` | `user`, `project`, or `local`. |
+
+A plugin and an Agent Skill are different things. Do not call one the other.
+
+---
+
+## 2. Pull requests — HARD RULES
+
+**Every PR fills [`.github/pull_request_template.md`](.github/pull_request_template.md).** Do not
+pass a one-paragraph `-b` to `gh pr create`. Write the body to a file and pass `--body-file`:
+
+```bash
+gh pr create --title "..." --body-file /tmp/pr-body.md
+```
+
+The template has six sections and all six are filled: Labels, Summary, How It Works, Linked Issues,
+Testing Evidence, Additional Notes.
+
+**Every PR carries four labels.** Type (`bug` | `enhancement` | `documentation`), `priority:*`,
+`t-shirt:*`, and at least one `area:*` (`area:cli`, `area:dx`, `area:docs`). A PR without all four
+is not ready for review.
+
+```bash
+gh pr edit <n> --add-label "bug,priority:high,t-shirt:medium,area:cli"
+```
+
+**Every PR description is written in ASD-STE100 (Simplified Technical English).** The full card is
+[`docs/guides/PR_DESCRIPTION_STANDARD.md`](docs/guides/PR_DESCRIPTION_STANDARD.md). It is the house
+standard, and it is the same in every repository that uses it. The portable Agent Skill that carries
+it across repositories is `pr-standard` in [`zot24/skills`](https://github.com/zot24/skills) — that
+repository is the skill home. Do not add a copy of it here. Six rules, and no more:
+
+- One idea per sentence. Keep sentences short.
+- The same word for the same thing. See the vocabulary table above. No synonyms inside one PR.
+- Active voice. Imperative in steps.
+- No filler: *basically, simply, just, actually, in order to, obviously, of course*.
+- Technical names stay exact: `known_marketplaces.json`, `enabledPlugins`, `~/.agents/skills/`.
+- **Write the body in a forked chat.** Do not draft it in the conversation that wrote the code —
+  that conversation knows the change already, so it writes for itself instead of for a reviewer.
+  Finish the code on the main chat. Fork it. Give the fork the diff summary, the mermaid text, and
+  the linked issues. The fork writes the description **so that a common reviewer understands the
+  change**, checks the mermaid renders on GitHub, and posts it. Then drop the fork. A fork that
+  inherits the whole coding conversation does not satisfy this rule: the writer must start from the
+  diff. **Length is whatever the reviewer needs** — the target is comprehension, not brevity.
+
+**Every PR description carries a mermaid diagram** of how the change works: call flow, or the
+branching logic the change adds. `sequenceDiagram` for a flow, `flowchart` for a classification.
+GitHub renders ```mermaid blocks natively.
+
+**A broken diagram fails silently.** GitHub renders unparseable mermaid as a plain code block with
+no error, and **no CI job reads the PR body**. Three traps: a `;` inside note or message text, HTML
+such as `<br/>` in a participant alias, and a bare `%%` line. Open the PR page and look at it.
+
+zskills has no `docs/diagrams/` directory. The mermaid block in the body is the whole requirement.
+If that directory is added later, commit the `.mmd` source alongside and reference it under the
+block.
+
+---
+
+## 3. Testing evidence
+
+Paste real output into the Testing Evidence section. Run all three:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+`RUSTFLAGS: "-D warnings"` is set in CI, so a warning fails the build.
+
+**Never exercise a state-changing command against your real home.** Point `CLAUDE_HOME` and
+`AGENTS_HOME` at a temporary directory and paste the before/after of the files the command touched:
+
+```bash
+export CLAUDE_HOME=/tmp/zs-sandbox/.claude AGENTS_HOME=/tmp/zs-sandbox/.agents
+./target/release/zskills doctor
+```
+
+The test suite sets `ZSKILLS_NO_CLAUDE_CLI=1` so no test reaches the developer's real `claude`
+binary. Keep it that way: `claude` reads `CLAUDE_CONFIG_DIR`, not `CLAUDE_HOME`.
+
+---
+
+## 4. Issues
+
+Open an issue before non-trivial work. Use the same label groups as a PR: priority, size, and area.
+
+---
+
+## 5. Release
+
+`release-please` owns versioning. Do not hand-edit `Cargo.toml` versions or
+`.release-please-manifest.json`. Write Conventional Commit subjects (`fix:`, `feat:`, `docs:`) —
+they drive the changelog and the version bump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+See [`AGENTS.md`](AGENTS.md). It is the source of truth for every agent working in this
+repository, Claude Code included.
+
+The rules that bind hardest:
+
+- **Every PR fills [`.github/pull_request_template.md`](.github/pull_request_template.md).** Do not
+  pass a one-paragraph `-b` to `gh pr create`. Use `--body-file`.
+- **Every PR carries four labels**: type (`bug` | `enhancement` | `documentation`), `priority:*`,
+  `t-shirt:*`, and at least one `area:*`.
+- **Every PR description is ASD-STE100**, written in a forked chat, and carries a mermaid diagram.
+  Card: [`docs/guides/PR_DESCRIPTION_STANDARD.md`](docs/guides/PR_DESCRIPTION_STANDARD.md).
+  The portable skill is `pr-standard` in [`zot24/skills`](https://github.com/zot24/skills), not here.
+- **Never run a state-changing command against your real `~/.claude`.** Use `CLAUDE_HOME` and
+  `AGENTS_HOME`.
+- Tests are `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,10 @@
 - [Architecture](./architecture.md)
 - [Troubleshooting](./troubleshooting.md)
 
+# Contributing
+
+- [PR description standard](./guides/PR_DESCRIPTION_STANDARD.md)
+
 # Project
 
 - [Changelog](./changelog.md)

--- a/docs/guides/PR_DESCRIPTION_STANDARD.md
+++ b/docs/guides/PR_DESCRIPTION_STANDARD.md
@@ -1,0 +1,153 @@
+# PR Description Standard (ASD-STE100)
+
+One card. Read it before you write a pull request description.
+
+The house standard is **ASD-STE100 (Simplified Technical English)**. It is a hard rule, not a
+suggestion. The rule covers the description text and the prose inside the mermaid diagram in that
+description.
+
+This card is the zskills copy of the house standard. The writing rules and the forked-chat rule are
+identical across repositories. Only the test commands and the diagram storage rule differ, because
+zskills is a Rust CLI.
+
+The portable version of this standard is the `pr-standard` Agent Skill in
+[`zot24/skills`](https://github.com/zot24/skills). That repository is the skill home. An agent that
+needs the standard in another repository installs it from there:
+
+```bash
+zskills install zot24/skills --skill pr-standard
+```
+
+Do not add a copy of the skill to this repository.
+
+Related: [`../../CLAUDE.md`](../../CLAUDE.md) · [`../../.github/pull_request_template.md`](../../.github/pull_request_template.md)
+
+---
+
+## 1. The four labels
+
+Every PR carries four labels. A PR without all four is not ready for review.
+
+| Group | Values |
+|---|---|
+| Type | `bug`, `enhancement`, `documentation` |
+| Priority | `priority:critical`, `priority:high`, `priority:medium` |
+| Size | `t-shirt:small`, `t-shirt:medium`, `t-shirt:big` |
+| Area | `area:cli`, `area:dx`, `area:docs` |
+
+More than one area label is allowed. Set the labels with `gh pr edit`:
+
+```bash
+gh pr edit 26 --add-label "bug,priority:high,t-shirt:big,area:cli"
+```
+
+`area:cli` covers command behaviour and the state zskills writes. `area:dx` covers the build, the
+tests, and the tooling. `area:docs` covers this card, the template, and `docs/`.
+
+---
+
+## 2. The six writing rules
+
+These six rules are the whole standard. Do not add more.
+
+| Rule | Do this | Not this |
+|---|---|---|
+| One idea per sentence | "`doctor` reads `known_marketplaces.json`. It reports an entry without `lastUpdated`." | "`doctor` reads `known_marketplaces.json` and reports an entry without `lastUpdated`, which also covers the empty-string case." |
+| Same word for the same thing | `marketplace` everywhere | `marketplace`, `tap`, `registry` in one PR |
+| Active voice | "`install` writes `enabledPlugins`." | "`enabledPlugins` is written by `install`." |
+| Imperative in steps | "Run `cargo test`." | "You will want to run `cargo test`." |
+| No filler | "The entry needs a string timestamp." | "Basically the entry just needs a string timestamp in order to work." |
+| Exact technical names | `known_marketplaces.json`, `enabledPlugins` | "the marketplace file", "the enabled map" |
+
+Banned filler words: **basically, simply, just, actually, in order to, obviously, of course**.
+
+Agreed nouns — use these, and no synonym for them: `plugin`, `marketplace`, `Agent Skill`,
+`MCP server`, `manifest`, `inventory`, `scope`.
+
+`plugin` and `Agent Skill` are different things. A plugin comes from a marketplace and lives in
+`~/.claude/plugins/`. An Agent Skill is a `SKILL.md` directory and lives in `~/.agents/skills/`.
+Do not call one the other.
+
+---
+
+## 3. Write the description in a forked chat
+
+Do not draft the description in the same conversation that wrote the code. That conversation already
+understands the change. It writes for itself, and a reviewer cannot follow the result.
+
+1. Finish the code on the main chat.
+2. Fork the conversation. Give the fork three things: the diff summary, the mermaid text, and the
+   linked issues. Tell it to apply this card.
+3. The fork writes the description **so that a common reviewer understands the change**, then puts
+   it on the PR (`gh pr create` or `gh pr edit`).
+4. Drop the fork.
+5. Continue the main chat.
+
+A fork that inherits the full coding conversation does not satisfy this rule. The writer must start
+from the diff, not from the memory of writing it.
+
+**The description does not have to be short.** Give the reviewer the context, the mechanism, and the
+risk. STE100 makes the text clear. It does not cap the length. Cut filler, not information.
+
+This applies to humans and to agents. Any in-repo agent or skill that opens a PR follows the same
+five steps.
+
+---
+
+## 4. Which diagram the PR needs
+
+Every PR carries a mermaid diagram of how the change works.
+
+| Change type | Required mermaid |
+|---|---|
+| Command flow, or a call into another process | `sequenceDiagram` |
+| Branching logic, or a classification | `flowchart` |
+
+Scope the diagram to the pieces the PR touches. Do not redraw the whole binary.
+
+zskills has no `docs/diagrams/` directory today, so the mermaid block in the PR body is the whole
+requirement. If the repository later adds `docs/diagrams/`, commit each diagram as a `.mmd` source
+there as well and reference it under the block.
+
+---
+
+## 5. Three mermaid patterns that break GitHub
+
+GitHub renders unparseable mermaid as a plain code block. It prints no error, so nobody notices.
+
+1. **`;` inside note or message text.** Mermaid reads `;` as a statement terminator, so
+   `stamps the field; keeps the tap` ends the statement early.
+2. **HTML in a participant alias.** `participant Doctor as doctor<br/>(--fix)` does not render.
+   Write the alias on one line with no tag.
+3. **A bare `%%` line.** The comment stripper needs one character after `%%`, so a bare `%%` glues
+   onto the next line. Use `%% ---` as a separator. This breaks flowcharts, not sequence diagrams.
+
+No CI job reads the PR body. The description is machine-unchecked. Open the PR page and look at the
+diagram.
+
+---
+
+## 6. Testing evidence
+
+Paste real output. These are the commands for this repository:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+zskills writes to the user's real `~/.claude` and `~/.agents`. When a PR changes a command that
+writes state, exercise the built binary against a temporary home and paste the before/after:
+
+```bash
+export CLAUDE_HOME=/tmp/zs-sandbox/.claude AGENTS_HOME=/tmp/zs-sandbox/.agents
+./target/release/zskills doctor
+```
+
+---
+
+## 7. Scope
+
+- **New PRs follow this card.** Old open PRs are not rewritten for the standard alone.
+- If you edit an old PR's body for another reason, bring it up to the standard while you are there.


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `documentation`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:small`
- [x] Area: `area:docs`, `area:dx`

## Summary

zskills pull requests had no fixed shape. A PR body was whatever the agent or the person typed into `gh pr create -b`. #25 and #26 carried no labels and no template sections. A reviewer got one paragraph, no diagram, and no test output.

The house standard already exists. It has three parts: a filled PR template, a four-label pack, and a description written in ASD-STE100 (Simplified Technical English) with a mermaid diagram. This PR brings zskills to that standard.

This PR copies that standard into zskills and adapts the repository-specific parts. It adds four files and edits one:

| File | Purpose |
|---|---|
| `.github/pull_request_template.md` | The body every PR fills. Six sections: Labels, Summary, How It Works, Linked Issues, Testing Evidence, Additional Notes. |
| `docs/guides/PR_DESCRIPTION_STANDARD.md` | The card. The four labels, the six writing rules, the forked-chat rule, the diagram rule, and three mermaid traps. |
| `AGENTS.md` | The hard rules for any agent in this repository: the vocabulary table, the PR rules, the test commands, and the sandboxed-home rule. |
| `CLAUDE.md` | A pointer to `AGENTS.md`, and the five rules that bind hardest. 17 lines. |
| `docs/SUMMARY.md` | Adds a `# Contributing` section that lists the new card, so mdbook does not treat the page as an orphan. |

The portable version of the standard is the `pr-standard` Agent Skill in [`zot24/skills`](https://github.com/zot24/skills). That repository is the skill home. `AGENTS.md`, `CLAUDE.md` and the card point at it, and this repository holds no copy of it.

This PR changes no Rust code. It adds no command, and it changes no command behaviour.

Nine labels were created on the repository. Seven come from the house standard, with the same names, descriptions and colours:

- `priority:critical` (Production blocker, `#b60205`), `priority:high` (Launch quality, `#d93f0b`), `priority:medium` (Post-launch improvement, `#fbca04`)
- `t-shirt:small` (`#1d76db`), `t-shirt:medium` (`#fbca04`), `t-shirt:big` (`#b60205`)
- `area:dx` (Developer experience, `#1d76db`)

Two are new, because the area set is CLI-shaped: `area:cli` (CLI commands and behaviour, `#1d76db`) and `area:docs` (Documentation and guides, `#0e8a16`). The type labels `bug`, `enhancement` and `documentation` already existed on the repository and were reused. Area labels are always per repository: name the surfaces this repository has, and no others.

#25 and #26 were stamped with the four-pack after the labels existed. #26 carries `bug`, `priority:critical`, `t-shirt:big`, `area:cli`, `area:dx`. #25 carries `bug`, `priority:high`, `t-shirt:medium`, `area:cli`.

## How It Works (diagram — REQUIRED)

```mermaid
flowchart TD
    A["Finish the code on the main chat"] --> B["Fork the chat"]
    B --> C["Hand the fork the diff summary and the linked issues"]
    C --> D["Fill .github/pull_request_template.md"]
    D --> E{"All six sections filled"}
    E -- no --> D
    E -- yes --> F["gh pr create --body-file"]
    F --> G["gh pr edit --add-label with the four labels"]
    G --> H["Open the PR page and look at the diagram"]
    H --> I{"Diagram renders as an image"}
    I -- no --> J["Fix the mermaid and edit the body"]
    J --> H
    I -- yes --> K["Ready for review"]
```

The card and `AGENTS.md` describe that workflow. Three parts of it deserve a reviewer's attention.

**The fork.** The conversation that wrote the code understands the change already, so it writes for itself. The card gives the writer five steps:

1. Finish the code on the main chat.
2. Fork the chat. Seed the fork with the diff summary and the linked issues.
3. Write the body in the fork.
4. Post it.
5. Drop the fork.

A fork that inherits the whole coding conversation does not satisfy the rule.

**The diagram.** Every PR carries a mermaid block. `sequenceDiagram` for a call flow, `flowchart` for branching logic. No CI job reads a PR body, and GitHub renders unparseable mermaid as a plain code block with no error. The card lists the three traps that cause this: a `;` inside note or message text, HTML such as `<br/>` in a participant alias, and a bare `%%` line. The last step of the workflow is a human check of the rendered page.

**The four labels.** Type, `priority:*`, `t-shirt:*`, and at least one `area:*`. A PR without all four is not ready for review.

### What this repository specialises

The writing rules, the four labels and the forked-chat rule are the house standard, unchanged. Five parts are repository-specific, and this PR sets them for a Rust CLI:

| Part | zskills |
|---|---|
| Test commands | `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, plus a sandboxed-home run |
| Agreed nouns | `plugin`, `marketplace`, `Agent Skill`, `MCP server`, `manifest`, `inventory`, `scope` |
| Area labels | `area:cli`, `area:dx`, `area:docs` |
| Diagram storage | The mermaid block in the PR body is the whole requirement. zskills has no `docs/diagrams/` directory. The card says to commit `.mmd` sources if that directory is added later. |
| Sections that do not apply | A database section, a user-interface section and an agent-workflow section are all dropped. zskills has no database and no user interface to screenshot. |

Two parts were added:

- **A `## Labels (REQUIRED)` section in the template.** The label rule is easy to skip when it lives only in the agent instructions. This template puts the four groups in the body as a checklist, and the card repeats them in §1.
- **A sandboxed-home rule.** zskills writes to the user's real `~/.claude/` and `~/.agents/`. `AGENTS.md` and the template require a state-changing command to run with `CLAUDE_HOME` and `AGENTS_HOME` pointed at a temporary directory, with the before/after of the touched files pasted into the PR.

The vocabulary table in `AGENTS.md` §1 is the reason for the agreed nouns. It records that a `plugin` comes from a `marketplace` and lives in `~/.claude/plugins/`, and that an `Agent Skill` is a `SKILL.md` directory that lives in `~/.agents/skills/`. The two are different things, and a PR must not call one the other.

## Linked Issues / ADRs

- Resolves: nothing. No tracking issue exists for this work. The three open issues (#14 MCP migration, #19 Agent Skill source type in `list`, #20 MCP auth status in `list`) all cover command behaviour, not process.
- Part of: #25 and #26. This standard was applied to both. Both were opened before it existed, and both were stamped with the four-pack.
- ADRs: none. This repository has no ADR directory.

## Testing Evidence

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Ran the built binary against a sandboxed `CLAUDE_HOME` — not applicable. This PR changes no command behaviour.

This PR changes no Rust code, so the Rust checks prove only that the branch is clean. They were run on `docs/pr-standard` at `4d43242`:

```
$ cargo fmt --check
(no output, exit 0)

$ cargo clippy --all-targets -- -D warnings
    Checking zskills v0.7.0 (/Users/anon/code/zskills)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.63s

$ cargo test
running 34 tests
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 49 tests
test result: ok. 49 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.70s
```

The evidence that matters for a docs change is the book build. `docs/SUMMARY.md` lists the new page, so mdbook renders it instead of reporting an orphan:

```
$ mdbook build
 INFO Book building has started
 INFO Running the html backend
 WARN unclosed HTML tag `<name>` found in `commands.md` while exiting Item
HTML tags must be closed before exiting a markdown element.
 INFO HTML book written to `/Users/anon/code/zskills/book`

$ ls book/guides/
PR_DESCRIPTION_STANDARD.html
```

The `<name>` warning is pre-existing. `docs/commands.md` on `main` uses `<name>` as a placeholder 29 times across 26 lines, from line 7 onward. This PR does not touch that file. The generated `book/` directory is gitignored and was deleted after the run.

Labels on the three open pull requests, read back with `gh pr list --state open --json number,labels`:

```
27  documentation, priority:medium, t-shirt:small, area:dx, area:docs
26  bug, priority:critical, t-shirt:big, area:cli, area:dx
25  bug, priority:high, t-shirt:medium, area:cli
```

(#17 is the `release-please` PR. It carries `autorelease: pending` and is machine-owned.)

## Additional Notes for Reviewers

- **This is a copy, and copies drift.** `docs/guides/PR_DESCRIPTION_STANDARD.md` holds its own copy of the house card rather than importing one. A change to the house standard does not reach zskills, and nothing re-syncs them. The `pr-standard` skill in `zot24/skills` is the intended fix: one owner, installed everywhere. A reviewer should decide whether the copy is acceptable until then.
- **The portable skill is not in this repository.** `zot24/skills` is the skill home, so `pr-standard` lives there and this repository holds a pointer. An earlier revision of this PR carried `skills/pr-standard/SKILL.md`; it was removed, because a second copy of the rules in a third repository is one more thing to drift. `AGENTS.md`, `CLAUDE.md` and the card all point at `zot24/skills`. **The skill is not published there yet.** `zot24/skills` exists and is public, but `skills/pr-standard/SKILL.md` returns 404, so the three links are forward references. The card also documents `zskills install zot24/skills --skill pr-standard`, and that command fails today. Land the skill in `zot24/skills`, or expect a reader to hit both.
- **No CI job enforces any of this.** No check reads the PR body, so nothing verifies the template sections, the four labels, the STE100 rules, or that the mermaid block renders. Repositories that run diagram checks in CI do not close this gap either, because those checks read committed files and never the description. The standard is convention. It holds only while agents and people follow it.
- **The template applies to everyone who opens a PR, including `release-please`.** #17 is machine-opened and carries none of this shape. That is expected. Do not label or rewrite the release PR.
- **One claim in `AGENTS.md` was checked.** `.github/workflows/ci.yml` line 11 sets `RUSTFLAGS: "-D warnings"`, so the sentence in §3 is correct today. It breaks if the workflow drops the variable.


