### PR TITLE
feat: pin a marketplace so update and upgrade cannot float it

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ zskills migrate-skill <name>            # promote ONE skill across every project
 zskills migrate-all <dir>               # interactive: walk a tree, prompt per skill
 zskills search <query> [-i]             # -i picks a result and installs it
 zskills marketplace add|remove|list|update
+                                        # pin one in skills.toml so update/upgrade can't float it
 ```
 
 `<name>` accepts unqualified (`servarr`) when unambiguous, or `name@marketplace` (`servarr@zot24-skills`) to disambiguate.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -362,6 +362,44 @@ zskills marketplace update [<name>]
 
 `add-recommended` seeds the trusted defaults (currently just `anthropics/claude-plugins-official`). Idempotent — safe to re-run; existing marketplaces are left as-is.
 
+### Pinning a marketplace
+
+By default `marketplace update`, `update` and `upgrade` all `git pull` every registered
+marketplace, so a marketplace tracks whatever its default branch moves to. Declare a pin in
+`skills.toml` to hold one at a tag, branch, or full sha:
+
+```toml
+[[marketplaces]]
+name = "llm-wiki"
+pin = "v0.23.0"   # tag, branch, or full sha
+```
+
+A pinned marketplace is checked out at that ref and **never pulled**. `marketplace list`
+marks it `[pinned v0.23.0]`. If the clone has drifted, the next update puts it back:
+
+```
+$ zskills update
+Updating llm-wiki ... pinned @ d02cbcb (restored)
+```
+
+Three details worth knowing:
+
+- The ref is resolved from what the clone already has. Only if that fails does zskills
+  `git fetch`, which cannot move `HEAD`.
+- A pin that cannot be resolved is an **error**, not a fallback. zskills will not pull a
+  marketplace it was told to hold, so a typo in a pin freezes the marketplace rather than
+  floating it.
+- A pinned clone sits on a detached `HEAD` on purpose. Leaving it on a branch invites the
+  next pull to move it.
+
+Remove the `pin` line (or blank it) to let the marketplace float again.
+
+The pin lives in `skills.toml`, not in `known_marketplaces.json`. That file belongs to
+Claude Code, which validates it and rejects the whole file when it disagrees — one entry
+missing `lastUpdated` is enough to break every `claude plugin install`. `skills.toml` is
+also the half of the configuration that is meant to be shared between machines;
+`known_marketplaces.json` holds machine-local absolute paths.
+
 `add skills.sh` is recognized only when zskills was built with `--features skills-sh`. It registers skills.sh as a `remote-index` source type (no git clone) and is dispatched by `search` and `install` via the HTTP API. See [Optional features](#optional-features) below.
 
 ## `search`

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -184,6 +184,10 @@ fn remove(name: String) -> Result<()> {
 
 fn list(as_json: bool) -> Result<()> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    // `list` is read-only, so a manifest it cannot parse costs the user the pin
+    // column and nothing else. The mutating commands use `load_pins()?` instead:
+    // there, treating an unparseable manifest as "no pins" would float every pinned
+    // marketplace, which is the failure the pin exists to prevent.
     let pins = crate::marketplace::load_pins().unwrap_or_default();
     if as_json {
         let mut out = known.clone();
@@ -264,7 +268,7 @@ fn update(name: Option<String>) -> Result<()> {
                     dirty = true;
                 }
             }
-            Err(e) => println!("{} ({})", "fail".red(), e),
+            Err(e) => println!("{} ({:#})", "fail".red(), e),
         }
     }
     if dirty {

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -184,8 +184,17 @@ fn remove(name: String) -> Result<()> {
 
 fn list(as_json: bool) -> Result<()> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    let pins = crate::marketplace::load_pins().unwrap_or_default();
     if as_json {
-        println!("{}", serde_json::to_string_pretty(&known)?);
+        let mut out = known.clone();
+        // Surface the pin in the JSON view without writing it to
+        // known_marketplaces.json — that file belongs to Claude Code.
+        for (name, pin) in &pins {
+            if let Some(entry) = out.get_mut(name).and_then(|e| e.as_object_mut()) {
+                entry.insert("zskillsPin".into(), Value::String(pin.clone()));
+            }
+        }
+        println!("{}", serde_json::to_string_pretty(&out)?);
         return Ok(());
     }
     if known.is_empty() {
@@ -214,16 +223,12 @@ fn list(as_json: bool) -> Result<()> {
             .get("autoUpdate")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        println!(
-            "  {}  {} plugin(s){}",
-            name.bold(),
-            count,
-            if auto {
-                "  [autoUpdate]".dimmed().to_string()
-            } else {
-                String::new()
-            }
-        );
+        let pin_note = match pins.get(name) {
+            Some(pin) => format!("  [pinned {}]", pin).yellow().to_string(),
+            None if auto => "  [autoUpdate]".dimmed().to_string(),
+            None => String::new(),
+        };
+        println!("  {}  {} plugin(s){}", name.bold(), count, pin_note);
     }
     Ok(())
 }
@@ -235,6 +240,7 @@ fn update(name: Option<String>) -> Result<()> {
         Some(n) => vec![n],
         None => known.keys().cloned().collect(),
     };
+    let pins = crate::marketplace::load_pins()?;
     let mut dirty = false;
     for n in &targets {
         if known.get(n).is_some_and(is_remote_index) {
@@ -245,17 +251,16 @@ fn update(name: Option<String>) -> Result<()> {
             continue;
         }
         print!("Updating {} ... ", n);
-        let result = if crate::git::is_git_repo(&repo) {
-            crate::git::pull(&repo)
-        } else {
-            crate::marketplace::update_via_tarball(n, &repo)
-        };
-        match result {
-            Ok(()) => {
-                println!("{}", "ok".green());
-                // The tap really did move — record when, so the field means
-                // something instead of just satisfying the schema.
-                if crate::marketplace::stamp_last_updated(&mut known, n) {
+        match crate::marketplace::refresh(n, &repo, pins.get(n).map(String::as_str)) {
+            Ok(outcome) => {
+                println!("{}", crate::marketplace::refresh_label(&outcome).green());
+                // Only stamp when the clone actually moved. A pin that was already
+                // satisfied changed nothing, and `lastUpdated` should not claim it did.
+                let moved = !matches!(
+                    outcome,
+                    crate::marketplace::Refresh::Pinned { moved: false, .. }
+                );
+                if moved && crate::marketplace::stamp_last_updated(&mut known, n) {
                     dirty = true;
                 }
             }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -19,7 +19,7 @@ pub fn run(_skills: Vec<String>) -> Result<()> {
                 }
                 println!("{}", crate::marketplace::refresh_label(&outcome).green());
             }
-            Err(e) => println!("{} ({})", "fail".red(), e),
+            Err(e) => println!("{} ({:#})", "fail".red(), e),
         }
     }
     println!("\nMarketplaces refreshed. Restart Claude Code to pull latest skill bytes.");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -2,24 +2,36 @@ use anyhow::Result;
 use owo_colors::OwoColorize;
 
 pub fn run(_skills: Vec<String>) -> Result<()> {
-    // Refresh every marketplace tap; Claude Code itself handles version negotiation.
+    // Refresh every marketplace; Claude Code itself handles version negotiation.
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    let pins = crate::marketplace::load_pins()?;
+    let mut pinned = 0usize;
     for mp_name in known.keys() {
         let repo = crate::paths::marketplaces_dir()?.join(mp_name);
         if !repo.exists() {
             continue;
         }
         print!("Updating {} ... ", mp_name);
-        let result = if crate::git::is_git_repo(&repo) {
-            crate::git::pull(&repo)
-        } else {
-            crate::marketplace::update_via_tarball(mp_name, &repo)
-        };
-        match result {
-            Ok(()) => println!("{}", "ok".green()),
+        match crate::marketplace::refresh(mp_name, &repo, pins.get(mp_name).map(String::as_str)) {
+            Ok(outcome) => {
+                if matches!(outcome, crate::marketplace::Refresh::Pinned { .. }) {
+                    pinned += 1;
+                }
+                println!("{}", crate::marketplace::refresh_label(&outcome).green());
+            }
             Err(e) => println!("{} ({})", "fail".red(), e),
         }
     }
     println!("\nMarketplaces refreshed. Restart Claude Code to pull latest skill bytes.");
+    if pinned > 0 {
+        println!(
+            "{}",
+            format!(
+                "{} marketplace(s) held at their pin in skills.toml — `zskills marketplace list` shows which.",
+                pinned
+            )
+            .dimmed()
+        );
+    }
     Ok(())
 }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -26,7 +26,7 @@ pub fn run(filter: Vec<String>) -> Result<()> {
             print!("  {} {} ... ", "↻".cyan(), name);
             match crate::marketplace::refresh(name, &repo, pins.get(name).map(String::as_str)) {
                 Ok(outcome) => println!("{}", crate::marketplace::refresh_label(&outcome).green()),
-                Err(e) => println!("{} ({})", "fail".red(), e),
+                Err(e) => println!("{} ({:#})", "fail".red(), e),
             }
         }
     }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -12,6 +12,7 @@ pub fn run(filter: Vec<String>) -> Result<()> {
 
     // ── Marketplaces ────────────────────────────────────────────────────
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
+    let pins = crate::marketplace::load_pins()?;
     if !known.is_empty() {
         println!("{}", "Marketplaces".bold());
         for name in known.keys() {
@@ -23,13 +24,8 @@ pub fn run(filter: Vec<String>) -> Result<()> {
                 continue;
             }
             print!("  {} {} ... ", "↻".cyan(), name);
-            let result = if crate::git::is_git_repo(&repo) {
-                crate::git::pull(&repo)
-            } else {
-                crate::marketplace::update_via_tarball(name, &repo)
-            };
-            match result {
-                Ok(()) => println!("{}", "ok".green()),
+            match crate::marketplace::refresh(name, &repo, pins.get(name).map(String::as_str)) {
+                Ok(outcome) => println!("{}", crate::marketplace::refresh_label(&outcome).green()),
                 Err(e) => println!("{} ({})", "fail".red(), e),
             }
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -46,6 +46,64 @@ pub fn is_git_repo(repo: &Path) -> bool {
     repo.join(".git").exists()
 }
 
+/// Fetch refs and tags from `origin` without touching the working tree.
+///
+/// A pinned marketplace never pulls. It may still need one fetch to learn about a
+/// tag it does not have yet, and a fetch cannot move `HEAD`.
+pub fn fetch_all(repo: &Path) -> Result<()> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["fetch", "--tags", "--quiet", "origin"])
+        .output()
+        .context("running git fetch")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "git fetch failed in {}: {}",
+        repo.display(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    Ok(())
+}
+
+/// Resolve a tag, branch, or sha to a full commit sha, using only what is already
+/// in the repository. Returns `None` when the ref is unknown locally.
+pub fn resolve_commit(repo: &Path, reference: &str) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", "--verify", "--quiet"])
+        .arg(format!("{}^{{commit}}", reference))
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+/// Check out `sha` as a detached HEAD.
+///
+/// Detached is deliberate. A pinned marketplace is not tracking a branch, and leaving
+/// it on one invites the next `git pull` to move it.
+pub fn checkout_detached(repo: &Path, sha: &str) -> Result<()> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["checkout", "--quiet", "--detach", sha])
+        .output()
+        .context("running git checkout")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "git checkout {} failed in {}: {}",
+        sha,
+        repo.display(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    Ok(())
+}
+
 pub fn head_sha(repo: &Path) -> Result<String> {
     let out = Command::new("git")
         .arg("-C")

--- a/src/git.rs
+++ b/src/git.rs
@@ -50,11 +50,17 @@ pub fn is_git_repo(repo: &Path) -> bool {
 ///
 /// A pinned marketplace never pulls. It may still need one fetch to learn about a
 /// tag it does not have yet, and a fetch cannot move `HEAD`.
+///
+/// `--force` is required, not cosmetic. When upstream moves a tag, a plain
+/// `git fetch --tags` rejects **every** tag with "would clobber existing tag" and exits
+/// non-zero, so one moved tag upstream would make an otherwise valid pin unresolvable.
+/// The real `llm-wiki` clone is in that state today. Tags are upstream's to define, so
+/// taking their version is the right resolution.
 pub fn fetch_all(repo: &Path) -> Result<()> {
     let out = Command::new("git")
         .arg("-C")
         .arg(repo)
-        .args(["fetch", "--tags", "--quiet", "origin"])
+        .args(["fetch", "--tags", "--force", "--quiet", "origin"])
         .output()
         .context("running git fetch")?;
     anyhow::ensure!(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,6 +10,10 @@
 //! [[skills]]
 //! name = "github"
 //! marketplace = "claude-plugins-official"
+//!
+//! [[marketplaces]]
+//! name = "llm-wiki"
+//! pin = "v0.23.0"
 //! ```
 
 use anyhow::{Context, Result};
@@ -30,6 +34,49 @@ pub struct Manifest {
     /// MCP servers — written into the runtime's `mcpServers` map at the chosen scope.
     #[serde(default)]
     pub mcps: Vec<McpEntry>,
+
+    /// Marketplace policy. Today this carries one thing: a `pin`, which stops
+    /// `update` and `upgrade` from floating a tap off the ref you chose.
+    #[serde(default)]
+    pub marketplaces: Vec<MarketplaceEntry>,
+}
+
+impl Manifest {
+    /// The pin declared for `name`, if any. An empty or whitespace-only `pin` is
+    /// treated as absent, so commenting a pin out by blanking it behaves as expected.
+    pub fn marketplace_pin(&self, name: &str) -> Option<&str> {
+        self.marketplaces
+            .iter()
+            .find(|m| m.name == name)
+            .and_then(|m| m.pin.as_deref())
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+    }
+}
+
+/// A marketplace declaration in `skills.toml`.
+///
+/// ```toml
+/// [[marketplaces]]
+/// name = "llm-wiki"
+/// pin = "v0.23.0"   # tag, branch, or full sha
+/// ```
+///
+/// **Why the pin lives here and not in `known_marketplaces.json`.** That file belongs
+/// to Claude Code, which validates it against its own schema and rejects the *whole
+/// file* when it disagrees — one entry missing `lastUpdated` is enough to break every
+/// `claude plugin install`. Adding a key it does not know is the same bet with the same
+/// downside. `skills.toml` is zskills' own manifest, it is the file that already
+/// declares intent rather than observed state, and unlike `known_marketplaces.json` it
+/// holds no machine-local absolute paths, so it is the half of the configuration that
+/// is meant to be shared between machines. A pin is exactly that kind of declaration.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct MarketplaceEntry {
+    pub name: String,
+    /// Tag, branch, or full sha. When set, `update`/`upgrade` check this ref out and
+    /// never pull.
+    #[serde(default)]
+    pub pin: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -454,4 +501,52 @@ pub fn append_mcp(path: &Path, entry: &McpEntry) -> Result<bool> {
     std::fs::write(path, doc.to_string())
         .with_context(|| format!("writing manifest {}", path.display()))?;
     Ok(true)
+}
+
+#[cfg(test)]
+mod marketplace_pin_tests {
+    use super::*;
+
+    fn parse(toml_src: &str) -> Manifest {
+        toml::from_str(toml_src).expect("manifest parses")
+    }
+
+    #[test]
+    fn reads_a_pin() {
+        let m = parse("[[marketplaces]]\nname = \"llm-wiki\"\npin = \"v0.23.0\"\n");
+        assert_eq!(m.marketplace_pin("llm-wiki"), Some("v0.23.0"));
+    }
+
+    #[test]
+    fn an_entry_without_a_pin_is_unpinned() {
+        let m = parse("[[marketplaces]]\nname = \"zot24-skills\"\n");
+        assert_eq!(m.marketplace_pin("zot24-skills"), None);
+    }
+
+    #[test]
+    fn a_blank_pin_is_unpinned() {
+        let m = parse("[[marketplaces]]\nname = \"a\"\npin = \"\"\n[[marketplaces]]\nname = \"b\"\npin = \"   \"\n");
+        assert_eq!(m.marketplace_pin("a"), None);
+        assert_eq!(m.marketplace_pin("b"), None);
+    }
+
+    #[test]
+    fn a_pin_is_trimmed() {
+        let m = parse("[[marketplaces]]\nname = \"a\"\npin = \"  v1  \"\n");
+        assert_eq!(m.marketplace_pin("a"), Some("v1"));
+    }
+
+    #[test]
+    fn an_unlisted_marketplace_is_unpinned() {
+        let m = parse("[[marketplaces]]\nname = \"a\"\npin = \"v1\"\n");
+        assert_eq!(m.marketplace_pin("other"), None);
+    }
+
+    #[test]
+    fn a_manifest_with_no_marketplaces_section_still_parses() {
+        // Every existing skills.toml predates this field.
+        let m = parse("[[skills]]\nname = \"firecrawl\"\nmarketplace = \"zot24-skills\"\n");
+        assert!(m.marketplaces.is_empty());
+        assert_eq!(m.marketplace_pin("zot24-skills"), None);
+    }
 }

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -112,6 +112,112 @@ fn github_from_url(url: &str) -> Option<String> {
     Some(stripped.to_string())
 }
 
+/// What a refresh did to a marketplace clone.
+#[derive(Debug)]
+pub enum Refresh {
+    /// Unpinned: pulled (or re-extracted) to whatever upstream now says.
+    Floated,
+    /// Pinned: the clone is at the pinned commit. `moved` is false when it was
+    /// already there, true when this call put it back.
+    Pinned { sha: String, moved: bool },
+}
+
+/// Read the marketplace pins declared in the user's `skills.toml`.
+///
+/// A missing or unparseable manifest means "no pins": a broken manifest must not
+/// silently turn every pin off, so a parse error is surfaced to the caller rather
+/// than swallowed.
+pub fn load_pins() -> Result<std::collections::BTreeMap<String, String>> {
+    let Some(path) = crate::manifest::discover() else {
+        return Ok(Default::default());
+    };
+    let manifest = crate::manifest::load(&path)?;
+    Ok(manifest
+        .marketplaces
+        .iter()
+        .filter_map(|m| {
+            manifest
+                .marketplace_pin(&m.name)
+                .map(|p| (m.name.clone(), p.to_string()))
+        })
+        .collect())
+}
+
+/// Bring one marketplace clone to where it should be.
+///
+/// Without a pin this is the old behaviour: `git pull`, or a tarball re-extract for a
+/// clone that is not a git working tree.
+///
+/// With a pin, the clone is checked out at that ref and **never pulled**. The ref is
+/// resolved from what the clone already has; only when that fails do we `git fetch`,
+/// which cannot move `HEAD`. If the ref still does not resolve, this is an error — a
+/// pin that cannot be honoured must never fall through to a pull, because floating the
+/// tap is the exact failure the pin exists to prevent.
+pub fn refresh(name: &str, repo: &Path, pin: Option<&str>) -> Result<Refresh> {
+    let Some(pin) = pin else {
+        if crate::git::is_git_repo(repo) {
+            crate::git::pull(repo)?;
+        } else {
+            update_via_tarball(name, repo)?;
+        }
+        return Ok(Refresh::Floated);
+    };
+
+    anyhow::ensure!(
+        crate::git::is_git_repo(repo),
+        "marketplace '{}' is pinned to {} but {} is not a git clone — \
+         a tarball marketplace has no refs to pin to. Remove the pin, or re-add the \
+         marketplace from a git source.",
+        name,
+        pin,
+        repo.display()
+    );
+
+    let target = match crate::git::resolve_commit(repo, pin) {
+        Some(sha) => sha,
+        None => {
+            crate::git::fetch_all(repo).with_context(|| {
+                format!("fetching marketplace '{}' to resolve pin {}", name, pin)
+            })?;
+            crate::git::resolve_commit(repo, pin).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "marketplace '{}' is pinned to {}, which does not exist in {} \
+                     even after a fetch — refusing to update it to anything else",
+                    name,
+                    pin,
+                    repo.display()
+                )
+            })?
+        }
+    };
+
+    let head = crate::git::head_sha(repo).unwrap_or_default();
+    if head == target {
+        return Ok(Refresh::Pinned {
+            sha: target,
+            moved: false,
+        });
+    }
+    crate::git::checkout_detached(repo, &target)?;
+    Ok(Refresh::Pinned {
+        sha: target,
+        moved: true,
+    })
+}
+
+/// One-line status for a refresh, for the three commands that print it.
+pub fn refresh_label(r: &Refresh) -> String {
+    match r {
+        Refresh::Floated => "ok".to_string(),
+        Refresh::Pinned { sha, moved: false } => {
+            format!("pinned @ {}", &sha[..sha.len().min(7)])
+        }
+        Refresh::Pinned { sha, moved: true } => {
+            format!("pinned @ {} (restored)", &sha[..sha.len().min(7)])
+        }
+    }
+}
+
 /// Fetch the marketplace's GitHub archive tarball and atomically replace `dest`.
 /// Tries `HEAD.tar.gz` (default branch). Uses the system temp dir for extraction
 /// then renames into place.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,6 +17,10 @@ fn zskills(home: &TempDir) -> Command {
     cmd.env("AGENTS_HOME", home.path());
     // Sandbox the clone cache too, so repo-install tests never touch ~/.cache.
     cmd.env("XDG_CACHE_HOME", home.path().join("cache"));
+    // Sandbox manifest discovery. `manifest::discover()` reads
+    // $XDG_CONFIG_HOME/zskills/skills.toml, so without this a test would read the
+    // developer's real manifest — and marketplace pins are declared there.
+    cmd.env("XDG_CONFIG_HOME", home.path().join("config"));
     // Set for readability of failure dumps. Note: zskills does not currently honour
     // NO_COLOR (owo-colors' override needs its `supports-colors` feature), so the
     // assertions below match the text *inside* the escapes rather than raw output.
@@ -617,6 +621,7 @@ fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
     cmd.env("AGENTS_HOME", parent.path().join(".agents"));
     cmd.env("NO_COLOR", "1");
     cmd.env("ZSKILLS_NO_CLAUDE_CLI", "1");
+    cmd.env("XDG_CONFIG_HOME", parent.path().join("config"));
     // Make sure the managed-settings probe doesn't pick up a real system file in CI.
     cmd.env(
         "ZSKILLS_MANAGED_SETTINGS",
@@ -2037,4 +2042,324 @@ fn doctor_fix_converges_and_does_not_count_unfixable_findings_as_failures() {
         .assert()
         .success()
         .stdout(predicate::str::contains("still open").not());
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace pins.
+//
+// Background (2026-08-21): `zskills update` and `zskills upgrade` `git pull` every
+// registered marketplace. That floated a marketplace off the tag it was deliberately
+// held at — v0.23.0 moved to v0.24.1 — and the next `upgrade` would have done it
+// again. A pin in skills.toml holds the clone at a tag, branch, or sha, and refuses
+// to fall back to a pull when the pin cannot be honoured.
+// ---------------------------------------------------------------------------
+
+/// An upstream marketplace with two commits. `v1` tags the first. `main` points at
+/// the second. Returns (repo path, sha_v1, sha_head).
+fn marketplace_upstream(
+    parent: &std::path::Path,
+    name: &str,
+) -> (std::path::PathBuf, String, String) {
+    let repo = parent.join(name);
+    fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
+    let manifest = |plugins: &str| {
+        format!(
+            r#"{{"name":"{}","owner":{{"name":"T"}},"plugins":[{}]}}"#,
+            name, plugins
+        )
+    };
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        manifest(r#"{"name":"alpha","description":"pinned release"}"#),
+    )
+    .unwrap();
+    git_init_and_commit(&repo);
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["tag", "v1"])
+        .status()
+        .unwrap();
+    let sha_v1 = rev_parse(&repo, "HEAD");
+
+    // A second commit, so "floated" and "pinned" are distinguishable.
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        manifest(
+            r#"{"name":"alpha","description":"newer"},{"name":"beta","description":"added later"}"#,
+        ),
+    )
+    .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["add", "-A"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["commit", "--quiet", "-m", "second"])
+        .status()
+        .unwrap();
+    let sha_head = rev_parse(&repo, "HEAD");
+    (repo, sha_v1, sha_head)
+}
+
+fn rev_parse(repo: &std::path::Path, r: &str) -> String {
+    let out = StdCommand::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", r])
+        .output()
+        .unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// Clone `upstream` into CLAUDE_HOME as a registered marketplace, checked out at `at`.
+fn register_clone(home: &TempDir, name: &str, upstream: &std::path::Path, at: &str) {
+    let dest = home.path().join("plugins").join("marketplaces").join(name);
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    StdCommand::new("git")
+        .args(["clone", "--quiet"])
+        .arg(file_url(upstream))
+        .arg(&dest)
+        .status()
+        .unwrap();
+    // Stay on the tracking branch and move it, rather than detaching. A real
+    // marketplace clone is on `main` with an upstream, which is what makes an
+    // unpinned `git pull` fast-forward — and what let the reported drift happen.
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&dest)
+        .args(["checkout", "--quiet", "main"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&dest)
+        .args(["reset", "--hard", "--quiet", at])
+        .status()
+        .unwrap();
+
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    known[name] = json!({
+        "source": { "source": "git", "url": file_url(upstream) },
+        "installLocation": dest.to_string_lossy(),
+        "autoUpdate": true,
+        "lastUpdated": "2026-08-21T00:00:00.000Z"
+    });
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+}
+
+/// Write a skills.toml into the sandboxed XDG_CONFIG_HOME.
+fn write_manifest(home: &TempDir, body: &str) {
+    let dir = home.path().join("config").join("zskills");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("skills.toml"), body).unwrap();
+}
+
+fn marketplace_head(home: &TempDir, name: &str) -> String {
+    rev_parse(
+        &home.path().join("plugins").join("marketplaces").join(name),
+        "HEAD",
+    )
+}
+
+#[test]
+fn update_holds_a_pinned_marketplace_and_floats_an_unpinned_one() {
+    let up = tempfile::tempdir().unwrap();
+    let (pinned_repo, pinned_v1, pinned_head) = marketplace_upstream(up.path(), "pinned-mp");
+    let (free_repo, free_v1, free_head) = marketplace_upstream(up.path(), "free-mp");
+
+    let home = fake_home();
+    register_clone(&home, "pinned-mp", &pinned_repo, &pinned_v1);
+    register_clone(&home, "free-mp", &free_repo, &free_v1);
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v1\"\n",
+    );
+
+    zskills(&home)
+        .args(["update"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pinned @"));
+
+    assert_eq!(
+        marketplace_head(&home, "pinned-mp"),
+        pinned_v1,
+        "a pinned marketplace must not float off its pin"
+    );
+    assert_ne!(marketplace_head(&home, "pinned-mp"), pinned_head);
+    assert_eq!(
+        marketplace_head(&home, "free-mp"),
+        free_head,
+        "an unpinned marketplace must still update"
+    );
+    assert_ne!(marketplace_head(&home, "free-mp"), free_v1);
+}
+
+#[test]
+fn upgrade_holds_a_pinned_marketplace() {
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, head) = marketplace_upstream(up.path(), "pinned-mp");
+    let home = fake_home();
+    register_clone(&home, "pinned-mp", &repo, &v1);
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v1\"\n",
+    );
+
+    zskills(&home).args(["upgrade"]).assert().success();
+
+    assert_eq!(marketplace_head(&home, "pinned-mp"), v1);
+    assert_ne!(marketplace_head(&home, "pinned-mp"), head);
+}
+
+#[test]
+fn marketplace_update_restores_a_pinned_clone_that_drifted() {
+    // The reported failure: something already floated the clone forward. The next
+    // update must put it back, not leave it and not push it further.
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, head) = marketplace_upstream(up.path(), "pinned-mp");
+    let home = fake_home();
+    register_clone(&home, "pinned-mp", &repo, &head); // already drifted
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v1\"\n",
+    );
+    assert_eq!(marketplace_head(&home, "pinned-mp"), head);
+
+    zskills(&home)
+        .args(["marketplace", "update"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("restored"));
+
+    assert_eq!(
+        marketplace_head(&home, "pinned-mp"),
+        v1,
+        "update must pull a drifted pinned clone back to its pin"
+    );
+}
+
+#[test]
+fn a_pin_accepts_a_full_sha() {
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, head) = marketplace_upstream(up.path(), "pinned-mp");
+    let home = fake_home();
+    register_clone(&home, "pinned-mp", &repo, &head);
+    write_manifest(
+        &home,
+        &format!("[[marketplaces]]\nname = \"pinned-mp\"\npin = \"{}\"\n", v1),
+    );
+
+    zskills(&home).args(["update"]).assert().success();
+    assert_eq!(marketplace_head(&home, "pinned-mp"), v1);
+}
+
+#[test]
+fn an_unresolvable_pin_fails_and_never_falls_back_to_a_pull() {
+    // The dangerous failure mode: a typo in the pin silently reverting to `git pull`
+    // would float the marketplace, which is what the pin exists to prevent.
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, head) = marketplace_upstream(up.path(), "pinned-mp");
+    let home = fake_home();
+    register_clone(&home, "pinned-mp", &repo, &v1);
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v9-does-not-exist\"\n",
+    );
+
+    zskills(&home)
+        .args(["update"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("does not exist"));
+
+    assert_eq!(
+        marketplace_head(&home, "pinned-mp"),
+        v1,
+        "a bad pin must leave the clone alone, not float it"
+    );
+    assert_ne!(marketplace_head(&home, "pinned-mp"), head);
+}
+
+#[test]
+fn a_blank_pin_is_treated_as_unpinned() {
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, head) = marketplace_upstream(up.path(), "free-mp");
+    let home = fake_home();
+    register_clone(&home, "free-mp", &repo, &v1);
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"free-mp\"\npin = \"   \"\n",
+    );
+
+    zskills(&home).args(["update"]).assert().success();
+    assert_eq!(
+        marketplace_head(&home, "free-mp"),
+        head,
+        "a blank pin must not freeze the marketplace"
+    );
+}
+
+#[test]
+fn marketplace_list_shows_the_pin() {
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, _) = marketplace_upstream(up.path(), "pinned-mp");
+    let home = fake_home();
+    register_clone(&home, "pinned-mp", &repo, &v1);
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v1\"\n",
+    );
+
+    zskills(&home)
+        .args(["marketplace", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[pinned v1]"));
+}
+
+#[test]
+fn pinning_a_tarball_marketplace_is_refused_with_a_reason() {
+    // A marketplace that is not a git clone has no refs, so a pin cannot mean
+    // anything. Say so, rather than silently re-extracting the tarball and
+    // leaving the user believing the pin held.
+    let home = fake_home();
+    let dir = home
+        .path()
+        .join("plugins")
+        .join("marketplaces")
+        .join("tarball-mp");
+    fs::create_dir_all(dir.join(".claude-plugin")).unwrap();
+    fs::write(
+        dir.join(".claude-plugin").join("marketplace.json"),
+        r#"{"name":"tarball-mp","plugins":[]}"#,
+    )
+    .unwrap();
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    known["tarball-mp"] = json!({
+        "source": { "source": "github", "repo": "owner/tarball-mp" },
+        "installLocation": dir.to_string_lossy(),
+        "autoUpdate": true,
+        "lastUpdated": "2026-08-21T00:00:00.000Z"
+    });
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"tarball-mp\"\npin = \"v1\"\n",
+    );
+
+    zskills(&home)
+        .args(["marketplace", "update"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("not a git clone"));
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2363,3 +2363,45 @@ fn pinning_a_tarball_marketplace_is_refused_with_a_reason() {
         .success()
         .stdout(predicate::str::contains("not a git clone"));
 }
+
+#[test]
+fn a_pin_resolves_even_when_upstream_moved_a_tag() {
+    // Regression: `git fetch --tags` rejects *every* tag with "would clobber existing
+    // tag" and exits non-zero when upstream has moved any one of them. One moved tag
+    // anywhere upstream would then make an otherwise valid pin unresolvable. The real
+    // llm-wiki clone is in exactly that state. `fetch_all` passes `--force`.
+    let up = tempfile::tempdir().unwrap();
+    let (repo, v1, head) = marketplace_upstream(up.path(), "moved-tag-mp");
+
+    let home = fake_home();
+    register_clone(&home, "moved-tag-mp", &repo, &v1);
+
+    // Upstream moves `v1` onto the second commit and publishes a new `v2` there.
+    // The clone still has the old `v1`, so any fetch must overwrite it.
+    for args in [vec!["tag", "-f", "v1", &head], vec!["tag", "v2", &head]] {
+        StdCommand::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(&args)
+            .status()
+            .unwrap();
+    }
+
+    // `v2` is not in the clone, so honouring this pin requires the fetch to succeed.
+    write_manifest(
+        &home,
+        "[[marketplaces]]\nname = \"moved-tag-mp\"\npin = \"v2\"\n",
+    );
+
+    zskills(&home)
+        .args(["update"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("would clobber").not());
+
+    assert_eq!(
+        marketplace_head(&home, "moved-tag-mp"),
+        head,
+        "a pin to a tag that needs fetching must resolve even when another tag moved"
+    );
+}


### PR DESCRIPTION
## Labels (REQUIRED)

- [x] Type: `enhancement`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`

## Summary

On 2026-08-21 the `llm-wiki` marketplace floated off the tag it was held at. The clone was at
v0.23.0 (`d02cbcb`). After a run of `zskills update` it was at v0.24.1 (`581a395`). Somebody had to
check the clone back to `d02cbcb` by hand.

This was not a bug in one command. `zskills marketplace update`, `zskills update` and
`zskills upgrade` each ran `git pull` on every registered marketplace clone. A marketplace therefore
always tracked whatever its default branch moved to. zskills had no way to record that a marketplace
must stay on a chosen ref. A hand-made checkout survives only until the next `zskills upgrade`, so
the same drift would have happened again on the next run.

This PR adds a **pin**. Declare a pin for a marketplace in the manifest (`skills.toml`):

```toml
[[marketplaces]]
name = "llm-wiki"
pin = "v0.23.0"   # tag, branch, or full sha
```

A pinned marketplace is checked out at that ref and is never pulled. An unpinned marketplace behaves
exactly as before. `zskills marketplace list` marks a pinned entry `[pinned v0.23.0]`.

## How It Works (diagram — REQUIRED)

```mermaid
flowchart TD
    A["update, upgrade, or marketplace update"] --> B["load_pins reads skills.toml"]
    B --> C{"Is this marketplace pinned?"}
    C -- No --> D["git pull, or re-extract the tarball"]
    D --> E["Refresh::Floated. Prints ok"]
    C -- Yes --> F{"Is the clone a git working tree?"}
    F -- No --> G["Error. A tarball marketplace has no refs to pin to"]
    F -- Yes --> H["resolve_commit reads the ref from the clone"]
    H -- Found --> K{"Does HEAD already equal the pinned commit?"}
    H -- Unknown --> I["fetch_all runs git fetch from origin"]
    I --> J["resolve_commit reads the ref again"]
    J -- Unknown --> L["Error. Refuse to move the clone to anything else"]
    J -- Found --> K
    K -- Yes --> M["Refresh::Pinned with moved false. Prints pinned at d02cbcb"]
    K -- No --> N["checkout_detached moves the clone back to the pinned commit"]
    N --> O["Refresh::Pinned with moved true. Prints pinned at d02cbcb (restored)"]
```

### The manifest schema

`skills.toml` gains one array of tables. `src/manifest.rs` adds `MarketplaceEntry` with two fields,
`name` and an optional `pin`. `Manifest::marketplace_pin(name)` returns the pin for one marketplace.
It trims the value and treats an empty or whitespace-only `pin` as absent, so a user can turn a pin
off by blanking it instead of deleting the line. The field carries `#[serde(default)]`, so every
`skills.toml` written before this PR still parses.

zskills reads the manifest that `manifest::discover()` finds: `$XDG_CONFIG_HOME/zskills/skills.toml`
first, then the platform configuration directory.

### One function for three commands

`src/marketplace.rs` adds `refresh(name, repo, pin)`. It returns a `Refresh` enum with two variants:
`Floated`, and `Pinned { sha, moved }`. `refresh_label()` turns that enum into the one line the
commands print.

The three call sites now share `refresh()`:

| Call site | Was | Is |
|---|---|---|
| `src/commands/marketplace.rs` (`marketplace update`) | `git::pull` or `update_via_tarball` inline | `marketplace::refresh` |
| `src/commands/update.rs` | `git::pull` or `update_via_tarball` inline | `marketplace::refresh` |
| `src/commands/upgrade.rs` | `git::pull` or `update_via_tarball` inline | `marketplace::refresh` |

`load_pins()` reads the pins once per command and passes each one into `refresh()`.

`marketplace update` also changes when it writes `lastUpdated` in `known_marketplaces.json`. It
stamps the field only when the clone moved. A pin that was already satisfied changed
nothing, so the field must not claim a refresh that did not happen.

`update` prints a dimmed count at the end when it held one or more marketplaces at a pin.

`marketplace list --json` reports a pin as a `zskillsPin` key in its own output. It does not write
that key into `known_marketplaces.json`.

### Three decisions that carry the risk

**1. Resolve the ref from the clone before any network call.** `git::resolve_commit()` runs
`git rev-parse --verify --quiet <ref>^{commit}` against the clone. Only when that returns nothing
does `refresh()` call `git::fetch_all()`, which runs `git fetch --tags --force --quiet origin`. A fetch
updates refs. It cannot move `HEAD`. A pin to a ref the clone already holds needs no network at all,
so `zskills update` stays fast and works offline for the common case.

**2. An unresolvable pin is an error, not a fallback.** When the ref does not resolve even after the
fetch, `refresh()` returns an error. It does not fall back to `git pull`. A fallback would float the
marketplace, which is the exact failure the pin exists to prevent. The cost is the opposite failure
mode: a typo in a pin freezes the marketplace instead of updating it. The command prints `fail` for
that marketplace and continues with the others. The clone is left where it was.

**3. A pinned clone is left on a detached `HEAD`.** `git::checkout_detached()` runs
`git checkout --quiet --detach <sha>`. Leaving the clone on a branch invites the next `git pull`,
from any source, to move it.

A pin on a marketplace that is not a git working tree is refused with a reason. A tarball
marketplace has no refs to pin to.

### Why the pin lives in `skills.toml`

This is the main design decision to check.

`known_marketplaces.json` was the obvious alternative and is the wrong file. That file belongs to
Claude Code. Claude Code validates it against its own schema and rejects the **whole file** when it
disagrees. PR #26 in this repository fixed exactly that failure: one entry missing `lastUpdated`
broke every `claude plugin install`. Writing a key that Claude Code does not know is the same bet
with the same downside.

`skills.toml` is the manifest that zskills owns. It already declares intent rather than observed
state, and a pin is a declaration of intent. It also holds no machine-local absolute paths, unlike
`known_marketplaces.json`, so it is the half of the configuration meant to be shared between
machines.

`skills.lock` was the other candidate and is wrong for the mirrored reason. A lockfile records
resolved state. A pin is an input to resolution, not its output. `src/lockfile.rs` is left as the
stub it already was.

## Linked Issues / ADRs

- Resolves: no tracking issue. This work started from the live incident, and no issue was opened
  first. `gh issue list --repo zot24/zskills` reports three open issues — #14, #19 and #20 — and
  none of them covers marketplace pinning. This repository has no ADR directory.
- Related: PR #26 (`fix: install plugins instead of just enabling them, and stop doctor lying`). It
  is the evidence for the `known_marketplaces.json` argument above, not a dependency.

## Testing Evidence

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME`

```
$ cargo fmt --check
$ echo $?
0

$ touch src/main.rs && cargo clippy --all-targets -- -D warnings
    Checking zskills v0.8.0 (/Users/anon/code/zskills/.worktrees/marketplace-pin)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.35s

$ cargo test
     Running unittests src/main.rs (target/debug/deps/zskills-6b386703d9fcc288)
running 60 tests
test result: ok. 60 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
     Running tests/cli.rs (target/debug/deps/cli-be8811e062acc3be)
running 74 tests
test result: ok. 74 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.47s
```

The commit adds 14 tests: 6 unit tests on `Manifest::marketplace_pin`, and 8 integration tests in
`tests/cli.rs`. The pin-related integration tests are:

```
test marketplace_list_shows_the_pin ... ok
test marketplace_update_restores_a_pinned_clone_that_drifted ... ok
test pinning_a_tarball_marketplace_is_refused_with_a_reason ... ok
test update_holds_a_pinned_marketplace_and_floats_an_unpinned_one ... ok
test upgrade_holds_a_pinned_marketplace ... ok
```

### Live verification against a sandboxed home

The incident was reproduced and the fix was verified against a real marketplace clone. A copy of the
`llm-wiki` clone was placed in a sandboxed `CLAUDE_HOME`, on branch `master` at `581a395` (v0.24.1),
which is the drifted state from 2026-08-21. `CLAUDE_HOME`, `AGENTS_HOME` and `XDG_CONFIG_HOME` all
pointed at a temporary directory. The real `~/.claude` and `~/.agents` were not touched.

```
$ git -C $CLAUDE_HOME/plugins/marketplaces/llm-wiki log --oneline -1
581a395 Bump to v0.24.1

$ zskills update
Updating llm-wiki ... pinned @ d02cbcb (restored)

Marketplaces refreshed. Restart Claude Code to pull latest skill bytes.
1 marketplace(s) held at their pin in skills.toml — `zskills marketplace list` shows which.

$ git -C $CLAUDE_HOME/plugins/marketplaces/llm-wiki log --oneline -1
d02cbcb Bump to v0.23.0

$ zskills update
Updating llm-wiki ... pinned @ d02cbcb

Marketplaces refreshed. Restart Claude Code to pull latest skill bytes.
1 marketplace(s) held at their pin in skills.toml — `zskills marketplace list` shows which.

$ zskills marketplace list
  llm-wiki  1 plugin(s)  [pinned v0.23.0]
```

The first run restored the clone and reported `(restored)`. The second run found the clone already
at the pinned commit, reported no restore, and made no network call. `git status` confirms the
clone is on a detached `HEAD` after the restore.

The unresolvable-pin path was also exercised in the same sandbox. The pin was changed to a ref that
does not exist:

```
$ zskills update   # with pin = "v9.9.9-typo"
Updating llm-wiki ... fail (fetching marketplace 'llm-wiki' to resolve pin v9.9.9-typo)

$ git -C $CLAUDE_HOME/plugins/marketplaces/llm-wiki log --oneline -1
d02cbcb Bump to v0.23.0
```

The command failed for that marketplace and left the clone where it was. It did not pull. That is
the intended behaviour. See the first note below for a problem this run exposed.

## Additional Notes for Reviewers

**Two defects were found during review and fixed in the second commit, `3496d67`.** Both are worth
reading, because the first would have hit the exact marketplace this feature was built for.

- **`git fetch --tags` failed on the real clone.** It rejects *every* tag with
  `! [rejected] v0.0.11 -> v0.0.11 (would clobber existing tag)` and exits non-zero as soon as
  upstream has moved any one of them. A dry-run fetch against the real `llm-wiki` clone rejects
  40-odd tags today. `refresh()` only reaches the fetch when the pinned ref is not already in the
  clone, so the happy path hid this — but a pin to a tag the clone had not seen would have failed.
  `fetch_all()` now passes `--force`. Tags are upstream's to define, so taking their version is the
  right resolution. `a_pin_resolves_even_when_upstream_moved_a_tag` covers it: it moves a tag
  upstream, pins to a second tag the clone does not have, and fails without `--force`.
- **The printed error hid its cause.** The three call sites used
  `println!("{} ({})", "fail".red(), e)`. `{}` on an `anyhow::Error` shows only the outermost
  context, so a failed fetch reported `fetching marketplace 'llm-wiki' to resolve pin v9.9.9` and
  swallowed the git stderr that said why. They now use `{:#}` and print the whole chain.

**A pinned clone is left detached, and zskills is not the only thing that touches it.** Anyone who
runs `git pull` in `~/.claude/plugins/marketplaces/<name>` by hand gets an error on a detached
`HEAD`, or moves the clone off the pin with an explicit checkout. Claude Code's own `autoUpdate`
flag in `known_marketplaces.json` is also outside zskills. The pin holds against the three zskills
commands. It is not a lock on the directory.

**A pin never expires.** A pinned marketplace stops receiving upstream changes, including security
fixes, and nothing in zskills reminds the user. `zskills update` prints a dimmed count of held
marketplaces, and `zskills marketplace list` marks them. Neither is loud. A staleness warning after
some age is a reasonable follow-up.

**A broken `skills.toml` now fails three commands.** `load_pins()` calls `manifest::load()` and
returns the parse error to the caller. `marketplace update`, `update` and `upgrade` propagate it
with `?`, so a manifest with a TOML syntax error stops those commands before they refresh anything.
This is deliberate: a broken manifest must not silently turn every pin off, which would float every
pinned marketplace. It is still a new failure mode for users who never had a valid `skills.toml`.
Note the asymmetry — `marketplace list` calls `load_pins().unwrap_or_default()`, so it swallows the
same error and shows no pins. Confirm the split is what you want.

**A pin covers the marketplace clone, not the plugin version.** The pin controls which commit of the
marketplace repository sits on disk. It does not control the version of a plugin recorded in
`installed_plugins.json`. Claude Code negotiates that separately, and zskills tells the user to
restart Claude Code after a refresh. A reviewer should not read this PR as full version pinning for
plugins.

**`src/lockfile.rs` is still a stub.** It is untouched by this PR. Real version pinning for plugins,
if it is ever built, belongs there and not in the marketplace pin.

**Test-harness fix included.** `manifest::discover()` reads `$XDG_CONFIG_HOME/zskills/skills.toml`,
and neither test-command builder in `tests/cli.rs` sandboxed that variable. The suite was therefore
reading the developer's real manifest. Both builders now point `XDG_CONFIG_HOME` at the test
tempdir. This is a pre-existing hole. The pin feature would have depended on it, because a pin is
declared in that file.

**Checked and not a problem.** Marketplace clones are created with `git clone --depth 1`, so a pin
to an older tag could plausibly fail to resolve on a shallow clone. Tested against a local shallow
clone: `git fetch --tags` deepens the clone enough, and the old tag resolves. No change needed.

**Documentation.** `docs/commands.md` gains a "Pinning a marketplace" section with the schema, the
three decisions, and the `known_marketplaces.json` argument. `README.md` gains one line in the
command list.


