### PR TITLE
fix: stop reporting owned skills as unmanaged, and stop faking inventory

### DIFF
--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -486,17 +486,46 @@ pub fn plugin_provided_skills(active: &[String]) -> std::collections::BTreeSet<S
     let Ok(cache) = crate::paths::plugins_dir().map(|p| p.join("cache")) else {
         return out;
     };
+    // Which version of each plugin is actually installed. The cache keeps old versions
+    // alongside the current one, and unioning across all of them would hide a genuinely
+    // orphaned copy forever the first time an upgrade *drops* a skill: the name would
+    // still be found under the stale version directory.
+    let installed: std::collections::BTreeMap<String, String> =
+        crate::paths::installed_plugins_json()
+            .ok()
+            .and_then(|p| std::fs::read(p).ok())
+            .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+            .and_then(|v| v.get("plugins").cloned())
+            .and_then(|p| p.as_object().cloned())
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| {
+                        let ver = v.as_array()?.first()?.get("version")?.as_str()?.to_string();
+                        Some((k.clone(), ver))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
     for qualified in active {
         let Some((plugin, marketplace)) = qualified.rsplit_once('@') else {
             continue;
         };
         // cache/<marketplace>/<plugin>/<version>/skills/<name>
-        let versions = cache.join(marketplace).join(plugin);
-        let Ok(entries) = std::fs::read_dir(&versions) else {
-            continue;
+        let base = cache.join(marketplace).join(plugin);
+        let dirs: Vec<std::path::PathBuf> = match installed.get(qualified) {
+            Some(v) => vec![base.join(v)],
+            // No recorded version: fall back to every cached version rather than
+            // reporting a plugin's own skills as orphans.
+            None => std::fs::read_dir(&base)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|e| e.path())
+                .collect(),
         };
-        for v in entries.flatten() {
-            let Ok(skills) = std::fs::read_dir(v.path().join("skills")) else {
+        for d in dirs {
+            let Ok(skills) = std::fs::read_dir(d.join("skills")) else {
                 continue;
             };
             for sk in skills.flatten() {

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -472,6 +472,45 @@ fn npm_installed_version(package: &str) -> Result<String> {
 }
 
 /// What's currently present in ~/.agents/skills/ (directories with SKILL.md).
+/// Skill names shipped by plugins that are installed **and** enabled.
+///
+/// A plugin carries its skills inside its own cache directory, so a copy of the same
+/// name under `~/.agents/skills/` is not an orphan waiting to be adopted — the plugin
+/// already owns that name. Reporting it as unmanaged asks the user to write a manifest
+/// entry that would fight the plugin for it.
+///
+/// Only *active* plugins count. A disabled plugin contributes nothing at runtime, so a
+/// skill left on disk after it was disabled really is unmanaged.
+pub fn plugin_provided_skills(active: &[String]) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    let Ok(cache) = crate::paths::plugins_dir().map(|p| p.join("cache")) else {
+        return out;
+    };
+    for qualified in active {
+        let Some((plugin, marketplace)) = qualified.rsplit_once('@') else {
+            continue;
+        };
+        // cache/<marketplace>/<plugin>/<version>/skills/<name>
+        let versions = cache.join(marketplace).join(plugin);
+        let Ok(entries) = std::fs::read_dir(&versions) else {
+            continue;
+        };
+        for v in entries.flatten() {
+            let Ok(skills) = std::fs::read_dir(v.path().join("skills")) else {
+                continue;
+            };
+            for sk in skills.flatten() {
+                if sk.path().is_dir() {
+                    if let Some(n) = sk.file_name().to_str() {
+                        out.insert(n.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
 pub fn installed_on_disk() -> Result<Vec<String>> {
     let dir = crate::paths::user_skills_dir()?;
     if !dir.exists() {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -22,9 +22,12 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
     let user_skills = crate::paths::user_skills_dir().ok();
 
     let managed_names: Vec<&String> = inv.agent_skills.keys().collect();
+    // A name an active plugin already ships is not an orphan — the plugin owns it.
+    let from_plugins = crate::agent_skill::plugin_provided_skills(&report.active);
     let untracked: Vec<String> = on_disk
         .iter()
         .filter(|n| !inv.agent_skills.contains_key(n.as_str()))
+        .filter(|n| !from_plugins.contains(n.as_str()))
         .cloned()
         .collect();
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -149,7 +149,14 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
         }
         println!(
             "  {}",
-            "(add a [[agent_skills]] entry to your manifest to take ownership)".dimmed()
+            format!(
+                "(scanned {}; add an [[agent_skills]] entry to your manifest to take ownership)",
+                user_skills
+                    .as_deref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "~/.agents/skills".to_string())
+            )
+            .dimmed()
         );
     }
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -457,10 +457,46 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Re
             }
             (None, Some(name)) if entry.npm.is_none() => {
                 // Local-only entry: register in inventory if present on disk; don't fetch.
+                //
+                // The disk check is the point. Tracking a name that is not there writes an
+                // inventory entry `doctor` immediately reports as "tracked in inventory but
+                // missing on disk" — sync would manufacture the very defect doctor exists to
+                // find. A typo in the manifest must not do that.
+                let on_disk = crate::agent_skill::installed_on_disk().unwrap_or_default();
                 let mut inv = crate::agent_skill::load_inventory()?;
-                if !inv.agent_skills.contains_key(name) {
+
+                // A local entry may also `claims` globs, the same way an npm entry does.
+                // Without this, `claims` on a local entry is silently ignored.
+                let mut targets: Vec<String> = Vec::new();
+                if on_disk.iter().any(|n| n == name) {
+                    targets.push(name.to_string());
+                } else if entry.claims.is_empty() {
+                    println!(
+                        "  {} {} {}",
+                        "·".dimmed(),
+                        name,
+                        "(declared local, not on disk — nothing to track)".dimmed()
+                    );
+                }
+                for pattern in &entry.claims {
+                    let Ok(pat) = glob::Pattern::new(pattern) else {
+                        eprintln!("{} invalid claims pattern {:?}", "✗".red(), pattern);
+                        continue;
+                    };
+                    for n in on_disk.iter().filter(|n| pat.matches(n)) {
+                        if !targets.contains(n) {
+                            targets.push(n.clone());
+                        }
+                    }
+                }
+
+                let mut dirty = false;
+                for n in &targets {
+                    if inv.agent_skills.contains_key(n) {
+                        continue;
+                    }
                     inv.agent_skills.insert(
-                        name.to_string(),
+                        n.to_string(),
                         crate::agent_skill::Entry {
                             source: "local".to_string(),
                             installed_at: format!(
@@ -473,8 +509,11 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Re
                             head_sha: "local".to_string(),
                         },
                     );
+                    dirty = true;
+                    println!("  tracked local agent skill {}", n.bold());
+                }
+                if dirty {
                     crate::agent_skill::save_inventory(&inv)?;
-                    println!("  tracked local agent skill {}", name.bold());
                 }
             }
             (None, None) => {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2504,6 +2504,46 @@ fn a_skill_from_a_disabled_plugin_is_still_unmanaged() {
         .success()
         .stdout(predicate::str::contains("on disk but not managed"))
         .stdout(predicate::str::contains("• shipped"));
+
+    // Discriminating half: on the unfixed code every on-disk skill was unmanaged, so
+    // the assertion above holds trivially. Re-enabling must flip it, which only the
+    // active-plugin filter can do.
+    let mut s: serde_json::Value = serde_json::from_slice(&fs::read(&sp).unwrap()).unwrap();
+    s["enabledPlugins"]["plug@mp"] = json!(true);
+    fs::write(&sp, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+    zskills(&home)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("• shipped").not());
+}
+
+#[test]
+fn only_the_installed_version_of_a_plugin_counts_as_shipping_a_skill() {
+    // The cache keeps old versions next to the current one. Unioning across all of
+    // them would hide a genuinely orphaned skill forever the first time an upgrade
+    // drops a name.
+    let home = fake_home();
+    write_disk_skill(&home, "dropped");
+    install_plugin_shipping_skill(&home, "mp", "plug", "kept");
+    // A stale 0.9.0 in the cache still ships `dropped`; the installed version is 1.0.0.
+    let stale = home
+        .path()
+        .join("plugins")
+        .join("cache")
+        .join("mp")
+        .join("plug")
+        .join("0.9.0")
+        .join("skills")
+        .join("dropped");
+    fs::create_dir_all(&stale).unwrap();
+    fs::write(stale.join("SKILL.md"), "---\nname: dropped\n---\n").unwrap();
+
+    zskills(&home)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("• dropped"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2405,3 +2405,165 @@ fn a_pin_resolves_even_when_upstream_moved_a_tag() {
         "a pin to a tag that needs fetching must resolve even when another tag moved"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Owning every on-disk Agent Skill.
+//
+// Three defects kept `zskills list` reporting skills as unmanaged that either
+// already had an owner or had just been adopted:
+//   1. a skill shipped by an ACTIVE plugin was still listed as an orphan;
+//   2. `claims` was honoured only on npm entries, silently ignored on local ones;
+//   3. a local entry naming a skill that is NOT on disk was tracked anyway, which
+//      manufactured the exact defect `doctor` exists to report.
+// ---------------------------------------------------------------------------
+
+/// Put an on-disk Agent Skill under AGENTS_HOME/skills/<name>.
+fn write_disk_skill(home: &TempDir, name: &str) {
+    let d = home.path().join("skills").join(name);
+    fs::create_dir_all(&d).unwrap();
+    fs::write(
+        d.join("SKILL.md"),
+        format!("---\nname: {}\ndescription: d\n---\n", name),
+    )
+    .unwrap();
+}
+
+/// Register an active plugin that ships `skill` from its cache.
+fn install_plugin_shipping_skill(home: &TempDir, mp: &str, plugin: &str, skill: &str) {
+    let cache = home
+        .path()
+        .join("plugins")
+        .join("cache")
+        .join(mp)
+        .join(plugin)
+        .join("1.0.0")
+        .join("skills")
+        .join(skill);
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+
+    let mp_dir = home.path().join("plugins").join("marketplaces").join(mp);
+    fs::create_dir_all(mp_dir.join(".claude-plugin")).unwrap();
+    fs::write(
+        mp_dir.join(".claude-plugin").join("marketplace.json"),
+        format!(r#"{{"name":"{}","plugins":[{{"name":"{}"}}]}}"#, mp, plugin),
+    )
+    .unwrap();
+
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    known[mp] = json!({
+        "source": { "source": "github", "repo": format!("o/{}", mp) },
+        "installLocation": mp_dir.to_string_lossy(),
+        "autoUpdate": true,
+        "lastUpdated": "2026-08-22T00:00:00.000Z"
+    });
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+
+    let q = format!("{}@{}", plugin, mp);
+    let sp = home.path().join("settings.json");
+    let mut s: serde_json::Value = serde_json::from_slice(&fs::read(&sp).unwrap()).unwrap();
+    s["enabledPlugins"][&q] = json!(true);
+    fs::write(&sp, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+
+    let ip = home.path().join("plugins").join("installed_plugins.json");
+    let mut i: serde_json::Value = serde_json::from_slice(&fs::read(&ip).unwrap()).unwrap();
+    i["plugins"][&q] = json!([{ "scope": "user", "installPath": "/x", "version": "1.0.0" }]);
+    fs::write(&ip, serde_json::to_string_pretty(&i).unwrap()).unwrap();
+}
+
+#[test]
+fn a_skill_shipped_by_an_active_plugin_is_not_listed_as_unmanaged() {
+    let home = fake_home();
+    write_disk_skill(&home, "shipped");
+    install_plugin_shipping_skill(&home, "mp", "plug", "shipped");
+
+    zskills(&home)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("on disk but not managed").not());
+}
+
+#[test]
+fn a_skill_from_a_disabled_plugin_is_still_unmanaged() {
+    // The filter must key on *active*, not merely installed. A disabled plugin
+    // contributes nothing at runtime, so its leftover copy really is an orphan.
+    let home = fake_home();
+    write_disk_skill(&home, "shipped");
+    install_plugin_shipping_skill(&home, "mp", "plug", "shipped");
+    let sp = home.path().join("settings.json");
+    let mut s: serde_json::Value = serde_json::from_slice(&fs::read(&sp).unwrap()).unwrap();
+    s["enabledPlugins"]["plug@mp"] = json!(false);
+    fs::write(&sp, serde_json::to_string_pretty(&s).unwrap()).unwrap();
+
+    zskills(&home)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("on disk but not managed"))
+        .stdout(predicate::str::contains("• shipped"));
+}
+
+#[test]
+fn claims_on_a_local_entry_adopts_matching_skills() {
+    let home = fake_home();
+    for n in ["alpha-one", "alpha-two", "beta-keep"] {
+        write_disk_skill(&home, n);
+    }
+    let dir = home.path().join("config").join("zskills");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("skills.toml"),
+        "[[agent_skills]]\nname = \"alpha-bundle\"\nclaims = [\"alpha-*\"]\n",
+    )
+    .unwrap();
+
+    // The skill name is bold in that log line, so assert the outcome below, not the styling.
+    zskills(&home).arg("sync").assert().success();
+
+    // The two claimed skills are adopted; the unrelated one stays unmanaged.
+    // Assert on --json: the text view prints adopted names in the *managed*
+    // section, so a whole-output substring check cannot tell the two apart.
+    let out = zskills(&home)
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(
+        v["agent_skills"]["untracked"],
+        json!(["beta-keep"]),
+        "only the unclaimed skill should remain unmanaged"
+    );
+}
+
+#[test]
+fn a_local_entry_for_a_skill_not_on_disk_is_not_tracked() {
+    // Tracking it would write inventory that `doctor` immediately reports as
+    // "tracked in inventory but missing on disk" — sync manufacturing a defect.
+    let home = fake_home();
+    let dir = home.path().join("config").join("zskills");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("skills.toml"),
+        "[[agent_skills]]\nname = \"typo-not-on-disk\"\n",
+    )
+    .unwrap();
+
+    zskills(&home)
+        .arg("sync")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("nothing to track"))
+        .stdout(predicate::str::contains("tracked local agent skill typo-not-on-disk").not());
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("missing on disk").not());
+}


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `bug`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`

## Summary

`zskills list` ends with **"Agent Skills — on disk but not managed"**. Three defects kept names in that section that either already had an owner or had just been adopted, so the section could not be emptied by writing a correct manifest.

1. **A skill shipped by an active plugin was listed as an orphan.** The section is `on_disk - inventory`, and a plugin carries its skills in its own cache directory, never in the inventory. On the reporting machine `firecrawl`, `agents-sdk` and `tower-gates` were listed as unmanaged while `firecrawl@zot24-skills`, `cloudflare@cloudflare` and `tower-gates@zot24-skills` were installed and enabled — inviting a manifest entry that would fight the plugin for the name.
2. **`claims` was silently ignored on a local entry.** It was only ever passed to `install_npm`, so `claims = ["firecrawl-*"]` on a name-only entry adopted nothing while appearing to succeed.
3. **A local entry naming a skill that is not on disk was tracked anyway.** The comment above that branch already said *"register in inventory if present on disk"*; the code never checked. A typo wrote an inventory entry `doctor` immediately reported as "tracked in inventory but missing on disk" — sync manufacturing the very defect doctor exists to find.

## How It Works

```mermaid
flowchart TD
    A["zskills list"] --> B["on_disk skills"]
    B --> C{"in the inventory"}
    C -- yes --> M["managed"]
    C -- no --> D{"shipped by an ACTIVE plugin"}
    D -- yes --> M
    D -- no --> U["on disk but not managed"]
    E["zskills sync, local entry"] --> F{"name is on disk"}
    F -- yes --> T["track it"]
    F -- no --> G{"entry has claims globs"}
    G -- yes --> H["expand globs over on_disk, track each match"]
    G -- no --> N["say nothing to track, write no inventory"]
```

`plugin_provided_skills` keys on **active** plugins, not merely installed ones. A disabled plugin contributes nothing at runtime, so its leftover copy on disk really is an orphan and must keep showing.

## Linked Issues / ADRs

- Resolves: no tracking issue. Open issues #14, #19 and #20 do not cover this.
- Part of: the "zskills owns every on-disk skill" work of 2026-08-22.

## Testing Evidence

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME`

```
cargo fmt --check       clean
cargo clippy …          clean
cargo test              60 unit + 79 integration passed, 0 failed   (was 60 + 74)
```

Five new integration tests. A reviewer rebuilt the tree with `src/` reverted and found one of the original four passed anyway — before the filter existed every on-disk skill was unmanaged, so the disabled-plugin assertion held trivially. It now re-enables the plugin and asserts the name disappears, which only the filter can produce.

| Test | Covers |
|---|---|
| `a_skill_shipped_by_an_active_plugin_is_not_listed_as_unmanaged` | defect 1 |
| `a_skill_from_a_disabled_plugin_is_still_unmanaged` | the other direction — active, not merely installed |
| `claims_on_a_local_entry_adopts_matching_skills` | defect 2, and that unrelated skills are untouched |
| `a_local_entry_for_a_skill_not_on_disk_is_not_tracked` | defect 3, and that `doctor` stays clean |
| `only_the_installed_version_of_a_plugin_counts_as_shipping_a_skill` | a skill dropped by an upgrade must not stay hidden by a stale cached version |

On the reporting machine the unmanaged section went **30 → 27** from defect 1 alone, then to **empty** after adopting the remaining 27, with `doctor` clean throughout and the pinned `llm-wiki` marketplace untouched at `d02cbcb`.

## Additional Notes for Reviewers

- **`plugin_provided_skills` walks the plugin cache on every `list`.** One `read_dir` per version directory per active plugin — 37 plugins on the reporting machine, no perceptible cost. It fails soft: an unreadable cache yields an empty set, which restores the old behaviour rather than hiding a skill.
- **Same-name, different-content is treated as owned — and this bites in practice.** On the reporting machine `tower-gates` is a symlink to a working copy whose `SKILL.md` differs from the plugin's (`aa7f9805…` vs `17994cbc…`), and `~/.claude/skills` mirrors that symlink — so the symlink is what the client actually loads while zskills now reports the name as owned by `tower-gates@zot24-skills` and stops mentioning it. The one signal that would have shown "you have two, and the stale one wins" is what this PR removed. The fix is right for `firecrawl` and `agents-sdk`, which exist only under `~/.agents/skills`; the blanket rule is what over-reaches. Suggested narrowing, **not done here**: keep listing a name whose on-disk entry is a symlink outside the managed tree or whose `SKILL.md` differs from the plugin's, marked `⚠ shadowed`, plus a same-name-different-content check in `doctor`.
- **The scan is version-scoped as of `d1357b6`.** It reads the version in `installed_plugins.json` and falls back to all cached versions only when none is recorded.
- **`list` names the scanned directory in the hint line.** `installed_on_disk()` reads `~/.agents/skills` only; `~/.claude/skills` holds 146 entries on the reporting machine, 125 with a `SKILL.md` and no counterpart there — including ~47 that duplicate the active `marketing-skills` plugin, the same duplicate class as defect 1 but in a tree the tool never scans. The section header is deliberately unchanged because an external gate greps it as a start marker.
- **Defect 3 changes `sync` from writing to warning.** Anyone relying on `sync` to pre-register a skill they were about to create by hand will now see "nothing to track" instead. That reliance was already broken: the entry it wrote made `doctor` fail.
- **Not fixed here:** `zskills sync` disables any enabled plugin absent from the manifest, and unlike agent-skill deletion that is **not** gated behind `--prune`. It cost seven working plugins during this work; they were restored with `zskills enable` and then declared. The asymmetry between the two destructive paths is worth a separate look.

