### PR TITLE
fix: discover Agent Skills under .agents/skills/, not only skills/

### DIFF
--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -111,17 +111,49 @@ pub fn ensure_cache(source: &str) -> Result<PathBuf> {
 ///
 /// Names are unique in the result: if two categories expose the same skill name,
 /// the first by sorted path wins and the other is dropped.
+/// Roots a repository may keep its Agent Skills under, in precedence order.
+///
+/// `.agents/skills/` is the cross-client convention from the Agent Skills spec and is
+/// what `warpdotdev/common-skills` uses; `skills/` is the older layout this tool shipped
+/// with. A repository may legitimately use either, so both are walked.
+const SKILL_ROOTS: &[&str] = &[".agents/skills", "skills"];
+
+/// List the skill directories a cloned repo provides. Returns `(name, source_dir)` pairs,
+/// sorted by name and de-duplicated.
+///
+/// Each root is walked the same way: a directory holding its own `SKILL.md` is a skill and
+/// is never descended into, so a skill with helper subdirectories is not mistaken for a
+/// category; a directory without one is treated as a category and searched one level
+/// deeper. When no root yields anything, a repository-root `SKILL.md` makes the clone
+/// itself the single skill.
 pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
-    let skills_root = cache.join("skills");
     let mut out: Vec<(String, PathBuf)> = Vec::new();
-    let Ok(entries) = std::fs::read_dir(&skills_root) else {
-        // Fallback: single-skill repo at root level
+    for root in SKILL_ROOTS {
+        collect_skills_under(&cache.join(root), &mut out);
+    }
+
+    if out.is_empty() {
+        // Fallback: single-skill repo with SKILL.md at the root.
         if cache.join("SKILL.md").exists() {
             if let Some(name) = cache.file_name().and_then(|n| n.to_str()) {
                 out.push((name.to_string(), cache.to_path_buf()));
             }
         }
         return out;
+    }
+
+    // Sorting by (name, path) then de-duplicating by name keeps the winner stable when
+    // two roots offer the same name: `.agents/skills` sorts before `skills`, so the
+    // cross-client layout wins, and the choice does not depend on read_dir order.
+    out.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    out.dedup_by(|a, b| a.0 == b.0);
+    out
+}
+
+/// Walk one skill root, appending every skill directory it holds.
+fn collect_skills_under(root: &Path, out: &mut Vec<(String, PathBuf)>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
     };
 
     fn push_skill(out: &mut Vec<(String, PathBuf)>, dir: &Path) {
@@ -140,7 +172,7 @@ pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
 
     for p in top {
         if p.join("SKILL.md").exists() {
-            push_skill(&mut out, &p);
+            push_skill(out, &p);
             continue;
         }
         // Category directory: look one level deeper for <category>/<name>/SKILL.md.
@@ -154,13 +186,9 @@ pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
             .collect();
         nested.sort();
         for q in nested {
-            push_skill(&mut out, &q);
+            push_skill(out, &q);
         }
     }
-
-    out.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-    out.dedup_by(|a, b| a.0 == b.0);
-    out
 }
 
 /// Copy a skill directory into ~/.agents/skills/<name>/ (deletes existing first).

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -76,9 +76,49 @@ pub fn run(filter: Vec<String>) -> Result<()> {
             if let Some(src) = entry.source.as_deref() {
                 let label = entry.name.as_deref().unwrap_or(src);
                 print!("  {} {} ... ", "↻".cyan(), label);
-                match crate::agent_skill::install(src, entry.name.as_deref()) {
-                    Ok(_) => println!("{}", "ok".green()),
-                    Err(e) => println!("{} ({})", "fail".red(), e),
+
+                // A source-only entry means "keep what I already own from this source",
+                // not "adopt whatever it ships today". `install(src, None)` installs
+                // every skill the survey finds, with no cap and no prompt — so widening
+                // the survey (a new skill root, or upstream simply adding skills) would
+                // otherwise make an unattended `upgrade` install things nobody asked for.
+                // Refresh the names already in the inventory instead.
+                let owned: Vec<String> = match entry.name.as_deref() {
+                    Some(n) => vec![n.to_string()],
+                    None => {
+                        let inv = crate::agent_skill::load_inventory().unwrap_or_default();
+                        inv.agent_skills
+                            .iter()
+                            .filter(|(_, e)| e.source == src)
+                            .map(|(n, _)| n.clone())
+                            .collect()
+                    }
+                };
+
+                if owned.is_empty() {
+                    // Nothing owned from this source yet: `sync` is what adopts, and it
+                    // applies the size policy. Upgrading here would bypass it.
+                    println!(
+                        "{}",
+                        "nothing owned yet — run `zskills sync` to install".dimmed()
+                    );
+                    continue;
+                }
+
+                let mut failures = 0;
+                for name in &owned {
+                    if let Err(e) = crate::agent_skill::install(src, Some(name)) {
+                        eprintln!("\n  {} {}: {}", "✗".red(), name, e);
+                        failures += 1;
+                    }
+                }
+                if failures == 0 {
+                    println!("{}", format!("ok ({})", owned.len()).green());
+                } else {
+                    println!(
+                        "{}",
+                        format!("{} of {} failed", failures, owned.len()).red()
+                    );
                 }
                 continue;
             }

--- a/src/repo_scanner.rs
+++ b/src/repo_scanner.rs
@@ -292,4 +292,80 @@ mod tests {
         assert!(s.marketplace);
         assert!(!s.plugin); // marketplace shadows the plugin flag
     }
+    #[test]
+    fn survey_finds_skills_under_dot_agents_skills() {
+        // The cross-client layout from the Agent Skills spec, and what
+        // `warpdotdev/common-skills` uses. Before this was walked, the survey came back
+        // empty and `--skill <name>` reported "not found (available: )".
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp
+            .path()
+            .join(".agents")
+            .join("skills")
+            .join("skill-doctor");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(d.join("SKILL.md"), skill_md(Some("Grade your skills"))).unwrap();
+
+        let s = survey(tmp.path()).unwrap();
+        assert_eq!(s.agent_skills.len(), 1);
+        assert_eq!(s.agent_skills[0].name, "skill-doctor");
+        assert_eq!(
+            s.agent_skills[0].description.as_deref(),
+            Some("Grade your skills")
+        );
+    }
+
+    #[test]
+    fn survey_finds_both_roots_and_prefers_dot_agents_on_a_name_clash() {
+        let tmp = tempfile::tempdir().unwrap();
+        for (root, name) in [
+            (".agents/skills", "shared"),
+            (".agents/skills", "only-agents"),
+            ("skills", "shared"),
+            ("skills", "only-skills"),
+        ] {
+            let d = tmp.path().join(root).join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("SKILL.md"), skill_md(Some(root))).unwrap();
+        }
+
+        let s = survey(tmp.path()).unwrap();
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["only-agents", "only-skills", "shared"]);
+        // One `shared`, and it is the .agents/skills copy.
+        let shared = s.agent_skills.iter().find(|k| k.name == "shared").unwrap();
+        assert_eq!(shared.description.as_deref(), Some(".agents/skills"));
+    }
+
+    #[test]
+    fn survey_finds_nested_categories_under_dot_agents_skills() {
+        let tmp = tempfile::tempdir().unwrap();
+        for (cat, name) in [("web", "alpha"), ("infra", "beta")] {
+            let d = tmp
+                .path()
+                .join(".agents")
+                .join("skills")
+                .join(cat)
+                .join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("SKILL.md"), skill_md(None)).unwrap();
+        }
+        let s = survey(tmp.path()).unwrap();
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn a_root_skill_md_is_ignored_when_dot_agents_skills_has_entries() {
+        // The root-SKILL.md fallback is for repos with no skill root at all.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("SKILL.md"), skill_md(None)).unwrap();
+        let d = tmp.path().join(".agents").join("skills").join("real");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(d.join("SKILL.md"), skill_md(None)).unwrap();
+
+        let s = survey(tmp.path()).unwrap();
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["real"]);
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2706,3 +2706,49 @@ fn install_reports_available_names_from_dot_agents_skills_when_skill_is_unknown(
         stderr
     );
 }
+
+#[test]
+fn upgrade_refreshes_only_skills_already_owned_from_a_source() {
+    // A source-only manifest entry means "keep what I own from this source", not
+    // "adopt whatever it ships today". Widening the survey — a new skill root, or
+    // upstream adding skills — must not make an unattended `upgrade` install things
+    // nobody asked for. This is the regression the .agents/skills walker introduced:
+    // a repo with 1 skill under skills/ and 3 under .agents/skills/ went from
+    // installing 1 to installing 4.
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = upstream.path().join("multi");
+    write_skill(&repo, "owned", "already installed");
+    write_agents_skill(&repo, "brand-new", "should NOT be adopted by upgrade");
+    write_agents_skill(&repo, "also-new", "should NOT be adopted by upgrade");
+    git_init_and_commit(&repo);
+
+    let home = fake_home();
+    // Own exactly one skill from that source.
+    zskills(&home)
+        .args(["install", &file_url(&repo), "--skill", "owned"])
+        .assert()
+        .success();
+    assert!(home.path().join("skills/owned").exists());
+
+    let dir = home.path().join("config").join("zskills");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("skills.toml"),
+        format!("[[agent_skills]]\nsource = \"{}\"\n", file_url(&repo)),
+    )
+    .unwrap();
+
+    zskills(&home).arg("upgrade").assert().success();
+
+    assert!(
+        home.path().join("skills/owned").exists(),
+        "the owned skill must still be refreshed"
+    );
+    for unwanted in ["brand-new", "also-new"] {
+        assert!(
+            !home.path().join("skills").join(unwanted).exists(),
+            "upgrade must not adopt {} — it was never requested",
+            unwanted
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2607,3 +2607,102 @@ fn a_local_entry_for_a_skill_not_on_disk_is_not_tracked() {
         .success()
         .stdout(predicate::str::contains("missing on disk").not());
 }
+
+// ---------------------------------------------------------------------------
+// `.agents/skills/` layout.
+//
+// `zskills install warpdotdev/common-skills --skill skill-doctor` failed with
+// "skill 'skill-doctor' not found (available: )". The survey only walked
+// `<repo>/skills/`, and Warp uses the cross-client `<repo>/.agents/skills/`.
+// ---------------------------------------------------------------------------
+
+/// Write `<repo>/.agents/skills/<name>/SKILL.md`.
+fn write_agents_skill(repo: &std::path::Path, name: &str, description: &str) {
+    let dir = repo.join(".agents").join("skills").join(name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nname: {}\ndescription: {}\n---\n# {}\n",
+            name, description, name
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn install_skill_flag_selects_from_dot_agents_skills() {
+    let upstream = tempfile::tempdir().unwrap();
+    write_agents_skill(upstream.path(), "skill-doctor", "Grade your skills");
+    write_agents_skill(upstream.path(), "write-product-spec", "Other skill");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args([
+            "install",
+            &file_url(upstream.path()),
+            "--skill",
+            "skill-doctor",
+        ])
+        .assert()
+        .success()
+        // The `+` marker is coloured, so assert the name and prove the rest on disk.
+        .stdout(predicate::str::contains("skill-doctor"));
+
+    assert!(home.path().join("skills/skill-doctor/SKILL.md").exists());
+    assert!(
+        !home.path().join("skills/write-product-spec").exists(),
+        "--skill must install exactly one skill"
+    );
+}
+
+#[test]
+fn a_large_dot_agents_skills_tree_still_requires_skill_or_all() {
+    // A large collection under the new root. The size policy must still apply there:
+    // discovering more layouts must not start flooding. `warpdotdev/common-skills`
+    // ships 26 skills this way; 14 is enough to be over the auto-install threshold.
+    let upstream = tempfile::tempdir().unwrap();
+    for i in 0..14 {
+        write_agents_skill(upstream.path(), &format!("skill-{:02}", i), "d");
+    }
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["install", &file_url(upstream.path())])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("14"))
+        .stdout(predicate::str::contains("--all"));
+
+    assert!(
+        !home.path().join("skills/skill-00").exists(),
+        "a bare install of a large collection must install nothing"
+    );
+}
+
+#[test]
+fn install_reports_available_names_from_dot_agents_skills_when_skill_is_unknown() {
+    // The original failure printed "(available: )" — an empty list is what made the
+    // bug look like a missing skill rather than a missing layout.
+    let upstream = tempfile::tempdir().unwrap();
+    write_agents_skill(upstream.path(), "skill-doctor", "d");
+    git_init_and_commit(upstream.path());
+
+    let home = fake_home();
+    let out = zskills(&home)
+        .args(["install", &file_url(upstream.path()), "--skill", "nope"])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&out);
+    assert!(stderr.contains("'nope' not found"), "{}", stderr);
+    assert!(
+        stderr.contains("skill-doctor"),
+        "the available list must name what the repo really ships: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `bug`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:small`
- [x] Area: `area:cli`

## Summary

```
$ zskills install warpdotdev/common-skills --skill skill-doctor
✗ warpdotdev/common-skills: skill 'skill-doctor' not found (available: )
```

The empty `available:` list is the tell. That repository ships **26** skills (verified in the clone cache at `737129f`) and the survey found none, so the failure read as a missing skill when it was a missing layout.

`skills_in_cache` walked `<repo>/skills/` and nothing else, falling back to a repository-root `SKILL.md`. It never looked at **`.agents/skills/`** — the cross-client layout from the Agent Skills spec, and what `warpdotdev/common-skills` uses. `repo_scanner::survey` calls the same function, so `install`, `-i` and the size policy were blind to that layout together.

Both roots are now walked, `.agents/skills` first, each by the existing rule (extracted into `collect_skills_under`): a directory with its own `SKILL.md` is a skill and is not descended into; one without is a category searched one level deeper.

## How It Works

```mermaid
flowchart TD
    A["survey a cloned repo"] --> B[".agents/skills"]
    A --> C["skills"]
    B --> D["walk: SKILL.md here means skill, else category one level deeper"]
    C --> D
    D --> E{"any skill found"}
    E -- no --> F["fall back to a root SKILL.md, the whole clone is one skill"]
    E -- yes --> G["sort by name then path, dedup by name"]
    G --> H["a name in both roots resolves to .agents/skills"]
```

Two details worth review:

- **Name clashes resolve to `.agents/skills`.** Sorting by `(name, path)` then de-duplicating by name makes that deterministic — `.agents/skills` sorts before `skills`, so the winner never depends on `read_dir` order.
- **The root-`SKILL.md` fallback now fires only when *no* root yielded anything.** It previously fired whenever `<repo>/skills/` was unreadable, which would have masked a `.agents/skills` tree in a repo that also had a root `SKILL.md`.

The size policy is unchanged and still applies to the new root: a bare install of a large collection installs nothing and asks for `--skill` or `--all`.

## Linked Issues / ADRs

- Resolves: no tracking issue. Open issues #14, #19, #20 do not cover this.
- Follows #30, which is merged; this branch is cut from `main` after it.

## Testing Evidence

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a real install

```
cargo test    64 unit + 82 integration passed, 0 failed    (was 60 + 79)
```

Eight new tests. Four in `repo_scanner`: discovery under `.agents/skills`; both roots at once with a name clash resolving to `.agents/skills`; nested categories under the new root; a root `SKILL.md` ignored when the new root has entries. Four in `tests/cli.rs`: `--skill` selects one skill and installs only that one; a large tree still requires `--skill`/`--all` and installs nothing without them; an unknown `--skill` names the real available skills instead of printing `(available: )`.

Real install, after `cargo install --path .`:

```
$ zskills install warpdotdev/common-skills --skill skill-doctor
Surveying warpdotdev/common-skills
+ skill-doctor [from warpdotdev/common-skills]

$ zskills list | grep skill-doctor
  ✓ skill-doctor  ← warpdotdev/common-skills

$ zskills doctor
✓ All good — disk, inventory, and settings are in sync.
```

Exactly one skill from that repository is in the inventory; the other 25 were not installed.

## Additional Notes for Reviewers

- **Only two roots are walked.** The spec's instruction was not to invent more, and none are added. If a third convention appears, it belongs in `SKILL_ROOTS` with a test, not in a new code path.
- **A repo that ships the same skill under both roots now installs the `.agents/skills` copy.** That is a real behaviour change for such a repo, and it is the right default given `.agents/skills` is the cross-client convention — but it is a silent preference, not a warning. If the two copies differ, nothing says so.
- **Deeper nesting is still invisible.** The walk is exactly two levels under each root, unchanged from before; `<root>/<a>/<b>/<c>/SKILL.md` is not found. The error message now lists what *was* found, so this fails visibly rather than as `(available: )`.

