### PR TITLE
feat!: typed plugin, skill, and mcp command groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,26 +69,24 @@ Existing tooling is per-runtime, per-language, and per-primitive: there's a Java
 ## Commands
 
 ```
-zskills list [-v]                       # what's installed; agent skills grouped by source
-zskills install <name>                  # add to enabledPlugins
-zskills install -i                      # browse all marketplace plugins, fuzzy-pick one
-zskills remove  <name>                  # disable + drop inventory entry (keep bytes — apt style)
-zskills remove  -i                      # multi-select from enabled plugins to remove
-zskills purge   <name>                  # also delete bytes
-zskills enable  <name>                  # flip on without (un)installing
-zskills disable <name>
-zskills sync [--file f.toml]            # apply declarative manifest (headline command)
-zskills update [<name>...]              # refresh marketplace caches (plugins only)
-zskills upgrade [<name>...]             # ONE command: refresh marketplaces + reinstall all agent skills
-zskills doctor [--fix]                  # reconcile disk ↔ inventory ↔ settings
-zskills scan [path]                     # find project-scope skills across a tree
-zskills migrate <project>               # promote one project's skills to user scope
-zskills migrate-skill <name>            # promote ONE skill across every project in a tree
-zskills migrate-all <dir>               # interactive: walk a tree, prompt per skill
-zskills search <query> [-i]             # -i picks a result and installs it
+zskills list [-v]                              # plugins, Agent Skills, MCP servers
+zskills plugin install <name@marketplace>      # add to enabledPlugins
+zskills plugin install -i                      # browse marketplace plugins
+zskills plugin remove  <name>                  # drop inventory, keep bytes
+zskills plugin purge   <name>                  # also delete bytes
+zskills plugin enable|disable <name>
+zskills agent-skill install <owner/repo>
+zskills agent-skill remove <name>              # deletes bytes
+zskills agent-skill upgrade [<name>...]
+zskills mcp add <name> --url|--command ...
+zskills mcp remove <name> [--scope user]
+zskills sync [--file f.toml]                   # apply skills.toml
 zskills marketplace add|remove|list|update
-                                        # pin one in skills.toml so update/upgrade can't float it
+zskills doctor [--fix]
+zskills scan|migrate|migrate-skill|migrate-all|search
 ```
+
+Bare `install`/`remove`/`purge`/`enable`/`disable`/`update`/`upgrade` exit 2 and name the typed replacement.
 
 `<name>` accepts unqualified (`servarr`) when unambiguous, or `name@marketplace` (`servarr@zot24-skills`) to disambiguate.
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Bare `install`/`remove`/`purge`/`enable`/`disable`/`update`/`upgrade` exit 2 and
 
 ## Declarative manifest (skills.toml)
 
+CLI group to manifest key:
+
+```
+[[skills]]        → plugins      → zskills plugin  install|remove|purge|enable|disable
+[[agent_skills]]  → Agent Skills → zskills skill   install|remove|upgrade
+[[mcps]]          → MCP servers  → zskills mcp     add|remove
+```
+
+The group `skill` writes `[[agent_skills]]`. The key `[[skills]]` is plugins.
+
 ```toml
 # Claude Code plugins (marketplace-based, controlled via enabledPlugins)
 [[skills]]

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ zskills plugin install -i                      # browse marketplace plugins
 zskills plugin remove  <name>                  # drop inventory, keep bytes
 zskills plugin purge   <name>                  # also delete bytes
 zskills plugin enable|disable <name>
-zskills agent-skill install <owner/repo>
-zskills agent-skill remove <name>              # deletes bytes
-zskills agent-skill upgrade [<name>...]
+zskills skill install <owner/repo>
+zskills skill remove <name>                    # deletes bytes
+zskills skill upgrade [<name>...]
 zskills mcp add <name> --url|--command ...
 zskills mcp remove <name> [--scope user]
 zskills sync [--file f.toml]                   # apply skills.toml

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ known_marketplaces.json:
 }
 ```
 
-Each driver lives behind its own cargo feature (today: `skills-sh`). Default builds don't compile the driver in — `marketplace add skills.sh` errors with *"unrecognized marketplace source"*. With the feature, `add` accepts the special name, `search` federates to the API when `ZSKILLS_SKILLS_SH_API_KEY` is set, and `install` falls through to the index when local plugin resolution misses (routing through the existing agent-skill install path).
+Each driver lives behind its own cargo feature (today: `skills-sh`). Default builds don't compile the driver in — `marketplace add skills.sh` errors with *"unrecognized marketplace source"*. With the feature, `add` accepts the special name, `search` federates to the API when `ZSKILLS_SKILLS_SH_API_KEY` is set, and `install` falls through to the index when local plugin resolution misses (routing through the existing skill install path).
 
 The non-feature build still tolerates remote-index entries that might be in `known_marketplaces.json` from a feature-built version: `list` shows them with a `[remote-index]` tag, `update` skips them, `remove` works as expected. This is a forward-compatibility hedge, not a runtime dispatch path.
 
@@ -213,7 +213,7 @@ The manifest entry's `claims` glob list bridges the gap when an npm package over
 - Sparse-checkout and partial-clone work correctly without bespoke handling.
 - Errors come back as plain git output, which is what users already know how to read.
 
-The trade-off is one process spawn per fetch, which is fine: marketplace updates and agent-skill installs are rare events.
+The trade-off is one process spawn per fetch, which is fine: marketplace updates and skill installs are rare events.
 
 ## Path resolution
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,8 +40,8 @@ Three accepted spec shapes:
 ```
 zskills plugin install <name>                       # plugin from a registered marketplace
 zskills plugin install <name>@<marketplace>         # qualified plugin
-zskills agent-skill install <owner>/<repo>          # Agent Skill(s) from a git repo
-zskills agent-skill install <git-url>               # same, for https://, git@, file://
+zskills skill install <owner>/<repo>                # Agent Skill(s) from a git repo
+zskills skill install <git-url>                     # same, for https://, git@, file://
 zskills plugin install -i                           # interactive picker over marketplace plugins
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,7 +67,7 @@ zskills plugin install -i                           # interactive picker over ma
 | 2–5 | install all | picker | install all | install just that one |
 | > 5 | **abort + summary + next-step hint** | picker | install all | install just that one |
 
-**Sparse installs (root-level SKILL.md).** A repo whose `SKILL.md` sits at the repo root inside a larger project (source code, lockfiles, websites…) is installed *sparsely*: only `SKILL.md`, the conventional skill dirs (`references/`, `assets/`, `scripts/`), and relative paths that `SKILL.md` links to are copied out — never the whole source tree, and never `.git/`. Installs from the `skills/<name>/SKILL.md` layout copy the skill subdirectory as before. Legacy full-repo installs are flagged by `zskills doctor` and slimmed on the next `zskills upgrade` (or `doctor --fix`).
+**Sparse installs (root-level SKILL.md).** A repo whose `SKILL.md` sits at the repo root inside a larger project (source code, lockfiles, websites…) is installed *sparsely*: only `SKILL.md`, the conventional skill dirs (`references/`, `assets/`, `scripts/`), and relative paths that `SKILL.md` links to are copied out — never the whole source tree, and never `.git/`. Installs from the `skills/<name>/SKILL.md` layout copy the skill subdirectory as before. Legacy full-repo installs are flagged by `zskills doctor` and slimmed on the next `zskills skill upgrade` (or `doctor --fix`).
 
 ## `remove` / `purge`
 
@@ -133,7 +133,7 @@ If a `./skills.toml` exists in CWD when you run `sync` without `--file`, zskills
 The one command for refreshing everything zskills manages — marketplaces, git agent skills, and npm agent skills.
 
 ```
-zskills upgrade [<name>...]
+zskills skill upgrade [<name>...]
 ```
 
 | Source kind | What `upgrade` does |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,6 +4,7 @@ Full reference for every `zskills` subcommand. Flags are shown with their defaul
 
 ## Conventions
 
+- CLI group to manifest key: `plugin` → `[[skills]]`; `skill` → `[[agent_skills]]`; `mcp` → `[[mcps]]`.
 - `<name>` accepts the unqualified skill name (e.g. `servarr`) when unambiguous, or `name@marketplace` (e.g. `servarr@zot24-skills`) when multiple marketplaces declare the same skill. This matches Claude Code's own syntax.
 - Most commands print colored output. Set `NO_COLOR=1` to disable, or pipe through `cat` if you need plain text.
 - `CLAUDE_HOME=/custom/path` overrides `~/.claude` for testing.
@@ -92,7 +93,19 @@ zskills plugin enable  <name>...
 zskills plugin disable <name>...
 ```
 
-`enable` is a no-op if the plugin isn't installed (Claude Code will install it on next start). `disable` keeps bytes and inventory; use `purge` to wipe completely.
+`plugin enable` fails if the plugin is not in `enabledPlugins` or the plugin inventory. `plugin disable` keeps bytes and inventory; use `plugin purge` to delete bytes.
+
+## `skill`
+
+Agent Skills live in `~/.agents/skills/`. The group writes `[[agent_skills]]`, not `[[skills]]`.
+
+```
+zskills skill install <owner/repo> [--skill NAME | --all | -i]
+zskills skill remove <name> [--force] [--file path]
+zskills skill upgrade [<name>...]
+```
+
+`skill remove` deletes bytes. It is not `plugin remove`. `--force` is required when the name is also shipped by an enabled plugin, or when a source-only `[[agent_skills]]` row owns it.
 
 ## `sync` (headline command)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,11 +38,11 @@ Servers are grouped by scope (managed → local → project → user) and only t
 Three accepted spec shapes:
 
 ```
-zskills install <name>                       # plugin from a registered marketplace
-zskills install <name>@<marketplace>         # qualified plugin
-zskills install <owner>/<repo>               # NEW: Agent Skill(s) directly from a git repo
-zskills install <git-url>                    # NEW: same, for arbitrary git URLs (https://, git@, file://)
-zskills install -i                           # interactive picker over marketplace plugins
+zskills plugin install <name>                       # plugin from a registered marketplace
+zskills plugin install <name>@<marketplace>         # qualified plugin
+zskills agent-skill install <owner>/<repo>          # Agent Skill(s) from a git repo
+zskills agent-skill install <git-url>               # same, for https://, git@, file://
+zskills plugin install -i                           # interactive picker over marketplace plugins
 ```
 
 **Plugin path (`<name>` / `<name>@<marketplace>`).** Resolves against registered marketplaces, flips `enabledPlugins` in `~/.claude/settings.json`. Claude Code materializes bytes on next launch.
@@ -74,9 +74,9 @@ zskills install -i                           # interactive picker over marketpla
 `remove` is apt-style: disable in `enabledPlugins` and drop the inventory entry, but leave bytes on disk so re-enabling is instant. `purge` does the same plus deletes the bytes from `~/.claude/plugins/cache/`.
 
 ```
-zskills remove <name>...
-zskills remove -i
-zskills purge  <name>...
+zskills plugin remove <name>...
+zskills plugin remove -i
+zskills plugin purge  <name>...
 ```
 
 | Flag | Default | Description |
@@ -88,8 +88,8 @@ zskills purge  <name>...
 Flip a plugin's `enabledPlugins` flag without (un)installing.
 
 ```
-zskills enable  <name>...
-zskills disable <name>...
+zskills plugin enable  <name>...
+zskills plugin disable <name>...
 ```
 
 `enable` is a no-op if the plugin isn't installed (Claude Code will install it on next start). `disable` keeps bytes and inventory; use `purge` to wipe completely.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,23 +75,17 @@ zskills doctor                          # reconcile disk ↔ inventory ↔ setti
 ## Commands
 
 ```text
-zskills list [-v]                       # what's installed; agent skills grouped by source
-zskills install <name>                  # add a plugin to enabledPlugins
-zskills remove  <name>                  # disable + drop inventory (keep bytes)
-zskills purge   <name>                  # also delete bytes
-zskills enable  <name> / disable <name> # flip the flag only
-zskills sync [--file f.toml] [--prune]  # apply declarative manifest
-zskills upgrade [<name>...]             # ONE command: refresh everything
-zskills update [<name>...]              # refresh marketplace caches (plugins only)
-zskills doctor [--fix]                  # reconcile disk ↔ inventory ↔ settings
-zskills scan [path]                     # find project-scope skills across a tree
-zskills migrate <project>               # promote project skills to user scope
-zskills migrate-skill <name>            # promote ONE skill across every project
-zskills migrate-all <dir>               # interactive sweep
-zskills search <query>                  # keyword search across registered marketplaces
-zskills marketplace add|remove|list|update
-zskills marketplace add-recommended     # seed trusted defaults (anthropics/claude-plugins-official)
+zskills list [-v]
+zskills plugin install|remove|purge|enable|disable
+zskills agent-skill install|remove|upgrade
+zskills mcp add|remove
+zskills sync [--file f.toml] [--prune]
+zskills doctor [--fix]
+zskills scan|migrate|migrate-skill|migrate-all|search
+zskills marketplace add|remove|list|update|add-recommended
 ```
+
+Bare `install`/`remove`/`purge`/`enable`/`disable`/`update`/`upgrade` exit 2.
 
 Optional capabilities live behind cargo features so the default binary stays minimal — see [Commands → Optional features](./commands.md#optional-features) for the `skills-sh` remote-index driver.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ zskills marketplace add-recommended     # seed trusted defaults (Anthropic-offic
 zskills marketplace add zot24/skills    # register additional taps as needed
 zskills search <query>                  # find skills across registered marketplaces
 zskills sync                            # apply the manifest
-zskills upgrade                         # refresh everything from origin
+zskills skill upgrade                   # refresh Agent Skills from origin
 zskills list                            # see what's installed
 zskills doctor                          # reconcile disk ↔ inventory ↔ settings
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ zskills doctor                          # reconcile disk ↔ inventory ↔ setti
 ```text
 zskills list [-v]
 zskills plugin install|remove|purge|enable|disable
-zskills agent-skill install|remove|upgrade
+zskills skill install|remove|upgrade
 zskills mcp add|remove
 zskills sync [--file f.toml] [--prune]
 zskills doctor [--fix]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -239,7 +239,7 @@ Managed scope is **read-only** by design — `zskills sync` never writes to it, 
 
 ## I want to remove an MCP from one scope without touching others
 
-`sync --prune` removes everything not in the manifest, across every writable scope. For a one-MCP one-scope removal today, edit the relevant settings file directly (or use `claude mcp remove` if it targets the scope you want). A finer-grained removal API is on the [roadmap](https://github.com/zot24/zskills/issues/14).
+`sync --prune` removes everything not in the manifest, across every writable scope. For one MCP server at one scope, run `zskills mcp remove <name> [--scope user|project|local]`. That command writes the matching `[[mcps]]` row and the runtime key. It does not run a full `sync`.
 
 ## How do I uninstall zskills entirely?
 

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -335,9 +335,37 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Reject names that would make `user_skills_dir().join(name)` escape that
+/// directory. Empty, `.`, `..`, and any path separator are refused before
+/// `remove_dir_all`. `sync --prune` calls this through [`remove`].
+pub fn validate_skill_name(skill_name: &str) -> Result<()> {
+    if skill_name.is_empty() {
+        anyhow::bail!("invalid Agent Skill name: empty");
+    }
+    if skill_name == "." || skill_name == ".." {
+        anyhow::bail!("invalid Agent Skill name: {skill_name:?}");
+    }
+    if skill_name.contains('/')
+        || skill_name.contains('\\')
+        || skill_name.contains(std::path::MAIN_SEPARATOR)
+    {
+        anyhow::bail!("invalid Agent Skill name {skill_name:?}: path separator not allowed");
+    }
+    Ok(())
+}
+
 /// Remove an installed agent skill from ~/.agents/skills/<name>/.
 pub fn remove_from_user_dir(skill_name: &str) -> Result<()> {
-    let dest = crate::paths::user_skills_dir()?.join(skill_name);
+    validate_skill_name(skill_name)?;
+    let base = crate::paths::user_skills_dir()?;
+    let dest = base.join(skill_name);
+    if dest.parent() != Some(base.as_path()) {
+        anyhow::bail!(
+            "refusing to delete {}: not a direct child of {}",
+            dest.display(),
+            base.display()
+        );
+    }
     if dest.exists() {
         std::fs::remove_dir_all(&dest)?;
     }
@@ -645,11 +673,18 @@ pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
 }
 
 pub fn remove(skill_name: &str) -> Result<bool> {
+    validate_skill_name(skill_name)?;
     let mut inv = load_inventory()?;
-    let removed_from_inventory = inv.agent_skills.remove(skill_name).is_some();
+    let in_inventory = inv.agent_skills.contains_key(skill_name);
+    let dest = crate::paths::user_skills_dir()?.join(skill_name);
+    let on_disk = dest.is_dir();
+    if !in_inventory && !on_disk {
+        return Ok(false);
+    }
+    inv.agent_skills.remove(skill_name);
     remove_from_user_dir(skill_name)?;
     save_inventory(&inv)?;
-    Ok(removed_from_inventory)
+    Ok(true)
 }
 
 fn chrono_now_iso() -> String {
@@ -753,5 +788,82 @@ mod tests {
     fn glob_exact_no_wildcard() {
         assert!(glob_match("foo", "foo"));
         assert!(!glob_match("foo", "foobar"));
+    }
+
+    /// Process-global `AGENTS_HOME` must not leak across tests.
+    static AGENTS_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_agents_home<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = AGENTS_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let skills = home.join("skills");
+        fs::create_dir_all(skills.join("alpha")).unwrap();
+        fs::write(skills.join("alpha").join("SKILL.md"), "a").unwrap();
+        fs::create_dir_all(skills.join("beta")).unwrap();
+        fs::write(skills.join("beta").join("SKILL.md"), "b").unwrap();
+        fs::create_dir_all(home.join(".claude")).unwrap();
+        fs::write(home.join(".claude").join("keep"), "x").unwrap();
+        // SAFETY: held under AGENTS_HOME_LOCK; restored before the guard drops.
+        let prev = std::env::var_os("AGENTS_HOME");
+        std::env::set_var("AGENTS_HOME", home);
+        let out = f(home);
+        match prev {
+            Some(v) => std::env::set_var("AGENTS_HOME", v),
+            None => std::env::remove_var("AGENTS_HOME"),
+        }
+        out
+    }
+
+    fn surviving_skills(home: &std::path::Path) -> Vec<String> {
+        let skills = home.join("skills");
+        if !skills.is_dir() {
+            return Vec::new();
+        }
+        let mut names: Vec<String> = fs::read_dir(&skills)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir() && e.path().join("SKILL.md").exists())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn remove_from_user_dir_rejects_empty_dot_dotdot_and_traversal() {
+        with_agents_home(|home| {
+            for bad in ["", ".", "..", "../.claude"] {
+                let err = super::remove_from_user_dir(bad).unwrap_err().to_string();
+                assert!(
+                    err.contains("invalid Agent Skill name") || err.contains("not a direct child"),
+                    "unexpected error for {bad:?}: {err}"
+                );
+                assert_eq!(surviving_skills(home), ["alpha", "beta"]);
+                assert!(
+                    home.join(".claude").join("keep").exists(),
+                    ".claude neighbour deleted for {bad:?}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn remove_resolves_presence_before_deleting_and_leaves_neighbours() {
+        with_agents_home(|home| {
+            for bad in ["", ".", "..", "../.claude"] {
+                assert!(
+                    super::remove(bad).is_err(),
+                    "remove({bad:?}) must error before any delete"
+                );
+            }
+            assert!(!super::remove("missing-skill").unwrap());
+            assert_eq!(surviving_skills(home), ["alpha", "beta"]);
+            assert!(home.join(".claude").join("keep").exists());
+
+            assert!(super::remove("alpha").unwrap());
+            assert_eq!(surviving_skills(home), ["beta"]);
+            assert!(!super::remove("alpha").unwrap());
+        });
     }
 }

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -73,7 +73,7 @@ pub fn parse_source(source: &str) -> Result<(String, String)> {
         Ok((url, sanitize(source)))
     } else {
         anyhow::bail!(
-            "unrecognized agent-skill source: {} (expected owner/repo or git URL)",
+            "unrecognized Agent Skill source: {} (expected owner/repo or git URL)",
             source
         )
     }
@@ -92,7 +92,7 @@ pub fn ensure_cache(source: &str) -> Result<PathBuf> {
     if cache.exists() {
         crate::git::pull(&cache).ok(); // best-effort
     } else {
-        crate::git::clone(&url, &cache).context("cloning agent-skill source repo")?;
+        crate::git::clone(&url, &cache).context("cloning Agent Skill source repo")?;
     }
     Ok(cache)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -247,12 +247,21 @@ pub enum PluginCmd {
 pub enum AgentSkillCmd {
     /// Install Agent Skills from owner/repo or a git URL
     Install {
-        #[arg(short = 'i', long)]
+        #[arg(short = 'i', long, help = "Pick skills from the source interactively")]
         interactive: bool,
-        #[arg(long)]
+        #[arg(long, help = "Install every skill the source provides (>5 needs this)")]
         all: bool,
-        #[arg(long, conflicts_with = "all", value_name = "NAME")]
+        #[arg(
+            long,
+            conflicts_with = "all",
+            value_name = "NAME",
+            help = "Install only this one skill out of the source"
+        )]
         skill: Option<String>,
+        #[arg(
+            value_name = "SOURCE",
+            help = "owner/repo, https://, git@ or file:// URL"
+        )]
         skills: Vec<String>,
     },
     /// Delete bytes + inventory for an Agent Skill
@@ -266,6 +275,12 @@ pub enum AgentSkillCmd {
     },
     /// Refresh git/npm Agent Skills (and marketplace caches)
     Upgrade { names: Vec<String> },
+    /// Hidden. `skill migrate` is not a verb. Point at `migrate-skill`.
+    #[command(hide = true, disable_help_flag = true)]
+    Migrate {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -366,6 +381,9 @@ impl Cli {
                     crate::commands::agent_skills::remove(names, force, file)
                 }
                 AgentSkillCmd::Upgrade { names } => crate::commands::agent_skills::upgrade(names),
+                AgentSkillCmd::Migrate { rest } => {
+                    crate::commands::stub::run("skill-migrate", &rest)
+                }
             },
             Command::Mcp(cmd) => match cmd {
                 McpCmd::Add {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,9 +5,10 @@ use std::path::PathBuf;
 #[command(
     name = "zskills",
     version,
-    about = "Package manager for Claude Code skills",
-    long_about = "Declarative install, enable, and reconciliation across Claude Code marketplaces.\n\
-                  Treats skills.toml as intent and ~/.claude/settings.json + installed_plugins.json as state."
+    about = "Package manager for plugins, Agent Skills, and MCP servers",
+    long_about = "Declarative install and reconciliation across Claude Code marketplaces.\n\
+                  Treats skills.toml as intent and ~/.claude/settings.json + installed_plugins.json as state.\n\
+                  Typed groups: plugin, agent-skill, mcp."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -32,65 +33,59 @@ pub enum Command {
         paths: bool,
     },
 
-    /// Install + enable one or more skills (format: name, name@marketplace, owner/repo, or git URL)
+    /// Marketplace plugins (`enabledPlugins` + `installed_plugins.json`)
+    #[command(subcommand)]
+    Plugin(PluginCmd),
+
+    /// Agent Skills in ~/.agents/skills/
+    #[command(name = "agent-skill", subcommand)]
+    AgentSkill(AgentSkillCmd),
+
+    /// MCP servers in skills.toml and the runtime mcpServers map
+    #[command(subcommand)]
+    Mcp(McpCmd),
+
+    /// Removed in 1.0. Prints the typed replacement and exits 2.
+    #[command(hide = true, disable_help_flag = true)]
     Install {
-        /// Browse all marketplace plugins interactively and pick one to install
-        #[arg(short = 'i', long)]
-        interactive: bool,
-
-        /// When installing from a repo (owner/repo or git URL) with more than 5 Agent Skills,
-        /// confirm "install everything." Without this, large collections abort with a summary
-        /// so they don't silently flood ~/.agents/skills/.
-        #[arg(long)]
-        all: bool,
-
-        /// When installing from a repo, install only the named skill (the manifest
-        /// `name` field / the name shown by the survey). Non-interactive alternative
-        /// to `-i` for multi-skill repos.
-        #[arg(long, conflicts_with = "all", value_name = "NAME")]
-        skill: Option<String>,
-
-        /// Skills to install
-        skills: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
-
-    /// Disable + drop from inventory (keeps bytes on disk)
+    /// Removed in 1.0.
+    #[command(hide = true, disable_help_flag = true)]
     Remove {
-        /// Browse enabled plugins interactively and pick which to remove
-        #[arg(short = 'i', long)]
-        interactive: bool,
-
-        skills: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
-
-    /// Like remove, but also deletes the bytes from ~/.claude/plugins
+    /// Removed in 1.0.
+    #[command(hide = true, disable_help_flag = true)]
     Purge {
-        #[arg(required = true)]
-        skills: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
-
-    /// Flip enabledPlugins on (skill must already be installed)
+    /// Removed in 1.0.
+    #[command(hide = true, disable_help_flag = true)]
     Enable {
-        #[arg(required = true)]
-        skills: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
-
-    /// Flip enabledPlugins off (skill stays installed)
+    /// Removed in 1.0.
+    #[command(hide = true, disable_help_flag = true)]
     Disable {
-        #[arg(required = true)]
-        skills: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
-
-    /// Update one or more skills (or all) to latest from their marketplace
+    /// Removed in 1.0. Use `marketplace update`.
+    #[command(hide = true, disable_help_flag = true)]
     Update {
-        /// Specific skills to update; empty = all
-        skills: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
-
-    /// Upgrade everything zskills manages: marketplaces, git agent skills, npm agent skills.
+    /// Removed in 1.0. Use `agent-skill upgrade` / `marketplace update`.
+    #[command(hide = true, disable_help_flag = true)]
     Upgrade {
-        /// Specific names to upgrade; empty = upgrade everything
-        names: Vec<String>,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+        rest: Vec<String>,
     },
 
     /// Apply a declarative skills.toml manifest to the current scope
@@ -114,6 +109,11 @@ pub enum Command {
         /// listed gets appended to the manifest. Inverse of `--prune`.
         #[arg(long, conflicts_with = "prune")]
         adopt: bool,
+
+        /// Allow applying a manifest that declares zero entries of a kind while
+        /// state still holds many (the silent mass-disable guard).
+        #[arg(long)]
+        force: bool,
     },
 
     /// Reconcile disk ↔ inventory ↔ settings; report orphans + mismatches
@@ -213,6 +213,94 @@ pub enum Command {
 }
 
 #[derive(Subcommand)]
+pub enum PluginCmd {
+    /// Install + enable a marketplace plugin (name or name@marketplace)
+    Install {
+        #[arg(short = 'i', long)]
+        interactive: bool,
+        skills: Vec<String>,
+    },
+    /// Drop enabledPlugins + inventory; keep bytes
+    Remove {
+        #[arg(short = 'i', long)]
+        interactive: bool,
+        skills: Vec<String>,
+    },
+    /// Like remove, and delete recorded installPath bytes
+    Purge {
+        #[arg(required = true)]
+        skills: Vec<String>,
+    },
+    /// Flip enabledPlugins on (plugin must already be installed)
+    Enable {
+        #[arg(required = true)]
+        skills: Vec<String>,
+    },
+    /// Flip enabledPlugins off (plugin stays installed)
+    Disable {
+        #[arg(required = true)]
+        skills: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AgentSkillCmd {
+    /// Install Agent Skills from owner/repo or a git URL
+    Install {
+        #[arg(short = 'i', long)]
+        interactive: bool,
+        #[arg(long)]
+        all: bool,
+        #[arg(long, conflicts_with = "all", value_name = "NAME")]
+        skill: Option<String>,
+        skills: Vec<String>,
+    },
+    /// Delete bytes + inventory for an Agent Skill
+    Remove {
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        file: Option<PathBuf>,
+        #[arg(required = true)]
+        names: Vec<String>,
+    },
+    /// Refresh git/npm Agent Skills (and marketplace caches)
+    Upgrade { names: Vec<String> },
+}
+
+#[derive(Subcommand)]
+pub enum McpCmd {
+    /// Declare an MCP server in skills.toml and the runtime map
+    Add {
+        name: String,
+        #[arg(long)]
+        transport: Option<String>,
+        #[arg(long)]
+        command: Option<String>,
+        #[arg(long = "args", value_name = "ARG")]
+        args: Vec<String>,
+        #[arg(long = "env", value_name = "KEY=VALUE", value_parser = crate::commands::mcp::parse_kv)]
+        env: Vec<(String, String)>,
+        #[arg(long)]
+        url: Option<String>,
+        #[arg(long = "header", value_name = "KEY=VALUE", value_parser = crate::commands::mcp::parse_kv)]
+        header: Vec<(String, String)>,
+        #[arg(long, default_value = "user")]
+        scope: String,
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
+    /// Remove one MCP server from skills.toml and the runtime map
+    Remove {
+        name: String,
+        #[arg(long)]
+        scope: Option<String>,
+        #[arg(long)]
+        file: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum MarketplaceCmd {
     /// Add a marketplace tap (owner/repo or full git URL)
     Add { source: String },
@@ -244,27 +332,81 @@ impl Cli {
                 verbose,
                 paths,
             } => crate::commands::list::run(json, verbose, paths),
-            Command::Install {
-                skills,
-                interactive,
-                all,
-                skill,
-            } => crate::commands::install::run(skills, interactive, all, skill),
-            Command::Remove {
-                skills,
-                interactive,
-            } => crate::commands::remove::run(skills, interactive, false),
-            Command::Purge { skills } => crate::commands::remove::run(skills, false, true),
-            Command::Enable { skills } => crate::commands::enable::run(skills, true),
-            Command::Disable { skills } => crate::commands::enable::run(skills, false),
-            Command::Update { skills } => crate::commands::update::run(skills),
-            Command::Upgrade { names } => crate::commands::upgrade::run(names),
+            Command::Plugin(cmd) => match cmd {
+                PluginCmd::Install {
+                    skills,
+                    interactive,
+                } => {
+                    if skills
+                        .iter()
+                        .any(|s| crate::commands::install::is_repo_spec(s))
+                    {
+                        anyhow::bail!(
+                            "plugin install takes name or name@marketplace; use `zskills agent-skill install` for owner/repo"
+                        );
+                    }
+                    crate::commands::install::run(skills, interactive, false, None)
+                }
+                PluginCmd::Remove {
+                    skills,
+                    interactive,
+                } => crate::commands::remove::run(skills, interactive, false),
+                PluginCmd::Purge { skills } => crate::commands::remove::run(skills, false, true),
+                PluginCmd::Enable { skills } => crate::commands::enable::run(skills, true),
+                PluginCmd::Disable { skills } => crate::commands::enable::run(skills, false),
+            },
+            Command::AgentSkill(cmd) => match cmd {
+                AgentSkillCmd::Install {
+                    skills,
+                    interactive,
+                    all,
+                    skill,
+                } => crate::commands::agent_skills::install(skills, interactive, all, skill),
+                AgentSkillCmd::Remove { names, force, file } => {
+                    crate::commands::agent_skills::remove(names, force, file)
+                }
+                AgentSkillCmd::Upgrade { names } => crate::commands::agent_skills::upgrade(names),
+            },
+            Command::Mcp(cmd) => match cmd {
+                McpCmd::Add {
+                    name,
+                    transport,
+                    command,
+                    args,
+                    env,
+                    url,
+                    header,
+                    scope,
+                    file,
+                } => crate::commands::mcp::add(
+                    name,
+                    transport,
+                    command,
+                    args,
+                    env,
+                    url,
+                    header,
+                    Some(scope),
+                    file,
+                ),
+                McpCmd::Remove { name, scope, file } => {
+                    crate::commands::mcp::remove(name, scope, file)
+                }
+            },
+            Command::Install { rest } => crate::commands::stub::run("install", &rest),
+            Command::Remove { rest } => crate::commands::stub::run("remove", &rest),
+            Command::Purge { rest } => crate::commands::stub::run("purge", &rest),
+            Command::Enable { rest } => crate::commands::stub::run("enable", &rest),
+            Command::Disable { rest } => crate::commands::stub::run("disable", &rest),
+            Command::Update { rest } => crate::commands::stub::run("update", &rest),
+            Command::Upgrade { rest } => crate::commands::stub::run("upgrade", &rest),
             Command::Sync {
                 file,
                 dry_run,
                 prune,
                 adopt,
-            } => crate::commands::sync::run(file, dry_run, prune, adopt),
+                force,
+            } => crate::commands::sync::run(file, dry_run, prune, adopt, force),
             Command::Doctor { fix } => crate::commands::doctor::run(fix),
             Command::Scan { path, depth, json } => crate::commands::scan::run(path, depth, json),
             Command::Migrate {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
     about = "Package manager for plugins, Agent Skills, and MCP servers",
     long_about = "Declarative install and reconciliation across Claude Code marketplaces.\n\
                   Treats skills.toml as intent and ~/.claude/settings.json + installed_plugins.json as state.\n\
-                  Typed groups: plugin, agent-skill, mcp."
+                  Typed groups: plugin, skill, mcp."
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -38,7 +38,7 @@ pub enum Command {
     Plugin(PluginCmd),
 
     /// Agent Skills in ~/.agents/skills/
-    #[command(name = "agent-skill", subcommand)]
+    #[command(name = "skill", subcommand)]
     AgentSkill(AgentSkillCmd),
 
     /// MCP servers in skills.toml and the runtime mcpServers map
@@ -81,7 +81,7 @@ pub enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
         rest: Vec<String>,
     },
-    /// Removed in 1.0. Use `agent-skill upgrade` / `marketplace update`.
+    /// Removed in 1.0. Use `skill upgrade` / `marketplace update`.
     #[command(hide = true, disable_help_flag = true)]
     Upgrade {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
@@ -342,7 +342,7 @@ impl Cli {
                         .any(|s| crate::commands::install::is_repo_spec(s))
                     {
                         anyhow::bail!(
-                            "plugin install takes name or name@marketplace; use `zskills agent-skill install` for owner/repo"
+                            "plugin install takes name or name@marketplace; use `zskills skill install` for owner/repo"
                         );
                     }
                     crate::commands::install::run(skills, interactive, false, None)

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -1,4 +1,4 @@
-//! `zskills agent-skill` verbs.
+//! `zskills skill` verbs.
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
@@ -15,7 +15,7 @@ pub fn install(
         .any(|s| !crate::commands::install::is_repo_spec(s))
     {
         anyhow::bail!(
-            "agent-skill install takes owner/repo or a git URL; use `zskills plugin install` for name@marketplace"
+            "skill install takes owner/repo or a git URL; use `zskills plugin install` for name@marketplace"
         );
     }
     crate::commands::install::run(specs, interactive, all, skill)

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -1,0 +1,94 @@
+//! `zskills agent-skill` verbs.
+
+use anyhow::Result;
+use owo_colors::OwoColorize;
+use std::path::PathBuf;
+
+pub fn install(
+    specs: Vec<String>,
+    interactive: bool,
+    all: bool,
+    skill: Option<String>,
+) -> Result<()> {
+    if specs
+        .iter()
+        .any(|s| !crate::commands::install::is_repo_spec(s))
+    {
+        anyhow::bail!(
+            "agent-skill install takes owner/repo or a git URL; use `zskills plugin install` for name@marketplace"
+        );
+    }
+    crate::commands::install::run(specs, interactive, all, skill)
+}
+
+pub fn upgrade(names: Vec<String>) -> Result<()> {
+    crate::commands::upgrade::run(names)
+}
+
+pub fn remove(names: Vec<String>, force: bool, file: Option<PathBuf>) -> Result<()> {
+    if names.is_empty() {
+        anyhow::bail!("specify at least one Agent Skill name");
+    }
+    let manifest_path = file.or_else(crate::manifest::discover);
+    let manifest = match manifest_path.as_ref() {
+        Some(p) => Some(crate::manifest::load(p)?),
+        None => None,
+    };
+    let inv = crate::agent_skill::load_inventory()?;
+    let report = crate::reconcile::run()?;
+    let from_plugins = crate::agent_skill::plugin_provided_skills(&report.active);
+
+    let mut failed = 0usize;
+    for name in &names {
+        if let Err(e) = remove_one(
+            name,
+            force,
+            manifest_path.as_deref(),
+            manifest.as_ref(),
+            &inv,
+            &from_plugins,
+        ) {
+            eprintln!("{} {name}: {e}", "✗".red());
+            failed += 1;
+        }
+    }
+    anyhow::ensure!(failed == 0, "{failed} Agent Skill remove(s) failed");
+    Ok(())
+}
+
+fn remove_one(
+    name: &str,
+    force: bool,
+    manifest_path: Option<&std::path::Path>,
+    manifest: Option<&crate::manifest::Manifest>,
+    inv: &crate::agent_skill::Inventory,
+    from_plugins: &std::collections::BTreeSet<String>,
+) -> Result<()> {
+    crate::agent_skill::validate_skill_name(name)?;
+    if from_plugins.contains(name) && !force {
+        anyhow::bail!(
+            "Agent Skill '{name}' is also shipped by an enabled plugin; removing the user copy will not remove it — use `zskills plugin remove`, or --force"
+        );
+    }
+    if let (Some(entry), Some(m)) = (inv.agent_skills.get(name), manifest) {
+        let source_only = m
+            .agent_skills
+            .iter()
+            .any(|e| e.name.is_none() && e.source.as_deref() == Some(entry.source.as_str()));
+        if source_only && !force {
+            anyhow::bail!(
+                "Agent Skill '{name}' is owned by a source-only [[agent_skills]] row (source = {}); convert to a named row first, or pass --force",
+                entry.source
+            );
+        }
+    }
+
+    if !crate::agent_skill::remove(name)? {
+        anyhow::bail!("Agent Skill '{name}' is not installed");
+    }
+    if let Some(path) = manifest_path {
+        let _ = crate::manifest::drop_named_agent_skill(path, name)?;
+    }
+    println!("{} removed Agent Skill {}", "-".yellow(), name.bold());
+    Ok(())
+}

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -11,6 +11,8 @@ pub fn run(fix: bool) -> Result<()> {
     let mut fixable = 0;
 
     issues += check_mcps();
+    issues += check_mcp_intent();
+    issues += check_stale_zskills_skill_md();
 
     // A marketplace entry with no `lastUpdated` string makes Claude Code reject the
     // *whole* known_marketplaces.json, which breaks every `claude plugin install`.
@@ -159,7 +161,8 @@ pub fn run(fix: bool) -> Result<()> {
         }
         println!(
             "  {}",
-            "run `zskills upgrade <name>` or `zskills doctor --fix` to re-install slim".dimmed()
+            "run `zskills agent-skill upgrade <name>` or `zskills doctor --fix` to re-install slim"
+                .dimmed()
         );
     }
 
@@ -339,6 +342,93 @@ fn check_mcps() -> usize {
         println!("  {} {}", format!("[{}]", scope).dimmed(), name.bold());
         for msg in msgs {
             println!("    - {}", msg);
+        }
+    }
+    issues
+}
+
+/// Compare [[mcps]] intent with runtime Manual keys. `--fix` stays a no-op.
+fn check_mcp_intent() -> usize {
+    let Some(path) = crate::manifest::discover() else {
+        return 0;
+    };
+    let Ok(manifest) = crate::manifest::load(&path) else {
+        return 0;
+    };
+    let runtime = crate::mcp::load_all().unwrap_or_default();
+    let mut issues = 0;
+    for entry in &manifest.mcps {
+        let Ok(scope) = entry.scope_kind() else {
+            continue;
+        };
+        let present = runtime.iter().any(|m| {
+            m.name == entry.name
+                && m.scope.label() == scope
+                && matches!(m.source, crate::mcp::Source::Manual)
+        });
+        if !present {
+            issues += 1;
+            println!(
+                "{} [[mcps]] `{}` ({}) is in the manifest but not in the runtime map",
+                "✗".red(),
+                entry.name,
+                scope
+            );
+        }
+    }
+    for m in runtime
+        .iter()
+        .filter(|m| matches!(m.source, crate::mcp::Source::Manual))
+    {
+        let in_manifest = manifest
+            .mcps
+            .iter()
+            .any(|e| e.name == m.name && e.scope_kind().ok() == Some(m.scope.label()));
+        if !in_manifest {
+            issues += 1;
+            println!(
+                "{} MCP `{}` ({}) is in the runtime map but not in [[mcps]]",
+                "✗".red(),
+                m.name,
+                m.scope.label()
+            );
+        }
+    }
+    issues
+}
+
+/// Warn if a SKILL.md named zskills still teaches bare verbs.
+fn check_stale_zskills_skill_md() -> usize {
+    let mut issues = 0;
+    let candidates = [
+        crate::paths::user_skills_dir()
+            .ok()
+            .map(|p| p.join("zskills").join("SKILL.md")),
+        crate::paths::claude_home()
+            .ok()
+            .map(|p| p.join("skills").join("zskills").join("SKILL.md")),
+    ];
+    for path in candidates.into_iter().flatten() {
+        if !path.exists() {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let stale = [
+            "zskills install ",
+            "zskills remove ",
+            "zskills purge ",
+            "zskills enable ",
+            "zskills disable ",
+        ];
+        if stale.iter().any(|s| text.contains(s)) {
+            issues += 1;
+            println!(
+                "{} {} still documents bare verbs removed in 1.0 — recopy skills/zskills/SKILL.md from this version",
+                "!".yellow(),
+                path.display()
+            );
         }
     }
     issues

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -161,7 +161,7 @@ pub fn run(fix: bool) -> Result<()> {
         }
         println!(
             "  {}",
-            "run `zskills agent-skill upgrade <name>` or `zskills doctor --fix` to re-install slim"
+            "run `zskills skill upgrade <name>` or `zskills doctor --fix` to re-install slim"
                 .dimmed()
         );
     }
@@ -218,7 +218,7 @@ pub fn run(fix: bool) -> Result<()> {
         let mut inv = crate::agent_skill::load_inventory()?;
         for k in &agent_inventory_missing {
             inv.agent_skills.remove(k);
-            println!("  removed {} from agent-skill inventory", k);
+            println!("  removed {} from Agent Skill inventory", k);
             fixed += 1;
         }
         crate::agent_skill::save_inventory(&inv)?;

--- a/src/commands/enable.rs
+++ b/src/commands/enable.rs
@@ -3,23 +3,47 @@ use owo_colors::OwoColorize;
 use serde_json::Value;
 
 pub fn run(specs: Vec<String>, enable: bool) -> Result<()> {
+    if specs.is_empty() {
+        anyhow::bail!("specify at least one plugin name");
+    }
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     let settings_path = crate::paths::settings_json()?;
+    let inventory_path = crate::paths::installed_plugins_json()?;
     let mut settings = crate::settings::load(&settings_path)?;
+    let inventory = crate::inventory::load(&inventory_path)?;
+    let mut failed = 0usize;
+    let mut any = false;
 
     for spec in &specs {
+        let ep = crate::settings::enabled_plugins(&settings)
+            .cloned()
+            .unwrap_or_default();
+        let plugs = crate::inventory::plugins(&inventory)
+            .cloned()
+            .unwrap_or_default();
         let qualified =
-            crate::marketplace::resolve_spec(spec, &known).unwrap_or_else(|_| spec.to_string());
+            match crate::commands::remove::resolve_installed_plugin(spec, &ep, &plugs, &known) {
+                Ok(q) => q,
+                Err(e) => {
+                    eprintln!("{} {e}", "✗".red());
+                    failed += 1;
+                    continue;
+                }
+            };
         let ep = crate::settings::enabled_plugins_mut(&mut settings);
         if enable {
             ep.insert(qualified.clone(), Value::Bool(true));
-            println!("{} enabled {}", "✓".green(), qualified);
+            println!("{} enabled plugin {}", "✓".green(), qualified);
         } else {
             ep.insert(qualified.clone(), Value::Bool(false));
-            println!("{} disabled {}", "•".yellow(), qualified);
+            println!("{} disabled plugin {}", "•".yellow(), qualified);
         }
+        any = true;
     }
 
-    crate::settings::save(&settings_path, &settings)?;
+    if any {
+        crate::settings::save(&settings_path, &settings)?;
+    }
+    anyhow::ensure!(failed == 0, "{failed} plugin enable/disable(s) failed");
     Ok(())
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -214,12 +214,12 @@ fn print_large_collection_summary(
     println!("\n{}", "Options:".bold());
     println!(
         "  {}   {}",
-        format!("zskills agent-skill install {} -i", spec).bold(),
+        format!("zskills skill install {} -i", spec).bold(),
         "interactive picker".dimmed()
     );
     println!(
         "  {}   {}",
-        format!("zskills agent-skill install {} --all", spec).bold(),
+        format!("zskills skill install {} --all", spec).bold(),
         format!("install all {} skills", count).dimmed()
     );
     let preview: Vec<&str> = skills.iter().take(5).map(|s| s.name.as_str()).collect();

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -85,8 +85,8 @@ fn install_from_repo(spec: &str, interactive: bool, all: bool, skill: Option<&st
         );
         println!("  zskills marketplace add {}", spec.bold());
         println!(
-            "  zskills install <plugin>@<marketplace>   {}",
-            "(or `zskills install -i` to browse)".dimmed()
+            "  zskills plugin install <plugin>@<marketplace>   {}",
+            "(or `zskills plugin install -i` to browse)".dimmed()
         );
         if !survey.agent_skills.is_empty() {
             println!(
@@ -214,12 +214,12 @@ fn print_large_collection_summary(
     println!("\n{}", "Options:".bold());
     println!(
         "  {}   {}",
-        format!("zskills install {} -i", spec).bold(),
+        format!("zskills agent-skill install {} -i", spec).bold(),
         "interactive picker".dimmed()
     );
     println!(
         "  {}   {}",
-        format!("zskills install {} --all", spec).bold(),
+        format!("zskills agent-skill install {} --all", spec).bold(),
         format!("install all {} skills", count).dimmed()
     );
     let preview: Vec<&str> = skills.iter().take(5).map(|s| s.name.as_str()).collect();

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1,0 +1,136 @@
+//! `zskills mcp add` / `zskills mcp remove`. Dual-write intent then state.
+
+use anyhow::Result;
+use owo_colors::OwoColorize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::manifest::McpEntry;
+use crate::mcp::Scope;
+
+#[allow(clippy::too_many_arguments)]
+pub fn add(
+    name: String,
+    transport: Option<String>,
+    command: Option<String>,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    url: Option<String>,
+    header: Vec<(String, String)>,
+    scope: Option<String>,
+    file: Option<PathBuf>,
+) -> Result<()> {
+    let entry = McpEntry {
+        name: name.clone(),
+        transport: transport.clone(),
+        command,
+        args,
+        env: env.into_iter().collect::<BTreeMap<_, _>>(),
+        url,
+        headers: header.into_iter().collect::<BTreeMap<_, _>>(),
+        scope: scope.clone(),
+    };
+    entry.validate()?;
+    let scope_s = entry.scope_kind()?;
+    let mcp_scope = parse_scope(scope_s)?;
+
+    let manifest_path = file.or_else(crate::manifest::discover);
+    if let Some(path) = manifest_path.as_ref() {
+        let outcome = crate::manifest::upsert_mcp(path, &entry)?;
+        println!(
+            "{} {outcome} [[mcps]] {} ({}) in {}",
+            "✓".green(),
+            name.bold(),
+            scope_s,
+            path.display().to_string().dimmed()
+        );
+    } else {
+        eprintln!(
+            "{} no skills.toml found — wrote runtime only; next sync cannot reproduce this",
+            "!".yellow()
+        );
+    }
+
+    crate::mcp::upsert(&mcp_scope, &name, entry.to_json_value())?;
+    println!("{} applied mcp {} ({})", "✓".green(), name.bold(), scope_s);
+    Ok(())
+}
+
+pub fn remove(name: String, scope: Option<String>, file: Option<PathBuf>) -> Result<()> {
+    let scope_s = scope.as_deref().unwrap_or("user");
+    let mcp_scope = parse_scope(scope_s)?;
+
+    let all = crate::mcp::load_all().unwrap_or_default();
+    let other_scopes: Vec<&str> = all
+        .iter()
+        .filter(|m| m.name == name && m.scope.label() != scope_s)
+        .map(|m| m.scope.label())
+        .collect();
+    let at_requested: Vec<_> = all
+        .iter()
+        .filter(|m| m.name == name && m.scope.label() == scope_s)
+        .collect();
+
+    if at_requested.is_empty() {
+        if other_scopes.is_empty() {
+            anyhow::bail!("MCP '{name}' is not configured at scope {scope_s}");
+        }
+        anyhow::bail!(
+            "MCP '{name}' is not configured at scope {scope_s} (found at: {}); pass --scope",
+            other_scopes.join("|")
+        );
+    }
+    if at_requested.len() > 1 {
+        // Two files at one scope: still delete both via mcp::remove.
+    }
+    let also_elsewhere: Vec<&str> = all
+        .iter()
+        .filter(|m| m.name == name && m.scope.label() != scope_s)
+        .map(|m| m.scope.label())
+        .collect();
+    if !also_elsewhere.is_empty() && scope.is_none() {
+        let mut scopes: Vec<&str> = vec![scope_s];
+        scopes.extend(also_elsewhere);
+        anyhow::bail!(
+            "MCP '{name}' exists at scopes: {}; pass --scope",
+            scopes.join(", ")
+        );
+    }
+
+    let manifest_path = file.or_else(crate::manifest::discover);
+    if let Some(path) = manifest_path.as_ref() {
+        crate::manifest::drop_mcp(path, &name, scope_s)?;
+    } else {
+        eprintln!(
+            "{} no skills.toml found — runtime only; intent was not updated",
+            "!".yellow()
+        );
+    }
+
+    let deleted = crate::mcp::remove(&mcp_scope, &name)?;
+    if !deleted {
+        anyhow::bail!("MCP '{name}' is not configured at scope {scope_s}");
+    }
+    println!("{} removed mcp {} ({})", "-".yellow(), name.bold(), scope_s);
+    Ok(())
+}
+
+fn parse_scope(s: &str) -> Result<Scope> {
+    match s {
+        "user" => Ok(Scope::User),
+        "project" => Ok(Scope::Project),
+        "local" => Ok(Scope::Local),
+        "managed" => anyhow::bail!("cannot write to managed scope — deployed by IT, not zskills"),
+        other => anyhow::bail!("unknown scope {other:?} (must be user, project, or local)"),
+    }
+}
+
+pub fn parse_kv(s: &str) -> Result<(String, String), String> {
+    let Some((k, v)) = s.split_once('=') else {
+        return Err(format!("expected KEY=VALUE, got {s:?}"));
+    };
+    if k.is_empty() {
+        return Err("empty KEY in KEY=VALUE".into());
+    }
+    Ok((k.to_string(), v.to_string()))
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,14 +1,17 @@
+pub mod agent_skills;
 pub mod doctor;
 pub mod enable;
 pub mod install;
 pub mod list;
 pub mod marketplace;
+pub mod mcp;
 pub mod migrate;
 pub mod migrate_all;
 pub mod migrate_skill;
 pub mod remove;
 pub mod scan;
 pub mod search;
+pub mod stub;
 pub mod sync;
 pub mod update;
 pub mod upgrade;

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -3,6 +3,43 @@
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
+use serde_json::Map;
+use serde_json::Value;
+
+/// Identity for plugin remove/enable/disable: what is installed, not the catalogue.
+pub(crate) fn resolve_installed_plugin(
+    spec: &str,
+    ep: &Map<String, Value>,
+    plugins: &Map<String, Value>,
+    known: &Map<String, Value>,
+) -> Result<String> {
+    if ep.contains_key(spec) || plugins.contains_key(spec) {
+        return Ok(spec.to_string());
+    }
+    match crate::marketplace::resolve_spec(spec, known) {
+        Ok(q) if ep.contains_key(&q) || plugins.contains_key(&q) => Ok(q),
+        Ok(q) => anyhow::bail!("plugin '{q}' is not installed"),
+        Err(_) => {
+            let prefix = format!("{spec}@");
+            let mut hits: Vec<String> = ep
+                .keys()
+                .chain(plugins.keys())
+                .filter(|k| k.as_str() == spec || k.starts_with(&prefix))
+                .cloned()
+                .collect();
+            hits.sort();
+            hits.dedup();
+            match hits.len() {
+                1 => Ok(hits.remove(0)),
+                0 => anyhow::bail!("plugin '{spec}' is not installed"),
+                _ => anyhow::bail!(
+                    "plugin '{spec}' is ambiguous — qualify with @marketplace (matches: {})",
+                    hits.join(", ")
+                ),
+            }
+        }
+    }
+}
 
 pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<()> {
     if interactive && specs.is_empty() {
@@ -10,7 +47,7 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
     }
 
     if specs.is_empty() {
-        anyhow::bail!("specify at least one skill name, or use -i/--interactive to browse");
+        anyhow::bail!("specify at least one plugin name, or use -i/--interactive to browse");
     }
 
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
@@ -19,19 +56,31 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
 
     let mut settings = crate::settings::load(&settings_path)?;
     let mut inventory = crate::inventory::load(&inventory_path)?;
+    let mut any = false;
+    let mut failed = 0usize;
 
     for spec in &specs {
-        let qualified =
-            crate::marketplace::resolve_spec(spec, &known).unwrap_or_else(|_| spec.to_string());
+        let ep = crate::settings::enabled_plugins(&settings)
+            .cloned()
+            .unwrap_or_default();
+        let plugs = crate::inventory::plugins(&inventory)
+            .cloned()
+            .unwrap_or_default();
+        let qualified = match resolve_installed_plugin(spec, &ep, &plugs, &known) {
+            Ok(q) => q,
+            Err(e) => {
+                eprintln!("{} {e}", "✗".red());
+                failed += 1;
+                continue;
+            }
+        };
 
-        // Remove from enabledPlugins
         let ep = crate::settings::enabled_plugins_mut(&mut settings);
-        ep.remove(&qualified);
+        let had_ep = ep.remove(&qualified).is_some();
 
-        // Remove from inventory and collect installPaths for purge
         let mut install_paths: Vec<std::path::PathBuf> = Vec::new();
         let plugins = crate::inventory::plugins_mut(&mut inventory);
-        if let Some(entries) = plugins.remove(&qualified) {
+        let had_inv = if let Some(entries) = plugins.remove(&qualified) {
             if purge_bytes {
                 if let Some(arr) = entries.as_array() {
                     for entry in arr {
@@ -41,7 +90,17 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
                     }
                 }
             }
+            true
+        } else {
+            false
+        };
+
+        if !had_ep && !had_inv && install_paths.is_empty() {
+            eprintln!("{} plugin '{qualified}' is not installed", "✗".red());
+            failed += 1;
+            continue;
         }
+        any = true;
 
         if purge_bytes {
             for p in &install_paths {
@@ -53,14 +112,17 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
                     }
                 }
             }
-            println!("{} purged {}", "✗".red(), qualified);
+            println!("{} purged plugin {}", "✗".red(), qualified);
         } else {
-            println!("{} removed {}", "-".yellow(), qualified);
+            println!("{} removed plugin {}", "-".yellow(), qualified);
         }
     }
 
-    crate::settings::save(&settings_path, &settings)?;
-    crate::inventory::save(&inventory_path, &inventory)?;
+    if any {
+        crate::settings::save(&settings_path, &settings)?;
+        crate::inventory::save(&inventory_path, &inventory)?;
+    }
+    anyhow::ensure!(failed == 0, "{failed} plugin remove(s) failed");
     Ok(())
 }
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -130,6 +130,7 @@ fn install_from_hits(hits: &[Hit]) -> Result<()> {
             let h = &hits[idx];
             let spec = format!("{}@{}", h.name, h.marketplace);
             crate::commands::install::run(vec![spec], false, false, None)?;
+            // search -i always produces name@marketplace (plugin path).
         }
     }
     Ok(())

--- a/src/commands/stub.rs
+++ b/src/commands/stub.rs
@@ -28,7 +28,7 @@ fn first_name(rest: &[String]) -> Option<&str> {
 fn doors(verb: &str) -> String {
     match verb {
         "install" => {
-            "  plugin:      zskills plugin install <name@marketplace>\n  skill:       zskills skill install <owner/repo>\n  mcp:         zskills mcp add <name>".into()
+            "  plugin:      zskills plugin install <name@marketplace>  (writes [[skills]])\n  skill:       zskills skill install <owner/repo>            (writes [[agent_skills]])\n  mcp:         zskills mcp add <name>".into()
         }
         "remove" => {
             "  plugin:      zskills plugin remove <name@marketplace>\n  skill:       zskills skill remove <name>\n  mcp:         zskills mcp remove <name> [--scope user|project|local]".into()
@@ -39,6 +39,9 @@ fn doors(verb: &str) -> String {
         "update" => "  marketplace: zskills marketplace update [name]".into(),
         "upgrade" => {
             "  skill:       zskills skill upgrade [name]\n  marketplace: zskills marketplace update [name]".into()
+        }
+        "skill-migrate" => {
+            "  use `zskills migrate-skill <name>` (top-level). `skill migrate` is not a verb.".into()
         }
         _ => String::new(),
     }

--- a/src/commands/stub.rs
+++ b/src/commands/stub.rs
@@ -28,17 +28,17 @@ fn first_name(rest: &[String]) -> Option<&str> {
 fn doors(verb: &str) -> String {
     match verb {
         "install" => {
-            "  plugin:      zskills plugin install <name@marketplace>\n  agent-skill: zskills agent-skill install <owner/repo>\n  mcp:         zskills mcp add <name>".into()
+            "  plugin:      zskills plugin install <name@marketplace>\n  skill:       zskills skill install <owner/repo>\n  mcp:         zskills mcp add <name>".into()
         }
         "remove" => {
-            "  plugin:      zskills plugin remove <name@marketplace>\n  agent-skill: zskills agent-skill remove <name>\n  mcp:         zskills mcp remove <name> [--scope user|project|local]".into()
+            "  plugin:      zskills plugin remove <name@marketplace>\n  skill:       zskills skill remove <name>\n  mcp:         zskills mcp remove <name> [--scope user|project|local]".into()
         }
         "purge" => "  plugin:      zskills plugin purge <name@marketplace>".into(),
         "enable" => "  plugin:      zskills plugin enable <name@marketplace>".into(),
         "disable" => "  plugin:      zskills plugin disable <name@marketplace>".into(),
         "update" => "  marketplace: zskills marketplace update [name]".into(),
         "upgrade" => {
-            "  agent-skill: zskills agent-skill upgrade [name]\n  marketplace: zskills marketplace update [name]".into()
+            "  skill:       zskills skill upgrade [name]\n  marketplace: zskills marketplace update [name]".into()
         }
         _ => String::new(),
     }
@@ -62,7 +62,7 @@ fn live_hint(name: &str) -> Option<String> {
     if let Ok(inv) = crate::agent_skill::load_inventory() {
         if inv.agent_skills.contains_key(name) {
             lines.push(format!(
-                "  agent-skill {name}                 → zskills agent-skill remove {name} (DELETES bytes)"
+                "  skill       {name}                 → zskills skill remove {name} (DELETES bytes)"
             ));
         }
     }

--- a/src/commands/stub.rs
+++ b/src/commands/stub.rs
@@ -1,0 +1,86 @@
+//! Hidden 1.0 stubs for dropped top-level verbs. Exit 2. Do not run the old work.
+
+use anyhow::Result;
+
+use crate::error::RemovedVerb;
+
+pub fn run(verb: &'static str, rest: &[String]) -> Result<()> {
+    let token = first_name(rest);
+    let mut msg = format!(
+        "error: removed-in-1.0: {verb}\n`zskills {verb}` was removed in 1.0.\n{}",
+        doors(verb)
+    );
+    if let Some(name) = token {
+        if let Some(hint) = live_hint(name) {
+            msg.push('\n');
+            msg.push_str(&hint);
+        }
+    }
+    Err(RemovedVerb { message: msg }.into())
+}
+
+fn first_name(rest: &[String]) -> Option<&str> {
+    rest.iter()
+        .map(String::as_str)
+        .find(|a| !a.starts_with('-'))
+}
+
+fn doors(verb: &str) -> String {
+    match verb {
+        "install" => {
+            "  plugin:      zskills plugin install <name@marketplace>\n  agent-skill: zskills agent-skill install <owner/repo>\n  mcp:         zskills mcp add <name>".into()
+        }
+        "remove" => {
+            "  plugin:      zskills plugin remove <name@marketplace>\n  agent-skill: zskills agent-skill remove <name>\n  mcp:         zskills mcp remove <name> [--scope user|project|local]".into()
+        }
+        "purge" => "  plugin:      zskills plugin purge <name@marketplace>".into(),
+        "enable" => "  plugin:      zskills plugin enable <name@marketplace>".into(),
+        "disable" => "  plugin:      zskills plugin disable <name@marketplace>".into(),
+        "update" => "  marketplace: zskills marketplace update [name]".into(),
+        "upgrade" => {
+            "  agent-skill: zskills agent-skill upgrade [name]\n  marketplace: zskills marketplace update [name]".into()
+        }
+        _ => String::new(),
+    }
+}
+
+fn live_hint(name: &str) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    if let Ok(settings) = crate::paths::settings_json().and_then(|p| crate::settings::load(&p)) {
+        if let Some(ep) = crate::settings::enabled_plugins(&settings) {
+            let hits: Vec<&String> = ep
+                .keys()
+                .filter(|k| *k == name || k.starts_with(&format!("{name}@")))
+                .collect();
+            for k in hits {
+                lines.push(format!(
+                    "  plugin      {k}    → zskills plugin remove {k}      (keeps bytes)"
+                ));
+            }
+        }
+    }
+    if let Ok(inv) = crate::agent_skill::load_inventory() {
+        if inv.agent_skills.contains_key(name) {
+            lines.push(format!(
+                "  agent-skill {name}                 → zskills agent-skill remove {name} (DELETES bytes)"
+            ));
+        }
+    }
+    if let Ok(mcps) = crate::mcp::load_all() {
+        for m in mcps.iter().filter(|m| m.name == name) {
+            lines.push(format!(
+                "  mcp         {name} ({})     → zskills mcp remove {name} --scope {}",
+                m.scope.label(),
+                m.scope.label()
+            ));
+        }
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "`{name}` currently exists in {} of your namespaces:\n{}",
+        lines.len(),
+        lines.join("\n")
+    ))
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -6,7 +6,13 @@ use serde_json::Value;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Result<()> {
+pub fn run(
+    file: Option<PathBuf>,
+    dry_run: bool,
+    prune: bool,
+    adopt: bool,
+    force: bool,
+) -> Result<()> {
     // Warn loudly if a `./skills.toml` exists and the user didn't pass --file.
     if file.is_none() {
         if let Some(cwd_path) = crate::manifest::cwd_skills_toml() {
@@ -61,6 +67,14 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Re
 
     let plugins_to_enable: Vec<_> = desired_plugins.difference(&current_plugins).collect();
     let plugins_to_disable: Vec<_> = current_plugins.difference(&desired_plugins).collect();
+    let skip_plugin_diff = desired_plugins.is_empty() && !current_plugins.is_empty() && !force;
+    if skip_plugin_diff {
+        eprintln!(
+            "{} skipping plugin reconcile: manifest has no [[skills]] ({} enabled); pass --force to disable extras",
+            "!".yellow(),
+            current_plugins.len()
+        );
+    }
 
     // -------- 2) Agent Skills reconciliation --------
     // The manifest carries (source, optional name). We need to compare against the inventory,
@@ -390,14 +404,16 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Re
     }
 
     // -------- 4) Apply --------
-    let ep = crate::settings::enabled_plugins_mut(&mut settings);
-    for k in &plugins_to_enable {
-        ep.insert((*k).clone(), Value::Bool(true));
+    if !skip_plugin_diff {
+        let ep = crate::settings::enabled_plugins_mut(&mut settings);
+        for k in &plugins_to_enable {
+            ep.insert((*k).clone(), Value::Bool(true));
+        }
+        for k in &plugins_to_disable {
+            ep.insert((*k).clone(), Value::Bool(false));
+        }
+        crate::settings::save(&settings_path, &settings)?;
     }
-    for k in &plugins_to_disable {
-        ep.insert((*k).clone(), Value::Bool(false));
-    }
-    crate::settings::save(&settings_path, &settings)?;
 
     for entry in &manifest.agent_skills {
         if let Some(pkg) = entry.npm.as_deref() {
@@ -560,10 +576,15 @@ pub fn run(file: Option<PathBuf>, dry_run: bool, prune: bool, adopt: bool) -> Re
     }
     if prune {
         for (scope, name) in &mcps_to_remove {
-            if let Err(e) = crate::mcp::remove(scope, name) {
-                eprintln!("{} mcp `{}`: {}", "✗".red(), name, e);
-            } else {
-                println!("  removed mcp {} ({})", name.bold(), scope.label());
+            match crate::mcp::remove(scope, name) {
+                Ok(true) => println!("  removed mcp {} ({})", name.bold(), scope.label()),
+                Ok(false) => eprintln!(
+                    "{} mcp `{}` ({}) not found in the attributed file",
+                    "✗".red(),
+                    name,
+                    scope.label()
+                ),
+                Err(e) => eprintln!("{} mcp `{}`: {}", "✗".red(), name, e),
             }
         }
     }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use owo_colors::OwoColorize;
 
+#[allow(dead_code)] // folded into `marketplace update`; kept for the all-tap refresh print
 pub fn run(_skills: Vec<String>) -> Result<()> {
     // Refresh every marketplace; Claude Code itself handles version negotiation.
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,19 @@
 use thiserror::Error;
 
+/// Hidden stub for a verb removed in 1.0. `main` maps this to exit 2.
+#[derive(Debug)]
+pub struct RemovedVerb {
+    pub message: String,
+}
+
+impl std::fmt::Display for RemovedVerb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RemovedVerb {}
+
 #[derive(Debug, Error)]
 #[allow(dead_code)]
 pub enum Error {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,19 @@ mod skills_sh;
 mod timestamp;
 
 use clap::Parser;
+use std::process::ExitCode;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> ExitCode {
     let cli = cli::Cli::parse();
-    cli.run()
+    match cli.run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("{e:#}");
+            if e.downcast_ref::<error::RemovedVerb>().is_some() {
+                ExitCode::from(2)
+            } else {
+                ExitCode::FAILURE
+            }
+        }
+    }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -503,6 +503,189 @@ pub fn append_mcp(path: &Path, entry: &McpEntry) -> Result<bool> {
     Ok(true)
 }
 
+fn mcp_table_scope(t: &toml_edit::Table) -> String {
+    t.get("scope")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| "user".into())
+}
+
+fn write_mcp_table(t: &mut toml_edit::Table, entry: &McpEntry) {
+    use toml_edit::{value, Array, InlineTable};
+    t["name"] = value(&entry.name);
+    match entry.scope.as_deref() {
+        Some(s) if s != "user" => t["scope"] = value(s),
+        _ => {
+            t.remove("scope");
+        }
+    }
+    if let Some(transport) = &entry.transport {
+        t["transport"] = value(transport);
+    } else {
+        t.remove("transport");
+    }
+    if let Some(c) = &entry.command {
+        t["command"] = value(c);
+    } else {
+        t.remove("command");
+    }
+    if !entry.args.is_empty() {
+        let mut arr = Array::new();
+        for a in &entry.args {
+            arr.push(a.as_str());
+        }
+        t["args"] = value(arr);
+    } else {
+        t.remove("args");
+    }
+    if !entry.env.is_empty() {
+        let mut tbl = InlineTable::new();
+        for (k, v) in &entry.env {
+            tbl.insert(k, v.as_str().into());
+        }
+        t["env"] = value(tbl);
+    } else {
+        t.remove("env");
+    }
+    if let Some(u) = &entry.url {
+        t["url"] = value(u);
+    } else {
+        t.remove("url");
+    }
+    if !entry.headers.is_empty() {
+        let mut tbl = InlineTable::new();
+        for (k, v) in &entry.headers {
+            tbl.insert(k, v.as_str().into());
+        }
+        t["headers"] = value(tbl);
+    } else {
+        t.remove("headers");
+    }
+}
+
+/// Replace or insert an `[[mcps]]` row for `(name, scope)`. Returns `"added"` or `"updated"`.
+pub fn upsert_mcp(path: &Path, entry: &McpEntry) -> Result<&'static str> {
+    use toml_edit::{ArrayOfTables, DocumentMut, Item, Table};
+
+    let raw = if path.exists() {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("reading manifest {}", path.display()))?
+    } else {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        String::new()
+    };
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
+
+    let new_scope = entry.scope.clone().unwrap_or_else(|| "user".into());
+    let mut found = None;
+    if let Some(Item::ArrayOfTables(existing)) = doc.get("mcps") {
+        for (i, t) in existing.iter().enumerate() {
+            let name = t.get("name").and_then(|v| v.as_str());
+            if name == Some(&entry.name) && mcp_table_scope(t) == new_scope {
+                found = Some(i);
+                break;
+            }
+        }
+    }
+
+    let aot = match doc
+        .entry("mcps")
+        .or_insert(Item::ArrayOfTables(ArrayOfTables::new()))
+    {
+        Item::ArrayOfTables(a) => a,
+        slot => {
+            *slot = Item::ArrayOfTables(ArrayOfTables::new());
+            match slot {
+                Item::ArrayOfTables(a) => a,
+                _ => unreachable!(),
+            }
+        }
+    };
+
+    if let Some(i) = found {
+        write_mcp_table(aot.get_mut(i).expect("index from scan"), entry);
+        std::fs::write(path, doc.to_string())
+            .with_context(|| format!("writing manifest {}", path.display()))?;
+        return Ok("updated");
+    }
+
+    let mut t = Table::new();
+    write_mcp_table(&mut t, entry);
+    aot.push(t);
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok("added")
+}
+
+/// Drop the `[[mcps]]` row whose `(name, scope)` matches. Missing `scope` counts as user.
+pub fn drop_mcp(path: &Path, name: &str, scope: &str) -> Result<bool> {
+    use toml_edit::{DocumentMut, Item};
+
+    if !path.exists() {
+        return Ok(false);
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading manifest {}", path.display()))?;
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
+
+    let Some(Item::ArrayOfTables(aot)) = doc.get_mut("mcps") else {
+        return Ok(false);
+    };
+    let mut idx = None;
+    for (i, t) in aot.iter().enumerate() {
+        let n = t.get("name").and_then(|v| v.as_str());
+        if n == Some(name) && mcp_table_scope(t) == scope {
+            idx = Some(i);
+            break;
+        }
+    }
+    let Some(i) = idx else {
+        return Ok(false);
+    };
+    aot.remove(i);
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(true)
+}
+
+/// Drop a named `[[agent_skills]]` row. Source-only rows (no `name`) are left alone.
+pub fn drop_named_agent_skill(path: &Path, name: &str) -> Result<bool> {
+    use toml_edit::{DocumentMut, Item};
+
+    if !path.exists() {
+        return Ok(false);
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading manifest {}", path.display()))?;
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
+
+    let Some(Item::ArrayOfTables(aot)) = doc.get_mut("agent_skills") else {
+        return Ok(false);
+    };
+    let mut idx = None;
+    for (i, t) in aot.iter().enumerate() {
+        if t.get("name").and_then(|v| v.as_str()) == Some(name) {
+            idx = Some(i);
+            break;
+        }
+    }
+    let Some(i) = idx else {
+        return Ok(false);
+    };
+    aot.remove(i);
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod marketplace_pin_tests {
     use super::*;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -508,14 +508,47 @@ pub fn upsert(scope: &Scope, name: &str, entry: serde_json::Value) -> Result<()>
     })
 }
 
-/// Remove one MCP server entry from the target file for `scope`. Atomic.
-/// No-op if the entry isn't present.
-pub fn remove(scope: &Scope, name: &str) -> Result<()> {
-    let (path, wrapped) = write_target(scope)?;
+/// Remove one MCP server at `scope` from the file `load_all` attributed it to.
+/// Returns `Ok(true)` if at least one JSON key was deleted.
+/// Returns `Ok(false)` if no matching Manual entry exists at that scope.
+/// Refuses `FromPlugin` and `managed`.
+pub fn remove(scope: &Scope, name: &str) -> Result<bool> {
+    if *scope == Scope::Managed {
+        anyhow::bail!("cannot write to managed scope — deployed by IT, not zskills");
+    }
+    let all = load_all().unwrap_or_default();
+    let hits: Vec<&McpServer> = all
+        .iter()
+        .filter(|m| m.scope == *scope && m.name == name)
+        .collect();
+    if hits.is_empty() {
+        return Ok(false);
+    }
+    let mut deleted = false;
+    for m in hits {
+        match &m.source {
+            Source::FromPlugin { plugin } => anyhow::bail!(
+                "MCP '{name}' at scope {} is provided by plugin {plugin}",
+                scope.label()
+            ),
+            Source::Manual => {
+                delete_key_from_file(&m.source_file, name)?;
+                deleted = true;
+            }
+        }
+    }
+    Ok(deleted)
+}
+
+fn delete_key_from_file(path: &Path, name: &str) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }
-    write_with_mutation(&path, wrapped, |servers| {
+    let wrapped = match read_json(path) {
+        Some(v) => v.get("mcpServers").is_some(),
+        None => true,
+    };
+    write_with_mutation(path, wrapped, |servers| {
         servers.shift_remove(name);
     })
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -497,7 +497,7 @@ fn upgrade_runs_without_marketplaces_or_manifest() {
     // "Upgrade complete" line.
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "upgrade"])
+        .args(["skill", "upgrade"])
         .assert()
         .success()
         .stdout(predicates::str::contains("Upgrade complete"));
@@ -1120,7 +1120,7 @@ fn install_repo_root_skill_is_sparse() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "install", &file_url(&repo)])
+        .args(["skill", "install", &file_url(&repo)])
         .assert()
         .success();
 
@@ -1155,7 +1155,7 @@ fn install_skill_flag_selects_single_skill() {
     let home = fake_home();
     zskills(&home)
         .args([
-            "agent-skill",
+            "skill",
             "install",
             &file_url(upstream.path()),
             "--skill",
@@ -1179,7 +1179,7 @@ fn install_skill_flag_unknown_name_errors() {
     let home = fake_home();
     let out = zskills(&home)
         .args([
-            "agent-skill",
+            "skill",
             "install",
             &file_url(upstream.path()),
             "--skill",
@@ -1203,14 +1203,7 @@ fn install_skill_flag_unknown_name_errors() {
 fn install_skill_flag_conflicts_with_all() {
     let home = fake_home();
     zskills(&home)
-        .args([
-            "agent-skill",
-            "install",
-            "owner/repo",
-            "--skill",
-            "x",
-            "--all",
-        ])
+        .args(["skill", "install", "owner/repo", "--skill", "x", "--all"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("cannot be used with"));
@@ -1227,7 +1220,7 @@ fn install_skill_flag_bypasses_large_collection_policy() {
     let home = fake_home();
     zskills(&home)
         .args([
-            "agent-skill",
+            "skill",
             "install",
             &file_url(upstream.path()),
             "--skill",
@@ -1297,7 +1290,7 @@ fn install_repo_single_skill_auto_installs() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("alpha"));
@@ -1320,7 +1313,7 @@ fn install_repo_small_multi_installs_all() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         .success();
 
@@ -1347,7 +1340,7 @@ fn install_repo_large_collection_aborts_without_all() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("won't install all"))
@@ -1376,12 +1369,7 @@ fn install_repo_large_collection_with_all_installs_everything() {
 
     let home = fake_home();
     zskills(&home)
-        .args([
-            "agent-skill",
-            "install",
-            &file_url(upstream.path()),
-            "--all",
-        ])
+        .args(["skill", "install", &file_url(upstream.path()), "--all"])
         .assert()
         .success();
 
@@ -1411,7 +1399,7 @@ fn install_repo_marketplace_redirects() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("marketplace"))
@@ -1440,7 +1428,7 @@ fn install_repo_mcp_hint_appears_alongside_skill_install() {
 
     let home = fake_home();
     let out = zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .get_output()
@@ -1465,7 +1453,7 @@ fn install_repo_with_no_skills_errors() {
 
     let home = fake_home();
     let out = zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         // A failed install exits non-zero: the error is on stderr *and* in $?.
         .failure()
@@ -2243,10 +2231,7 @@ fn upgrade_holds_a_pinned_marketplace() {
         "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v1\"\n",
     );
 
-    zskills(&home)
-        .args(["agent-skill", "upgrade"])
-        .assert()
-        .success();
+    zskills(&home).args(["skill", "upgrade"]).assert().success();
 
     assert_eq!(marketplace_head(&home, "pinned-mp"), v1);
     assert_ne!(marketplace_head(&home, "pinned-mp"), head);
@@ -2679,7 +2664,7 @@ fn install_skill_flag_selects_from_dot_agents_skills() {
     let home = fake_home();
     zskills(&home)
         .args([
-            "agent-skill",
+            "skill",
             "install",
             &file_url(upstream.path()),
             "--skill",
@@ -2710,7 +2695,7 @@ fn a_large_dot_agents_skills_tree_still_requires_skill_or_all() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["agent-skill", "install", &file_url(upstream.path())])
+        .args(["skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("14"))
@@ -2733,7 +2718,7 @@ fn install_reports_available_names_from_dot_agents_skills_when_skill_is_unknown(
     let home = fake_home();
     let out = zskills(&home)
         .args([
-            "agent-skill",
+            "skill",
             "install",
             &file_url(upstream.path()),
             "--skill",
@@ -2771,13 +2756,7 @@ fn upgrade_refreshes_only_skills_already_owned_from_a_source() {
     let home = fake_home();
     // Own exactly one skill from that source.
     zskills(&home)
-        .args([
-            "agent-skill",
-            "install",
-            &file_url(&repo),
-            "--skill",
-            "owned",
-        ])
+        .args(["skill", "install", &file_url(&repo), "--skill", "owned"])
         .assert()
         .success();
     assert!(home.path().join("skills/owned").exists());
@@ -2790,10 +2769,7 @@ fn upgrade_refreshes_only_skills_already_owned_from_a_source() {
     )
     .unwrap();
 
-    zskills(&home)
-        .args(["agent-skill", "upgrade"])
-        .assert()
-        .success();
+    zskills(&home).args(["skill", "upgrade"]).assert().success();
 
     assert!(
         home.path().join("skills/owned").exists(),
@@ -2817,6 +2793,7 @@ fn bare_remove_stub_exits_2_and_names_typed_replacement() {
         .failure()
         .code(2)
         .stderr(predicate::str::contains("error: removed-in-1.0: remove"))
+        .stderr(predicate::str::contains("zskills skill remove"))
         .stderr(predicate::str::contains("zskills mcp remove"));
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -130,7 +130,7 @@ fn list_json_reports_active_and_orphan() {
 fn enable_disable_flips_settings_without_clobbering_other_fields() {
     let home = fake_home();
     zskills(&home)
-        .args(["disable", "foo@test-mp"])
+        .args(["plugin", "disable", "foo@test-mp"])
         .assert()
         .success();
     let s: serde_json::Value =
@@ -140,7 +140,7 @@ fn enable_disable_flips_settings_without_clobbering_other_fields() {
     assert!(s["hooks"].is_object()); // preserved
 
     zskills(&home)
-        .args(["enable", "foo@test-mp"])
+        .args(["plugin", "enable", "foo@test-mp"])
         .assert()
         .success();
     let s: serde_json::Value =
@@ -497,7 +497,7 @@ fn upgrade_runs_without_marketplaces_or_manifest() {
     // "Upgrade complete" line.
     let home = fake_home();
     zskills(&home)
-        .args(["upgrade"])
+        .args(["agent-skill", "upgrade"])
         .assert()
         .success()
         .stdout(predicates::str::contains("Upgrade complete"));
@@ -549,7 +549,7 @@ fn doctor_detects_orphan_and_fixes_it() {
 fn install_interactive_flag_in_help() {
     let home = fake_home();
     zskills(&home)
-        .args(["install", "--help"])
+        .args(["plugin", "install", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains("-i"))
@@ -571,7 +571,7 @@ fn search_interactive_flag_in_help() {
 fn remove_interactive_flag_in_help() {
     let home = fake_home();
     zskills(&home)
-        .args(["remove", "--help"])
+        .args(["plugin", "remove", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains("-i"))
@@ -1120,7 +1120,7 @@ fn install_repo_root_skill_is_sparse() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(&repo)])
+        .args(["agent-skill", "install", &file_url(&repo)])
         .assert()
         .success();
 
@@ -1154,7 +1154,13 @@ fn install_skill_flag_selects_single_skill() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path()), "--skill", "beta"])
+        .args([
+            "agent-skill",
+            "install",
+            &file_url(upstream.path()),
+            "--skill",
+            "beta",
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("beta"));
@@ -1172,7 +1178,13 @@ fn install_skill_flag_unknown_name_errors() {
 
     let home = fake_home();
     let out = zskills(&home)
-        .args(["install", &file_url(upstream.path()), "--skill", "nope"])
+        .args([
+            "agent-skill",
+            "install",
+            &file_url(upstream.path()),
+            "--skill",
+            "nope",
+        ])
         .assert()
         .failure()
         .get_output()
@@ -1191,7 +1203,14 @@ fn install_skill_flag_unknown_name_errors() {
 fn install_skill_flag_conflicts_with_all() {
     let home = fake_home();
     zskills(&home)
-        .args(["install", "owner/repo", "--skill", "x", "--all"])
+        .args([
+            "agent-skill",
+            "install",
+            "owner/repo",
+            "--skill",
+            "x",
+            "--all",
+        ])
         .assert()
         .failure()
         .stderr(predicate::str::contains("cannot be used with"));
@@ -1207,7 +1226,13 @@ fn install_skill_flag_bypasses_large_collection_policy() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path()), "--skill", "skill-3"])
+        .args([
+            "agent-skill",
+            "install",
+            &file_url(upstream.path()),
+            "--skill",
+            "skill-3",
+        ])
         .assert()
         .success();
 
@@ -1272,7 +1297,7 @@ fn install_repo_single_skill_auto_installs() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("alpha"));
@@ -1295,7 +1320,7 @@ fn install_repo_small_multi_installs_all() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         .success();
 
@@ -1322,7 +1347,7 @@ fn install_repo_large_collection_aborts_without_all() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("won't install all"))
@@ -1351,7 +1376,12 @@ fn install_repo_large_collection_with_all_installs_everything() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path()), "--all"])
+        .args([
+            "agent-skill",
+            "install",
+            &file_url(upstream.path()),
+            "--all",
+        ])
         .assert()
         .success();
 
@@ -1381,7 +1411,7 @@ fn install_repo_marketplace_redirects() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("marketplace"))
@@ -1410,7 +1440,7 @@ fn install_repo_mcp_hint_appears_alongside_skill_install() {
 
     let home = fake_home();
     let out = zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .get_output()
@@ -1435,7 +1465,7 @@ fn install_repo_with_no_skills_errors() {
 
     let home = fake_home();
     let out = zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         // A failed install exits non-zero: the error is on stderr *and* in $?.
         .failure()
@@ -1699,7 +1729,7 @@ fn install_plugin_invokes_claude_to_fetch_the_bytes() {
     zskills(&home)
         .env_remove("ZSKILLS_NO_CLAUDE_CLI")
         .env("ZSKILLS_CLAUDE_BIN", &stub)
-        .args(["install", "vercel@vercel-plugin"])
+        .args(["plugin", "install", "vercel@vercel-plugin"])
         .assert()
         .success()
         .stdout(predicate::str::contains("fetched vercel@vercel-plugin"));
@@ -1731,7 +1761,7 @@ fn install_plugin_reports_pending_when_claude_cli_is_missing() {
 
     // ZSKILLS_NO_CLAUDE_CLI=1 is already set by the helper.
     zskills(&home)
-        .args(["install", "vercel@vercel-plugin"])
+        .args(["plugin", "install", "vercel@vercel-plugin"])
         .assert()
         // The plugin genuinely is not installed, so the exit code says so too.
         .failure()
@@ -1763,7 +1793,7 @@ fn install_plugin_does_not_claim_success_when_the_fetch_fails() {
     zskills(&home)
         .env_remove("ZSKILLS_NO_CLAUDE_CLI")
         .env("ZSKILLS_CLAUDE_BIN", &stub)
-        .args(["install", "vercel@vercel-plugin"])
+        .args(["plugin", "install", "vercel@vercel-plugin"])
         .assert()
         .failure()
         .stdout(predicate::str::contains("enabled but not installed"))
@@ -1947,7 +1977,7 @@ fn install_does_not_trust_a_zero_exit_without_bytes() {
     zskills(&home)
         .env_remove("ZSKILLS_NO_CLAUDE_CLI")
         .env("ZSKILLS_CLAUDE_BIN", &stub)
-        .args(["install", "vercel@vercel-plugin"])
+        .args(["plugin", "install", "vercel@vercel-plugin"])
         .assert()
         .stdout(predicate::str::contains("fetched vercel@vercel-plugin").not())
         .stdout(predicate::str::contains("installed and ready").not())
@@ -1972,7 +2002,7 @@ fn install_kills_a_hanging_claude_instead_of_waiting_forever() {
         .env_remove("ZSKILLS_NO_CLAUDE_CLI")
         .env("ZSKILLS_CLAUDE_BIN", &stub)
         .env("ZSKILLS_CLAUDE_TIMEOUT_SECS", "1")
-        .args(["install", "vercel@vercel-plugin"])
+        .args(["plugin", "install", "vercel@vercel-plugin"])
         .assert()
         .stderr(predicate::str::contains("timed out"));
     assert!(
@@ -1995,7 +2025,7 @@ fn install_rejects_a_plugin_no_marketplace_offers_instead_of_writing_a_bogus_ena
     );
 
     zskills(&home)
-        .args(["install", "bogus@no-such-mp"])
+        .args(["plugin", "install", "bogus@no-such-mp"])
         .assert()
         .failure()
         .stdout(predicate::str::contains("+ bogus@no-such-mp").not());
@@ -2024,7 +2054,7 @@ fn install_exits_non_zero_when_the_fetch_fails() {
     zskills(&home)
         .env_remove("ZSKILLS_NO_CLAUDE_CLI")
         .env("ZSKILLS_CLAUDE_BIN", &stub)
-        .args(["install", "vercel@vercel-plugin"])
+        .args(["plugin", "install", "vercel@vercel-plugin"])
         .assert()
         .failure();
 }
@@ -2183,7 +2213,7 @@ fn update_holds_a_pinned_marketplace_and_floats_an_unpinned_one() {
     );
 
     zskills(&home)
-        .args(["update"])
+        .args(["marketplace", "update"])
         .assert()
         .success()
         .stdout(predicate::str::contains("pinned @"));
@@ -2213,7 +2243,10 @@ fn upgrade_holds_a_pinned_marketplace() {
         "[[marketplaces]]\nname = \"pinned-mp\"\npin = \"v1\"\n",
     );
 
-    zskills(&home).args(["upgrade"]).assert().success();
+    zskills(&home)
+        .args(["agent-skill", "upgrade"])
+        .assert()
+        .success();
 
     assert_eq!(marketplace_head(&home, "pinned-mp"), v1);
     assert_ne!(marketplace_head(&home, "pinned-mp"), head);
@@ -2257,7 +2290,10 @@ fn a_pin_accepts_a_full_sha() {
         &format!("[[marketplaces]]\nname = \"pinned-mp\"\npin = \"{}\"\n", v1),
     );
 
-    zskills(&home).args(["update"]).assert().success();
+    zskills(&home)
+        .args(["marketplace", "update"])
+        .assert()
+        .success();
     assert_eq!(marketplace_head(&home, "pinned-mp"), v1);
 }
 
@@ -2275,7 +2311,7 @@ fn an_unresolvable_pin_fails_and_never_falls_back_to_a_pull() {
     );
 
     zskills(&home)
-        .args(["update"])
+        .args(["marketplace", "update"])
         .assert()
         .success()
         .stdout(predicate::str::contains("does not exist"));
@@ -2299,7 +2335,10 @@ fn a_blank_pin_is_treated_as_unpinned() {
         "[[marketplaces]]\nname = \"free-mp\"\npin = \"   \"\n",
     );
 
-    zskills(&home).args(["update"]).assert().success();
+    zskills(&home)
+        .args(["marketplace", "update"])
+        .assert()
+        .success();
     assert_eq!(
         marketplace_head(&home, "free-mp"),
         head,
@@ -2394,7 +2433,7 @@ fn a_pin_resolves_even_when_upstream_moved_a_tag() {
     );
 
     zskills(&home)
-        .args(["update"])
+        .args(["marketplace", "update"])
         .assert()
         .success()
         .stdout(predicate::str::contains("would clobber").not());
@@ -2640,6 +2679,7 @@ fn install_skill_flag_selects_from_dot_agents_skills() {
     let home = fake_home();
     zskills(&home)
         .args([
+            "agent-skill",
             "install",
             &file_url(upstream.path()),
             "--skill",
@@ -2670,7 +2710,7 @@ fn a_large_dot_agents_skills_tree_still_requires_skill_or_all() {
 
     let home = fake_home();
     zskills(&home)
-        .args(["install", &file_url(upstream.path())])
+        .args(["agent-skill", "install", &file_url(upstream.path())])
         .assert()
         .success()
         .stdout(predicate::str::contains("14"))
@@ -2692,7 +2732,13 @@ fn install_reports_available_names_from_dot_agents_skills_when_skill_is_unknown(
 
     let home = fake_home();
     let out = zskills(&home)
-        .args(["install", &file_url(upstream.path()), "--skill", "nope"])
+        .args([
+            "agent-skill",
+            "install",
+            &file_url(upstream.path()),
+            "--skill",
+            "nope",
+        ])
         .assert()
         .failure()
         .get_output()
@@ -2725,7 +2771,13 @@ fn upgrade_refreshes_only_skills_already_owned_from_a_source() {
     let home = fake_home();
     // Own exactly one skill from that source.
     zskills(&home)
-        .args(["install", &file_url(&repo), "--skill", "owned"])
+        .args([
+            "agent-skill",
+            "install",
+            &file_url(&repo),
+            "--skill",
+            "owned",
+        ])
         .assert()
         .success();
     assert!(home.path().join("skills/owned").exists());
@@ -2738,7 +2790,10 @@ fn upgrade_refreshes_only_skills_already_owned_from_a_source() {
     )
     .unwrap();
 
-    zskills(&home).arg("upgrade").assert().success();
+    zskills(&home)
+        .args(["agent-skill", "upgrade"])
+        .assert()
+        .success();
 
     assert!(
         home.path().join("skills/owned").exists(),
@@ -2751,4 +2806,78 @@ fn upgrade_refreshes_only_skills_already_owned_from_a_source() {
             unwanted
         );
     }
+}
+
+#[test]
+fn bare_remove_stub_exits_2_and_names_typed_replacement() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["remove", "honcho"])
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("error: removed-in-1.0: remove"))
+        .stderr(predicate::str::contains("zskills mcp remove"));
+}
+
+#[test]
+fn plugin_remove_unknown_name_does_not_print_success() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["plugin", "remove", "this-does-not-exist-xyz123"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is not installed"));
+}
+
+#[test]
+fn mcp_add_and_remove_write_intent_then_runtime() {
+    let (parent, claude_home) = fake_home_nested();
+    let manifest_dir = parent.path().join("config").join("zskills");
+    fs::create_dir_all(&manifest_dir).unwrap();
+    let manifest = manifest_dir.join("skills.toml");
+    fs::write(&manifest, "").unwrap();
+    let claude_json = parent.path().join(".claude.json");
+    fs::write(&claude_json, r#"{"mcpServers":{}}"#).unwrap();
+
+    zskills_nested(&parent, &claude_home)
+        .args([
+            "mcp",
+            "add",
+            "honcho",
+            "--url",
+            "https://mcp.honcho.dev",
+            "--transport",
+            "http",
+            "--file",
+            manifest.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let toml = fs::read_to_string(&manifest).unwrap();
+    assert!(toml.contains("name = \"honcho\""));
+    let json: serde_json::Value = serde_json::from_slice(&fs::read(&claude_json).unwrap()).unwrap();
+    assert_eq!(
+        json["mcpServers"]["honcho"]["url"],
+        "https://mcp.honcho.dev"
+    );
+
+    zskills_nested(&parent, &claude_home)
+        .args([
+            "mcp",
+            "remove",
+            "honcho",
+            "--file",
+            manifest.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("removed mcp"))
+        .stdout(predicate::str::contains("honcho"));
+
+    let toml = fs::read_to_string(&manifest).unwrap();
+    assert!(!toml.contains("name = \"honcho\""));
+    let json: serde_json::Value = serde_json::from_slice(&fs::read(&claude_json).unwrap()).unwrap();
+    assert!(json["mcpServers"].get("honcho").is_none());
 }


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `enhancement`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:big`
- [x] Area: `area:cli`, `area:docs`

## Summary
This PR is the 1.0 CLI cut.

`zskills` used one top-level verb for three kinds of object. `install` and `remove` mixed plugin, Agent Skill, and MCP server. A user who typed `zskills remove honcho` could run the wrong command.

The CLI now has three typed groups:

- `zskills plugin install|remove|purge|enable|disable`
- `zskills skill install|remove|upgrade`
- `zskills mcp add|remove`

Bare `install`, `remove`, `purge`, `enable`, `disable`, `update`, and `upgrade` stay in clap as hidden stubs. Each stub prints `error: removed-in-1.0: VERB`. It names the typed replacement. `main` maps `RemovedVerb` to exit 2.

The first commit is a library guard. That guard is a release blocker. `agent_skill::remove_from_user_dir` used to join the name onto `~/.agents/skills/` and call `remove_dir_all`. An empty name and `..` delete the skills tree. The guard rejects empty, `.`, `..`, and path separators before the delete. `remove()` now resolves presence first. A missing name returns `false` and does not delete.

`plugin remove` looks up `enabledPlugins` and the plugin inventory. A missing name fails with exit 1.

`mcp add` and `mcp remove` write `skills.toml` first. Then they write the runtime `mcpServers` map.

Docs in `README.md`, `docs/index.md`, `docs/commands.md`, and `docs/troubleshooting.md` show the typed groups.

This is a breaking change. Squash merge must keep the `feat!:` subject so `release-please` cuts 1.0.0. Do not edit `Cargo.toml` by hand. The crate version stays `0.9.0` until `release-please` bumps it.

The binary name stays `zskills` (D5).

## How It Works (diagram — REQUIRED)

A user command hits one of four paths. A bare verb never runs the old work. It exits 2 and names the typed group. A typed group writes one kind of object.

```mermaid
flowchart TD
  user[User command]
  user --> stub{Bare verb?}
  stub -->|yes| exit2[Exit 2 and name typed replacement]
  stub -->|plugin| p[plugin install remove purge enable disable]
  stub -->|skill| a[skill install remove upgrade]
  stub -->|mcp| m[mcp add remove]
  m --> intent[Write skills.toml first]
  intent --> runtime[Write runtime mcpServers]
  a --> guard[validate_skill_name then remove_dir_all]
```

### Hidden stubs

`src/cli.rs` keeps the old verbs. Each verb uses `hide`, `disable_help_flag`, and `trailing_var_arg`. `zskills remove --help` still hits the stub. It does not print old help.

`src/commands/stub.rs` builds the error. It prints `error: removed-in-1.0: VERB`. It lists the typed doors for that verb.

```
  plugin:      zskills plugin remove <name@marketplace>
  skill:       zskills skill remove <name>
  mcp:         zskills mcp remove <name> [--scope user|project|local]
```

If the user passed a name, the stub looks at live state. It checks `enabledPlugins`, the Agent Skill inventory, and `mcp::load_all`. When the name exists, it prints the matching typed command. Plugin remove keeps bytes. Agent Skill remove deletes bytes.

`src/main.rs` returns `ExitCode`. `RemovedVerb` maps to 2. Other errors map to 1.

### Plugin group

`plugin install` takes `name` or `name@marketplace`. It rejects `owner/repo`. It tells the user to run `zskills skill install`.

`plugin remove` calls `resolve_installed_plugin`. That helper looks at `enabledPlugins` and `installed_plugins.json` first. A name that is not installed fails. It does not print success. `plugin purge` is the same lookup, then it deletes recorded `installPath` bytes.

`plugin enable` and `plugin disable` flip `enabledPlugins` only.

### Agent Skill group

`skill install` takes `owner/repo` or a git URL. It rejects a marketplace plugin spec. It tells the user to run `zskills plugin install`.

`skill remove` deletes bytes under `~/.agents/skills/<name>/`. It also drops the inventory row in `.zskills.json`. Then it drops a named `[[agent_skills]]` row from `skills.toml` when a manifest exists.

Before the delete, `remove_one` runs three checks:

1. `validate_skill_name` rejects empty, `.`, `..`, and path separators.
2. A name shipped by an enabled plugin is refused unless `--force`.
3. A name owned by a source-only `[[agent_skills]]` row is refused unless `--force`.

`agent_skill::remove` now checks inventory and disk first. A missing name returns `false`. It does not call `remove_dir_all` on a neighbour. `sync --prune` inherits the same library check.

### MCP server group

`mcp add` builds a `McpEntry`. It validates transport. It writes `skills.toml` through `manifest::upsert_mcp`. Then it writes the runtime map through `mcp::upsert`. `--file` selects the manifest. `--scope` selects `user`, `project`, or `local`. `managed` is refused.

If no `skills.toml` is found, `mcp add` still writes runtime. It warns that the next `sync` cannot reproduce the entry.

`mcp remove` looks up the name in `mcp::load_all`. A missing name at the requested scope fails. A name that exists at another scope fails unless the user passed `--scope`. Then it drops the `[[mcps]]` row through `manifest::drop_mcp`. Then `mcp::remove` deletes the JSON key from the `source_file` that `load_all` attributed. `mcp::remove` returns `Result<bool>`. `false` means no Manual entry was deleted. A `FromPlugin` entry is refused.

Intent always writes first. Runtime writes second.

### `sync` and `doctor`

`sync` skips plugin mass-disable when `[[skills]]` is empty and plugins are still enabled. Pass `--force` to disable extras. `sync` uses the `mcp::remove` bool.

`doctor` now compares `[[mcps]]` intent with runtime Manual keys. A row in the manifest with no runtime key is a finding. A runtime Manual key with no `[[mcps]]` row is a finding. `--fix` does not write MCP server state.

`doctor` also warns if `~/.agents/skills/zskills/SKILL.md` still documents bare verbs. The in-repo `skills/zskills/SKILL.md` rewrite is not in this PR.

## Linked Issues / ADRs
- Resolves: none
- Part of: none
- Out of scope: #14, #19, #20. This PR does not fold those issues.

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

```
$ cargo fmt --check
# exit 0

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
# exit 0

$ cargo test
running 66 tests
test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests/cli.rs
running 86 tests
test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.60s
```

New coverage in this PR:

- `remove_from_user_dir_rejects_empty_dot_dotdot_and_traversal`
- `remove_resolves_presence_before_deleting_and_leaves_neighbours`
- `bare_remove_stub_exits_2_and_names_typed_replacement`
- `plugin_remove_unknown_name_does_not_print_success`
- `mcp_add_and_remove_write_intent_then_runtime`

Sandbox. `CLAUDE_HOME`, `AGENTS_HOME`, and `XDG_CONFIG_HOME` pointed at `/tmp/zs-sandbox-typed-crud`. `ZSKILLS_NO_CLAUDE_CLI=1`. Binary: `target/debug/zskills` from this branch.

```
===== BEFORE mcp add =====
-- skills.toml --
-- .claude.json --
{"mcpServers":{}}

===== mcp add honcho =====
✓ added [[mcps]] honcho (user) in /tmp/zs-sandbox-typed-crud/config/zskills/skills.toml
✓ applied mcp honcho (user)
exit=0

===== AFTER mcp add =====
-- skills.toml --
[[mcps]]
name = "honcho"
transport = "http"
url = "https://mcp.honcho.dev"
-- .claude.json --
{
  "mcpServers": {
    "honcho": {
      "type": "http",
      "url": "https://mcp.honcho.dev"
    }
  }
}

===== mcp remove honcho =====
- removed mcp honcho (user)
exit=0

===== AFTER mcp remove =====
-- skills.toml --
-- .claude.json --
{
  "mcpServers": {}
}

===== plugin remove missing name =====
✗ plugin 'this-does-not-exist-xyz123' is not installed
1 plugin remove(s) failed
exit=1

===== bare remove honcho (expect 2) =====
error: removed-in-1.0: remove
`zskills remove` was removed in 1.0.
  plugin:      zskills plugin remove <name@marketplace>
  skill:       zskills skill remove <name>
  mcp:         zskills mcp remove <name> [--scope user|project|local]
exit=2
```

Live machine after the sandbox:

```
$ ~/.cargo/bin/zskills --version
zskills 0.9.0
```

Live `~/.claude.json` still has `honcho` at `https://mcp.honcho.dev`. The sandbox add/remove did not touch that file. Do not run these verbs against a real `~/.claude`.

## Additional Notes for Reviewers
- Oldest commit is the O1 library guard (`16cf474`). That commit is a release blocker. Measured before the guard: empty name and `..` delete the skills tree.
- Binary name stays `zskills` (D5).
- Squash merge must keep `feat!:` in the subject so `release-please` cuts 1.0.0. Put this trailer on the squashed commit:

```
BREAKING CHANGE: Bare verbs install, remove, purge, enable, disable, update, upgrade no longer run. Typed replacements: zskills plugin <verb>, zskills skill <verb>, zskills mcp add|remove. Hidden stubs exit 2.
```

- `skills/zskills/SKILL.md` rewrite is waiting on an owner decision (not-yet-specified). `doctor` warns if that file still has bare verbs.
- `plugin remove` is fail-closed. A missing name is an error. It is not a no-op success.
- `skill remove` deletes bytes. `plugin remove` keeps bytes. The stub live-hint text says this.
- Do not fold #14, #19, or #20 into this PR.


