### PR TITLE
feat: name which harnesses can see a plugin or Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Existing tooling is per-runtime, per-language, and per-primitive: there's a Java
 ## Commands
 
 ```
-zskills list [-v]                              # plugins, Agent Skills, MCP servers
+zskills list [-v]                              # plugins, Agent Skills, MCP servers (prints which harnesses can see each name)
 zskills plugin install <name@marketplace>      # add to enabledPlugins
+zskills plugin install <name> --harness pi,grok  # copy nested skills/<name>/ into ~/.agents/skills/ (the shared hub)
 zskills plugin install -i                      # browse marketplace plugins
 zskills plugin remove  <name>                  # drop inventory, keep bytes
 zskills plugin purge   <name>                  # also delete bytes
@@ -106,9 +107,18 @@ The group `skill` writes `[[agent_skills]]`. The key `[[skills]]` is plugins.
 
 ```toml
 # Claude Code plugins (marketplace-based, controlled via enabledPlugins)
+[defaults]
+harnesses = ["claude", "pi", "hermes", "kimi", "grok", "codex"]
+mcp_harnesses = ["claude", "pi", "hermes", "kimi", "grok", "codex"]
+
 [[skills]]
 name = "umbrel-app"
 marketplace = "zot24-skills"
+
+[[skills]]
+name = "pi"
+marketplace = "zot24-skills"
+# harnesses = ["claude", "pi"]   # optional override; inherit [defaults].harnesses if omitted
 
 [[skills]]
 name = "github"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,11 +8,12 @@ Full reference for every `zskills` subcommand. Flags are shown with their defaul
 - `<name>` accepts the unqualified skill name (e.g. `servarr`) when unambiguous, or `name@marketplace` (e.g. `servarr@zot24-skills`) when multiple marketplaces declare the same skill. This matches Claude Code's own syntax.
 - Most commands print colored output. Set `NO_COLOR=1` to disable, or pipe through `cat` if you need plain text.
 - `CLAUDE_HOME=/custom/path` overrides `~/.claude` for testing.
+- `AGENTS_HOME` overrides `~/.agents`.
 - `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` are respected for manifest/cache locations.
 
 ## `list`
 
-What's currently installed, with each item's enabled/disabled/orphaned status. Covers both Claude Code plugins and Agent Skills.
+What's currently installed, with each item's enabled/disabled/orphaned status. Covers both Claude Code plugins and Agent Skills. Each plugin and Agent Skill line names which **harnesses** can see it: `claude`, `pi`, `hermes`, `kimi`, `grok`, `codex`. A Claude-only plugin is not a Pi install. Harnesses that have no cited skill root are listed as skipped (`unsupported`), not as present.
 
 ```
 zskills list [--json] [-v] [--paths]
@@ -41,12 +42,13 @@ Three accepted spec shapes:
 ```
 zskills plugin install <name>                       # plugin from a registered marketplace
 zskills plugin install <name>@<marketplace>         # qualified plugin
+zskills plugin install <name> --harness pi,grok     # copy nested skills/<name>/ into the shared Agent Skill hub
 zskills skill install <owner>/<repo>                # Agent Skill(s) from a git repo
 zskills skill install <git-url>                     # same, for https://, git@, file://
 zskills plugin install -i                           # interactive picker over marketplace plugins
 ```
 
-**Plugin path (`<name>` / `<name>@<marketplace>`).** Resolves against registered marketplaces, flips `enabledPlugins` in `~/.claude/settings.json`. Claude Code materializes bytes on next launch.
+**Plugin path (`<name>` / `<name>@<marketplace>`).** Resolves against registered marketplaces. `--harness` is a one-shot override of `[defaults].harnesses` (comma-separated: `claude`, `pi`, `hermes`, `kimi`, `grok`, `codex`). Missing `[defaults]` and missing `--harness` keep 1.0 behaviour: Claude only. `claude` in the set flips `enabledPlugins` in `~/.claude/settings.json` and materializes the marketplace plugin. `pi` / `grok` / `codex` copy each nested `skills/<name>/` tree into the shared hub `~/.agents/skills/<name>/` so `SKILL.md` sits at the scan root (those harnesses already scan the hub). Copies are real directories. Symlinks are refused. `hermes` and `kimi` print `unsupported` and do not invent a folder.
 
 **Repo path (`<owner>/<repo>` or git URL).** Clones the repo via `git clone --depth 1` into `~/.cache/zskills/agent-skills/<owner>-<repo>/`, surveys the tree, and:
 - **Agent Skills** (any directory under `skills/<name>/SKILL.md`) — installed to `~/.agents/skills/<name>/` (the cross-client convention; visible to Claude Code, Grok CLI, and any other compliant client). Inventory tagged with the source.
@@ -58,6 +60,7 @@ zskills plugin install -i                           # interactive picker over ma
 | `-i`, `--interactive` | off | For plugin specs: without any `<name>`, browse all marketplace plugins with a fuzzy picker. For repo specs: always opens a multi-select picker over the Agent Skills found in the repo. |
 | `--all` | off | For repo specs only: when the repo contains more than 5 Agent Skills, confirm "yes, install every one." Without `--all`, large collections abort with a sample summary so they don't silently flood `~/.agents/skills/`. Ignored for repos with ≤5 skills (those install everything by default). |
 | `--skill <name>` | none | For repo specs only: install exactly one skill by name (the manifest `name` field) — the non-interactive counterpart to `-i` for multi-skill repos. Bypasses the >5-skill size policy (the selection is explicit) and conflicts with `--all`. |
+| `--harness <list>` | `[defaults].harnesses`, or Claude only | Comma-separated harness names. One-shot override. Not `--to`. |
 
 **Repo-path count behavior**:
 
@@ -123,7 +126,7 @@ zskills sync [--file <path>] [--dry-run] [--prune | --adopt]
 | `--adopt` | off | Inverse of `--prune`. Append every orphan (installed agent skill, enabled plugin, configured MCP that isn't yet in the manifest) to `skills.toml` and exit. Useful for capturing a hand-curated environment into your manifest in one shot. Mutually exclusive with `--prune`. |
 
 What sync does:
-1. For each `[[skills]]` entry: resolve `name@marketplace`, write to `enabledPlugins`. Entries currently enabled but not in the manifest get flipped off.
+1. For each `[[skills]]` entry: resolve `name@marketplace`. If `harnesses` (or `[defaults].harnesses`) contains `claude`, write to `enabledPlugins`. Entries currently enabled but not in the manifest get flipped off. Hub-backed harnesses (`pi`, `grok`, `codex`) copy nested `skills/<name>/` trees into `~/.agents/skills/` in the same pass.
 2. For each `[[agent_skills]]` entry: if `source` is present, clone/pull and copy `skills/<name>/` to `~/.agents/skills/`. If `npm` is present, run `npm install -g --no-fund --no-audit <pkg>` (or `install_cmd`), then claim all matching `claims` globs. If neither is present (just `name`), register the existing on-disk skill in inventory without fetching anything.
 3. Agent skills tracked in inventory but missing from the manifest are reported. With `--prune` they're deleted; with `--adopt` they're appended to the manifest; otherwise they're skipped.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,10 @@ Requires `git` and (for npm-sourced skills) `npm` on `$PATH`.
 Create `~/.config/zskills/skills.toml`:
 
 ```toml
+[defaults]
+harnesses = ["claude", "pi", "hermes", "kimi", "grok", "codex"]
+mcp_harnesses = ["claude", "pi", "hermes", "kimi", "grok", "codex"]
+
 # Claude Code plugins (marketplace-based)
 [[skills]]
 name = "umbrel-app"
@@ -68,7 +72,7 @@ zskills marketplace add zot24/skills    # register additional taps as needed
 zskills search <query>                  # find skills across registered marketplaces
 zskills sync                            # apply the manifest
 zskills skill upgrade                   # refresh Agent Skills from origin
-zskills list                            # see what's installed
+zskills list                            # see what's installed (prints which harnesses can see each name)
 zskills doctor                          # reconcile disk ↔ inventory ↔ settings
 ```
 

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -27,6 +27,10 @@ pub struct Entry {
     pub source: String,
     pub installed_at: String,
     pub head_sha: String,
+    /// Scan roots this copy was written to (`agents`, `pi`, `project`).
+    /// Empty means today's default: `agents` only.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub to: Vec<String>,
 }
 
 pub fn load_inventory() -> Result<Inventory> {
@@ -193,12 +197,34 @@ fn collect_skills_under(root: &Path, out: &mut Vec<(String, PathBuf)>) {
 
 /// Copy a skill directory into ~/.agents/skills/<name>/ (deletes existing first).
 pub fn install_to_user_dir(skill_name: &str, src_dir: &Path) -> Result<()> {
-    let dest = crate::paths::user_skills_dir()?.join(skill_name);
-    if dest.exists() {
-        std::fs::remove_dir_all(&dest)?;
+    install_to_root(&crate::paths::user_skills_dir()?, skill_name, src_dir)
+}
+
+/// Copy a skill directory into `<root>/<name>/`. Replaces an existing directory
+/// or leftover symlink. Never creates a symlink.
+pub fn install_to_root(root: &Path, skill_name: &str, src_dir: &Path) -> Result<()> {
+    validate_skill_name(skill_name)?;
+    let dest = root.join(skill_name);
+    if let Ok(meta) = dest.symlink_metadata() {
+        if meta.file_type().is_symlink() {
+            std::fs::remove_file(&dest)
+                .with_context(|| format!("refusing to keep a symlink at {}", dest.display()))?;
+        } else if meta.is_dir() {
+            std::fs::remove_dir_all(&dest)?;
+        } else {
+            std::fs::remove_file(&dest)?;
+        }
     }
     std::fs::create_dir_all(&dest)?;
     copy_dir_recursive(src_dir, &dest)?;
+    anyhow::ensure!(
+        !dest
+            .symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false),
+        "install produced a symlink at {} — copies must be real directories",
+        dest.display()
+    );
     Ok(())
 }
 
@@ -209,8 +235,9 @@ const CONVENTIONAL_SKILL_DIRS: &[&str] = &["references", "assets", "scripts"];
 /// Sparse-install a **root-level** skill (SKILL.md at the repo root of a larger
 /// project): materialize only SKILL.md, the conventional skill dirs, and the
 /// relative paths SKILL.md references — never the whole source tree.
-pub fn install_root_skill_sparse(skill_name: &str, cache: &Path) -> Result<()> {
-    let dest = crate::paths::user_skills_dir()?.join(skill_name);
+pub fn install_root_skill_sparse_to(root: &Path, skill_name: &str, cache: &Path) -> Result<()> {
+    validate_skill_name(skill_name)?;
+    let dest = root.join(skill_name);
     if dest.exists() {
         std::fs::remove_dir_all(&dest)?;
     }
@@ -446,6 +473,7 @@ pub fn install_npm(
                 source: source_tag.clone(),
                 installed_at: now.clone(),
                 head_sha: pkg_version.clone(),
+                to: vec!["agents".into()],
             },
         );
     }
@@ -654,7 +682,7 @@ pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
         if src_dir == &cache {
             // Root-level SKILL.md in a larger project — materialize sparsely
             // instead of copying the whole source tree.
-            install_root_skill_sparse(skill_name, &cache)?;
+            install_root_skill_sparse_to(&crate::paths::user_skills_dir()?, skill_name, &cache)?;
         } else {
             install_to_user_dir(skill_name, src_dir)?;
         }
@@ -664,6 +692,7 @@ pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
                 source: source.to_string(),
                 installed_at: installed_at.clone(),
                 head_sha: head_sha.clone(),
+                to: vec!["agents".into()],
             },
         );
         installed_names.push(skill_name.clone());
@@ -685,6 +714,10 @@ pub fn remove(skill_name: &str) -> Result<bool> {
     remove_from_user_dir(skill_name)?;
     save_inventory(&inv)?;
     Ok(true)
+}
+
+pub(crate) fn inventory_now() -> String {
+    chrono_now_iso()
 }
 
 fn chrono_now_iso() -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,6 +218,15 @@ pub enum PluginCmd {
     Install {
         #[arg(short = 'i', long)]
         interactive: bool,
+        /// One-shot harness override (comma-separated): claude,pi,hermes,kimi,grok,codex.
+        /// Omitted: `[defaults].harnesses`, or Claude only when `[defaults]` is missing.
+        #[arg(
+            long = "harness",
+            value_delimiter = ',',
+            value_enum,
+            value_name = "HARNESS"
+        )]
+        harness: Vec<crate::harness::Harness>,
         skills: Vec<String>,
     },
     /// Drop enabledPlugins + inventory; keep bytes
@@ -258,6 +267,14 @@ pub enum AgentSkillCmd {
             help = "Install only this one skill out of the source"
         )]
         skill: Option<String>,
+        /// One-shot harness override (comma-separated). Omitted: `[defaults].harnesses`.
+        #[arg(
+            long = "harness",
+            value_delimiter = ',',
+            value_enum,
+            value_name = "HARNESS"
+        )]
+        harness: Vec<crate::harness::Harness>,
         #[arg(
             value_name = "SOURCE",
             help = "owner/repo, https://, git@ or file:// URL"
@@ -304,6 +321,14 @@ pub enum McpCmd {
         scope: String,
         #[arg(long)]
         file: Option<PathBuf>,
+        /// One-shot MCP harness override. Omitted: `[defaults].mcp_harnesses`.
+        #[arg(
+            long = "harness",
+            value_delimiter = ',',
+            value_enum,
+            value_name = "HARNESS"
+        )]
+        harness: Vec<crate::harness::Harness>,
     },
     /// Remove one MCP server from skills.toml and the runtime map
     Remove {
@@ -351,6 +376,7 @@ impl Cli {
                 PluginCmd::Install {
                     skills,
                     interactive,
+                    harness,
                 } => {
                     if skills
                         .iter()
@@ -360,7 +386,7 @@ impl Cli {
                             "plugin install takes name or name@marketplace; use `zskills skill install` for owner/repo"
                         );
                     }
-                    crate::commands::install::run(skills, interactive, false, None)
+                    crate::commands::install::run(skills, interactive, false, None, harness)
                 }
                 PluginCmd::Remove {
                     skills,
@@ -376,7 +402,10 @@ impl Cli {
                     interactive,
                     all,
                     skill,
-                } => crate::commands::agent_skills::install(skills, interactive, all, skill),
+                    harness,
+                } => {
+                    crate::commands::agent_skills::install(skills, interactive, all, skill, harness)
+                }
                 AgentSkillCmd::Remove { names, force, file } => {
                     crate::commands::agent_skills::remove(names, force, file)
                 }
@@ -396,6 +425,7 @@ impl Cli {
                     header,
                     scope,
                     file,
+                    harness,
                 } => crate::commands::mcp::add(
                     name,
                     transport,
@@ -406,6 +436,7 @@ impl Cli {
                     header,
                     Some(scope),
                     file,
+                    harness,
                 ),
                 McpCmd::Remove { name, scope, file } => {
                     crate::commands::mcp::remove(name, scope, file)

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -9,6 +9,7 @@ pub fn install(
     interactive: bool,
     all: bool,
     skill: Option<String>,
+    harness: Vec<crate::harness::Harness>,
 ) -> Result<()> {
     if specs
         .iter()
@@ -18,7 +19,7 @@ pub fn install(
             "skill install takes owner/repo or a git URL; use `zskills plugin install` for name@marketplace"
         );
     }
-    crate::commands::install::run(specs, interactive, all, skill)
+    crate::commands::install::run(specs, interactive, all, skill, harness)
 }
 
 pub fn upgrade(names: Vec<String>) -> Result<()> {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -17,9 +17,15 @@ use anyhow::Result;
 use owo_colors::OwoColorize;
 use serde_json::Value;
 
-pub fn run(specs: Vec<String>, interactive: bool, all: bool, skill: Option<String>) -> Result<()> {
+pub fn run(
+    specs: Vec<String>,
+    interactive: bool,
+    all: bool,
+    skill: Option<String>,
+    harness: Vec<crate::harness::Harness>,
+) -> Result<()> {
     if interactive && specs.is_empty() {
-        return run_interactive_browse_marketplaces();
+        return run_interactive_browse_marketplaces(harness);
     }
 
     if specs.is_empty() {
@@ -37,14 +43,14 @@ pub fn run(specs: Vec<String>, interactive: bool, all: bool, skill: Option<Strin
 
     let mut failures = 0usize;
     for spec in &repo_specs {
-        if let Err(e) = install_from_repo(spec, interactive, all, skill.as_deref()) {
+        if let Err(e) = install_from_repo(spec, interactive, all, skill.as_deref(), &harness) {
             eprintln!("{} {}: {}", "✗".red(), spec, e);
             failures += 1;
         }
     }
 
     if !plugin_specs.is_empty() {
-        failures += install_plugin_specs(plugin_specs)?;
+        failures += install_plugin_specs(plugin_specs, &harness)?;
     }
 
     // Printing an error and exiting 0 makes every failure invisible to `set -e`,
@@ -68,7 +74,20 @@ pub(crate) fn is_repo_spec(spec: &str) -> bool {
     spec.contains("://") || spec.starts_with("git@") || spec.contains('/')
 }
 
-fn install_from_repo(spec: &str, interactive: bool, all: bool, skill: Option<&str>) -> Result<()> {
+fn install_from_repo(
+    spec: &str,
+    interactive: bool,
+    all: bool,
+    skill: Option<&str>,
+    harness: &[crate::harness::Harness],
+) -> Result<()> {
+    let (defaults, _) = crate::harness::load_defaults();
+    let hs = crate::harness::resolve(harness, &defaults, &[], crate::harness::default_skill())?;
+    for h in &hs {
+        if let Some(reason) = h.skill_skip_reason() {
+            println!("  {} {}: {reason}", "·".dimmed(), h.as_str());
+        }
+    }
     println!("{} {}", "Surveying".dimmed(), spec.to_string().bold());
     let cache = crate::agent_skill::ensure_cache(spec)?;
     let survey = crate::repo_scanner::survey(&cache)?;
@@ -235,7 +254,7 @@ fn print_large_collection_summary(
     );
 }
 
-fn install_plugin_specs(specs: Vec<String>) -> Result<usize> {
+fn install_plugin_specs(specs: Vec<String>, harness: &[crate::harness::Harness]) -> Result<usize> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     if known.is_empty() {
         println!(
@@ -244,6 +263,12 @@ fn install_plugin_specs(specs: Vec<String>) -> Result<usize> {
         );
         return Ok(specs.len());
     }
+
+    let (defaults, _) = crate::harness::load_defaults();
+    let targets =
+        crate::harness::resolve(harness, &defaults, &[], crate::harness::default_plugin())?;
+    let want_claude = targets.contains(&crate::harness::Harness::Claude);
+    let want_hub = targets.iter().any(|h| h.hub_is_enough());
 
     let settings_path = crate::paths::settings_json()?;
     let mut settings = crate::settings::load(&settings_path)?;
@@ -254,8 +279,10 @@ fn install_plugin_specs(specs: Vec<String>) -> Result<usize> {
     for spec in &specs {
         match crate::marketplace::resolve_spec(spec, &known) {
             Ok(qualified) => {
-                let ep = crate::settings::enabled_plugins_mut(&mut settings);
-                ep.insert(qualified.clone(), Value::Bool(true));
+                if want_claude {
+                    let ep = crate::settings::enabled_plugins_mut(&mut settings);
+                    ep.insert(qualified.clone(), Value::Bool(true));
+                }
                 println!("{} {}", "+".green(), qualified);
                 resolved.push(qualified);
             }
@@ -279,7 +306,7 @@ fn install_plugin_specs(specs: Vec<String>) -> Result<usize> {
         }
     }
 
-    if !resolved.is_empty() {
+    if !resolved.is_empty() && want_claude {
         // Record intent first, so it survives even if the fetch below fails.
         crate::settings::save(&settings_path, &settings)?;
         println!(
@@ -294,6 +321,25 @@ fn install_plugin_specs(specs: Vec<String>) -> Result<usize> {
             skill_count,
             crate::paths::user_skills_dir()?.display()
         );
+    }
+    if want_hub || targets.iter().any(|h| h.skill_skip_reason().is_some()) {
+        for q in &resolved {
+            match crate::harness::materialize_hub(q, &targets) {
+                Ok(names) if !names.is_empty() => {
+                    println!(
+                        "  {} copied {} nested skill(s) from {} into the Agent Skill hub",
+                        "✓".green(),
+                        names.len(),
+                        q
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("{} {q}: {e}", "✗".red());
+                    failures += 1;
+                }
+            }
+        }
     }
     Ok(failures)
 }
@@ -361,7 +407,7 @@ pub(crate) fn materialize_plugins(qualified: &[String]) -> Result<usize> {
     Ok(installed)
 }
 
-fn run_interactive_browse_marketplaces() -> Result<()> {
+fn run_interactive_browse_marketplaces(harness: Vec<crate::harness::Harness>) -> Result<()> {
     use crate::interactive::Item;
 
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
@@ -404,7 +450,13 @@ fn run_interactive_browse_marketplaces() -> Result<()> {
 
     match crate::interactive::pick_one("Install plugin", &items)? {
         None => println!("Aborted."),
-        Some(idx) => run(vec![qualified_names[idx].clone()], false, false, None)?,
+        Some(idx) => run(
+            vec![qualified_names[idx].clone()],
+            false,
+            false,
+            None,
+            harness,
+        )?,
     }
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -21,7 +21,21 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
     };
     let user_skills = crate::paths::user_skills_dir().ok();
 
-    let managed_names: Vec<&String> = inv.agent_skills.keys().collect();
+    let managed_names: Vec<&String> = inv
+        .agent_skills
+        .iter()
+        .filter(|(n, e)| {
+            if let Some(q) = e.source.strip_prefix("plugin:") {
+                if report.active.iter().any(|a| a == q) {
+                    // The plugin line already names these locations.
+                    let _ = n;
+                    return false;
+                }
+            }
+            true
+        })
+        .map(|(n, _)| n)
+        .collect();
     // A name an active plugin already ships is not an orphan — the plugin owns it.
     let from_plugins = crate::agent_skill::plugin_provided_skills(&report.active);
     let untracked: Vec<String> = on_disk
@@ -57,16 +71,38 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
                 })
             })
             .collect();
+        let mut plugin_locations = serde_json::Map::new();
+        for k in &report.active {
+            plugin_locations.insert(
+                k.clone(),
+                crate::harness::visibility_for_plugin(k, true).to_json(),
+            );
+        }
+        for k in &report.installed_disabled {
+            plugin_locations.insert(
+                k.clone(),
+                crate::harness::visibility_for_plugin(k, false).to_json(),
+            );
+        }
+        let mut skill_locations = serde_json::Map::new();
+        for names in by_source.values() {
+            for n in names {
+                skill_locations
+                    .insert(n.clone(), crate::harness::visibility_for_skill(n).to_json());
+            }
+        }
         let out = json!({
             "plugins": {
                 "active": report.active,
                 "installed_disabled": report.installed_disabled,
                 "enabled_orphan": report.enabled_orphan,
                 "installed_orphan": report.installed_orphan,
+                "harnesses": plugin_locations,
             },
             "agent_skills": {
                 "managed": groups,
                 "untracked": untracked,
+                "harnesses": skill_locations,
             },
             "mcp_servers": mcps,
         });
@@ -82,14 +118,14 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
         println!("  (none)");
     } else {
         for k in &report.active {
-            print_plugin_line("✓", k, paths, &plugin_inv);
+            print_plugin_line("✓", k, paths, &plugin_inv, true);
         }
     }
 
     if !report.installed_disabled.is_empty() {
         println!("\n{}", "Plugins — installed but disabled".bold().yellow());
         for k in &report.installed_disabled {
-            print_plugin_line("•", k, paths, &plugin_inv);
+            print_plugin_line("•", k, paths, &plugin_inv, false);
         }
     }
 
@@ -178,10 +214,12 @@ fn print_group(
         } else {
             String::new()
         };
+        let loc = crate::harness::visibility_for_skill(&names[0]).format_human();
         println!(
-            "  ✓ {}  {}{}",
+            "  ✓ {}  {}{}{}",
             names[0],
             format!("← {}", source).dimmed(),
+            loc.dimmed(),
             path_suffix
         );
         return;
@@ -204,7 +242,8 @@ fn print_group(
             } else {
                 String::new()
             };
-            println!("      • {}{}", n, path_suffix);
+            let loc = crate::harness::visibility_for_skill(n).format_human();
+            println!("      • {}{}{}", n, loc.dimmed(), path_suffix);
         }
     } else {
         let preview: Vec<&str> = names.iter().take(5).map(|s| s.as_str()).collect();
@@ -223,13 +262,26 @@ fn agent_skill_path_suffix(name: &str, user_skills: Option<&std::path::Path>) ->
     }
 }
 
-fn print_plugin_line(marker: &str, qualified: &str, paths: bool, inv: &serde_json::Value) {
+fn print_plugin_line(
+    marker: &str,
+    qualified: &str,
+    paths: bool,
+    inv: &serde_json::Value,
+    active: bool,
+) {
+    let loc = crate::harness::visibility_for_plugin(qualified, active).format_human();
     if !paths {
-        println!("  {} {}", marker, qualified);
+        println!("  {} {}{}", marker, qualified, loc.dimmed());
         return;
     }
     let path = plugin_install_path(qualified, inv).unwrap_or_else(|| "(unknown)".to_string());
-    println!("  {} {}  {}", marker, qualified, path.dimmed());
+    println!(
+        "  {} {}{}  {}",
+        marker,
+        qualified,
+        loc.dimmed(),
+        path.dimmed()
+    );
 }
 
 fn plugin_install_path(qualified: &str, inv: &serde_json::Value) -> Option<String> {

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -19,6 +19,7 @@ pub fn add(
     header: Vec<(String, String)>,
     scope: Option<String>,
     file: Option<PathBuf>,
+    harness: Vec<crate::harness::Harness>,
 ) -> Result<()> {
     let entry = McpEntry {
         name: name.clone(),
@@ -29,6 +30,7 @@ pub fn add(
         url,
         headers: header.into_iter().collect::<BTreeMap<_, _>>(),
         scope: scope.clone(),
+        mcp_harnesses: harness.iter().map(|h| h.as_str().to_string()).collect(),
     };
     entry.validate()?;
     let scope_s = entry.scope_kind()?;
@@ -51,8 +53,18 @@ pub fn add(
         );
     }
 
-    crate::mcp::upsert(&mcp_scope, &name, entry.to_json_value())?;
-    println!("{} applied mcp {} ({})", "✓".green(), name.bold(), scope_s);
+    let (_, mcp_defaults) = crate::harness::load_defaults();
+    let hs = crate::harness::resolve(
+        &harness,
+        &mcp_defaults,
+        &[],
+        vec![crate::harness::Harness::Claude],
+    )?;
+    if hs.contains(&crate::harness::Harness::Claude) {
+        crate::mcp::upsert(&mcp_scope, &name, entry.to_json_value())?;
+        println!("{} applied mcp {} ({})", "✓".green(), name.bold(), scope_s);
+    }
+    crate::harness::print_mcp_skips(&hs);
     Ok(())
 }
 

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -176,6 +176,7 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
                             .unwrap_or(0)
                     ),
                     head_sha: "local".to_string(),
+                    to: vec!["agents".into()],
                 },
             );
         }

--- a/src/commands/migrate_skill.rs
+++ b/src/commands/migrate_skill.rs
@@ -131,6 +131,7 @@ pub fn run(
                         .unwrap_or(0)
                 ),
                 head_sha: "local".to_string(),
+                to: vec!["agents".into()],
             },
         );
         crate::agent_skill::save_inventory(&inv)?;

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -129,7 +129,7 @@ fn install_from_hits(hits: &[Hit]) -> Result<()> {
         Some(idx) => {
             let h = &hits[idx];
             let spec = format!("{}@{}", h.name, h.marketplace);
-            crate::commands::install::run(vec![spec], false, false, None)?;
+            crate::commands::install::run(vec![spec], false, false, None, Vec::new())?;
             // search -i always produces name@marketplace (plugin path).
         }
     }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -35,6 +35,7 @@ pub fn run(
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
 
     let mut desired_plugins: BTreeSet<String> = BTreeSet::new();
+    let mut plugin_copies: Vec<(String, Vec<crate::harness::Harness>)> = Vec::new();
     for entry in &manifest.skills {
         let qualified = match entry.qualified() {
             Some(q) => q,
@@ -46,7 +47,27 @@ pub fn run(
                 }
             },
         };
-        desired_plugins.insert(qualified);
+        let targets = match crate::harness::resolve(
+            &[],
+            &manifest.defaults.harnesses,
+            &entry.harnesses,
+            crate::harness::default_plugin(),
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("{} {}: {}", "✗".red(), entry.name, e);
+                continue;
+            }
+        };
+        if targets.contains(&crate::harness::Harness::Claude) {
+            desired_plugins.insert(qualified.clone());
+        }
+        if targets
+            .iter()
+            .any(|h| h.hub_is_enough() || h.skill_skip_reason().is_some())
+        {
+            plugin_copies.push((qualified, targets));
+        }
     }
 
     let settings_path = crate::paths::settings_json()?;
@@ -212,7 +233,8 @@ pub fn run(
         && deferred_sources_to_install.is_empty()
         && mcps_to_install.is_empty()
         && mcps_to_update.is_empty()
-        && mcps_to_remove.is_empty();
+        && mcps_to_remove.is_empty()
+        && plugin_copies.is_empty();
     if nothing {
         println!("  (no changes — manifest matches current state)");
         return Ok(());
@@ -220,6 +242,17 @@ pub fn run(
 
     for k in &plugins_to_enable {
         println!("  {} enable  plugin  {}", "+".green(), k);
+    }
+    for (q, hs) in &plugin_copies {
+        let dests = hs
+            .iter()
+            .filter(|h| h.hub_is_enough())
+            .map(|h| h.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !dests.is_empty() {
+            println!("  {} copy    plugin  {} → hub ({})", "~".cyan(), q, dests);
+        }
     }
     for k in &plugins_to_disable {
         if adopt {
@@ -341,6 +374,7 @@ pub fn run(
                 name,
                 marketplace: mp,
                 version: None,
+                harnesses: Vec::new(),
             };
             if crate::manifest::append_skill(&path, &entry)? {
                 adopted += 1;
@@ -413,6 +447,22 @@ pub fn run(
             ep.insert((*k).clone(), Value::Bool(false));
         }
         crate::settings::save(&settings_path, &settings)?;
+    }
+
+    for (q, hs) in &plugin_copies {
+        match crate::harness::materialize_hub(q, hs) {
+            Ok(names) => {
+                if !names.is_empty() {
+                    println!(
+                        "  {} {}  copied {} nested skill(s) into the Agent Skill hub",
+                        "✓".green(),
+                        q,
+                        names.len()
+                    );
+                }
+            }
+            Err(e) => eprintln!("{} {q}: {e}", "✗".red()),
+        }
     }
 
     for entry in &manifest.agent_skills {
@@ -523,6 +573,7 @@ pub fn run(
                                     .unwrap_or(0)
                             ),
                             head_sha: "local".to_string(),
+                            to: vec!["agents".into()],
                         },
                     );
                     dirty = true;

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,0 +1,456 @@
+//! Which coding harness can see a name.
+//!
+//! Tokens are harnesses (`claude`, `pi`, `hermes`, `kimi`, `grok`, `codex`),
+//! not directories. Pi, Grok, and the Agent Skills spec already scan the
+//! shared hub `~/.agents/skills/<name>/`. This module copies a nested
+//! marketplace `skills/<name>/` tree into that hub. It does not symlink.
+//! Extra per-harness trees are not invented when the hub is enough.
+
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use owo_colors::OwoColorize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, ValueEnum)]
+pub enum Harness {
+    Claude,
+    Pi,
+    Hermes,
+    Kimi,
+    Grok,
+    Codex,
+}
+
+impl Harness {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Pi => "pi",
+            Self::Hermes => "hermes",
+            Self::Kimi => "kimi",
+            Self::Grok => "grok",
+            Self::Codex => "codex",
+        }
+    }
+
+    pub fn parse_name(s: &str) -> Result<Self> {
+        match s {
+            "claude" => Ok(Self::Claude),
+            "pi" => Ok(Self::Pi),
+            "hermes" => Ok(Self::Hermes),
+            "kimi" => Ok(Self::Kimi),
+            "grok" => Ok(Self::Grok),
+            "codex" => Ok(Self::Codex),
+            other => anyhow::bail!(
+                "unknown harness {other:?} (must be claude, pi, hermes, kimi, grok, or codex)"
+            ),
+        }
+    }
+
+    /// True when a hub copy at `~/.agents/skills/<name>/SKILL.md` is enough
+    /// for this harness to load the skill. Cited from the harness's own docs
+    /// or from this crate's Agent Skills path. Hermes and Kimi are not.
+    pub fn hub_is_enough(self) -> bool {
+        matches!(self, Self::Pi | Self::Grok | Self::Codex)
+    }
+
+    pub fn mcp_supported(self) -> bool {
+        matches!(self, Self::Claude)
+    }
+
+    pub fn mcp_skip_reason(self) -> &'static str {
+        match self {
+            Self::Claude => "",
+            Self::Pi => "no built-in MCP",
+            Self::Grok => "runtime CLI owns ~/.grok/config.toml",
+            Self::Hermes => "no cited MCP map",
+            Self::Kimi => "no cited MCP map",
+            Self::Codex => "not writing ~/.codex/config.toml this PR",
+        }
+    }
+
+    pub fn skill_skip_reason(self) -> Option<&'static str> {
+        match self {
+            Self::Hermes => {
+                Some("unsupported (category tree ~/.hermes/skills/<cat>/<name>/; not writing)")
+            }
+            Self::Kimi => Some("unsupported (no cited skills directory; not inventing a folder)"),
+            _ => None,
+        }
+    }
+}
+
+pub fn parse_names(names: &[String]) -> Result<Vec<Harness>> {
+    let mut out = Vec::new();
+    for n in names {
+        let h = Harness::parse_name(n)?;
+        if !out.contains(&h) {
+            out.push(h);
+        }
+    }
+    Ok(out)
+}
+
+pub fn unique(hs: &[Harness]) -> Vec<Harness> {
+    let mut out = Vec::new();
+    for h in hs {
+        if !out.contains(h) {
+            out.push(*h);
+        }
+    }
+    out
+}
+
+/// Plugin with no `[defaults].harnesses` and no `--harness`: Claude only.
+pub fn default_plugin() -> Vec<Harness> {
+    vec![Harness::Claude]
+}
+
+/// Agent Skill with no `[defaults].harnesses` and no `--harness`: hub only.
+pub fn default_skill() -> Vec<Harness> {
+    vec![Harness::Pi, Harness::Grok, Harness::Codex]
+}
+
+/// CLI `--harness` wins. Else `[defaults].harnesses`. Else today's default.
+pub fn resolve(
+    cli: &[Harness],
+    defaults: &[String],
+    row: &[String],
+    fallback: Vec<Harness>,
+) -> Result<Vec<Harness>> {
+    if !cli.is_empty() {
+        return Ok(unique(cli));
+    }
+    if !row.is_empty() {
+        return parse_names(row);
+    }
+    if !defaults.is_empty() {
+        return parse_names(defaults);
+    }
+    Ok(fallback)
+}
+
+pub fn load_defaults() -> (Vec<String>, Vec<String>) {
+    let Some(path) = crate::manifest::discover() else {
+        return (Vec::new(), Vec::new());
+    };
+    match crate::manifest::load(&path) {
+        Ok(m) => (m.defaults.harnesses, m.defaults.mcp_harnesses),
+        Err(_) => (Vec::new(), Vec::new()),
+    }
+}
+
+/// Nested `skills/<name>/SKILL.md` trees inside a marketplace plugin.
+pub fn plugin_skill_trees(qualified: &str) -> Result<Vec<(String, PathBuf)>> {
+    let root = plugin_root(qualified)?;
+    let skills = root.join("skills");
+    let mut out = Vec::new();
+    let rd = std::fs::read_dir(&skills).with_context(|| {
+        format!(
+            "plugin {qualified} has no skills/ directory at {}",
+            root.display()
+        )
+    })?;
+    for ent in rd.flatten() {
+        let p = ent.path();
+        if !(p.is_dir() && p.join("SKILL.md").is_file()) {
+            continue;
+        }
+        let Some(n) = p.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        crate::agent_skill::validate_skill_name(n)?;
+        out.push((n.to_string(), p));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    if out.is_empty() {
+        anyhow::bail!(
+            "plugin {qualified} has no nested skills/<name>/SKILL.md under {}",
+            root.display()
+        );
+    }
+    Ok(out)
+}
+
+fn plugin_root(qualified: &str) -> Result<PathBuf> {
+    if let Some(p) = installed_plugin_path(qualified) {
+        if p.join("skills").is_dir() {
+            return Ok(p);
+        }
+    }
+    if let Some(p) = marketplace_plugin_dir(qualified) {
+        if p.join("skills").is_dir() {
+            return Ok(p);
+        }
+    }
+    if let Some(p) = cached_plugin_dir(qualified) {
+        if p.join("skills").is_dir() {
+            return Ok(p);
+        }
+    }
+    anyhow::bail!("could not find the plugin source tree for {qualified}")
+}
+
+fn installed_plugin_path(qualified: &str) -> Option<PathBuf> {
+    let raw = std::fs::read(crate::paths::installed_plugins_json().ok()?).ok()?;
+    let v: Value = serde_json::from_slice(&raw).ok()?;
+    let path = v
+        .get("plugins")?
+        .get(qualified)?
+        .as_array()?
+        .first()?
+        .get("installPath")?
+        .as_str()?;
+    let p = PathBuf::from(path);
+    p.exists().then_some(p)
+}
+
+fn marketplace_plugin_dir(qualified: &str) -> Option<PathBuf> {
+    let (name, mp) = qualified.rsplit_once('@')?;
+    let known =
+        crate::marketplace::load_known(&crate::paths::known_marketplaces_json().ok()?).ok()?;
+    let loc = known
+        .get(mp)?
+        .get("installLocation")?
+        .as_str()
+        .map(PathBuf::from)?;
+    let rel = plugin_source_rel(mp, name).unwrap_or_else(|| format!("skills/{name}"));
+    Some(loc.join(rel))
+}
+
+fn plugin_source_rel(marketplace: &str, plugin: &str) -> Option<String> {
+    let path = crate::paths::marketplace_manifest(marketplace).ok()?;
+    let manifest = crate::marketplace::load_manifest(&path).ok()?;
+    let entry = manifest.plugins.iter().find(|p| p.name == plugin)?;
+    match &entry.source {
+        Some(Value::String(s)) => Some(s.trim_start_matches("./").to_string()),
+        _ => None,
+    }
+}
+
+fn cached_plugin_dir(qualified: &str) -> Option<PathBuf> {
+    let (plugin, mp) = qualified.rsplit_once('@')?;
+    let base = crate::paths::plugins_dir()
+        .ok()?
+        .join("cache")
+        .join(mp)
+        .join(plugin);
+    let mut versions: Vec<PathBuf> = std::fs::read_dir(&base)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    versions.sort();
+    versions.pop()
+}
+
+fn plugin_skill_names(qualified: &str) -> Vec<String> {
+    plugin_skill_trees(qualified)
+        .map(|v| v.into_iter().map(|(n, _)| n).collect())
+        .unwrap_or_else(|_| {
+            qualified
+                .split_once('@')
+                .map(|(n, _)| vec![n.to_string()])
+                .unwrap_or_default()
+        })
+}
+
+fn hub_has(name: &str) -> bool {
+    crate::paths::user_skills_dir()
+        .map(|root| root.join(name).join("SKILL.md").is_file())
+        .unwrap_or(false)
+}
+
+/// Copy nested plugin skill trees into the shared Agent Skill hub.
+/// Prints a skip line for harnesses that need a tree we will not invent.
+pub fn materialize_hub(qualified: &str, harnesses: &[Harness]) -> Result<Vec<String>> {
+    let want_hub = harnesses.iter().any(|h| h.hub_is_enough());
+    for h in harnesses {
+        if let Some(reason) = h.skill_skip_reason() {
+            println!("  {} {}: {reason}", "·".dimmed(), h.as_str());
+        }
+    }
+    if !want_hub {
+        return Ok(Vec::new());
+    }
+    let trees = plugin_skill_trees(qualified)?;
+    let root = crate::paths::user_skills_dir()?;
+    let mut copied = BTreeSet::new();
+    for (name, src) in &trees {
+        crate::agent_skill::install_to_root(&root, name, src)?;
+        copied.insert(name.clone());
+        println!(
+            "  {} {} → {} (hub)",
+            "+".green(),
+            name,
+            root.join(name).display()
+        );
+    }
+    if !copied.is_empty() {
+        record_plugin_copies(qualified, &copied)?;
+    }
+    Ok(copied.into_iter().collect())
+}
+
+fn record_plugin_copies(qualified: &str, names: &BTreeSet<String>) -> Result<()> {
+    let mut inv = crate::agent_skill::load_inventory()?;
+    let now = crate::agent_skill::inventory_now();
+    for name in names {
+        let entry =
+            inv.agent_skills
+                .entry(name.clone())
+                .or_insert_with(|| crate::agent_skill::Entry {
+                    source: format!("plugin:{qualified}"),
+                    installed_at: now.clone(),
+                    head_sha: String::new(),
+                    to: vec!["agents".into()],
+                });
+        if !entry.source.starts_with("plugin:") {
+            anyhow::bail!(
+                "refusing to overwrite Agent Skill '{name}' (source {}) with a plugin projection of {qualified}",
+                entry.source
+            );
+        }
+        entry.source = format!("plugin:{qualified}");
+        if !entry.to.iter().any(|t| t == "agents") {
+            entry.to.push("agents".into());
+        }
+    }
+    crate::agent_skill::save_inventory(&inv)
+}
+
+pub struct Visibility {
+    pub visible: Vec<Harness>,
+    pub skipped: Vec<(Harness, &'static str)>,
+}
+
+impl Visibility {
+    pub fn format_human(&self) -> String {
+        let vis = self
+            .visible
+            .iter()
+            .map(|h| h.as_str())
+            .collect::<Vec<_>>()
+            .join(" · ");
+        let vis = if vis.is_empty() {
+            "nowhere".into()
+        } else {
+            vis
+        };
+        if self.skipped.is_empty() {
+            return format!("  [{vis}]");
+        }
+        let skip = self
+            .skipped
+            .iter()
+            .map(|(h, _)| h.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("  [{vis} | skipped {skip}]")
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        let skipped: serde_json::Map<String, serde_json::Value> = self
+            .skipped
+            .iter()
+            .map(|(h, r)| {
+                (
+                    h.as_str().to_string(),
+                    serde_json::Value::String((*r).into()),
+                )
+            })
+            .collect();
+        serde_json::json!({
+            "visible": self.visible.iter().map(|h| h.as_str()).collect::<Vec<_>>(),
+            "skipped": skipped,
+        })
+    }
+}
+
+/// Harnesses that can see a marketplace plugin. `claude` is true when the
+/// plugin is enabled and inventoried. Hub-backed harnesses are true when any
+/// nested skill name has `SKILL.md` in `~/.agents/skills/`.
+pub fn visibility_for_plugin(qualified: &str, active: bool) -> Visibility {
+    let names = plugin_skill_names(qualified);
+    let on_hub = names.iter().any(|n| hub_has(n));
+    visibility(active, on_hub)
+}
+
+pub fn visibility_for_skill(name: &str) -> Visibility {
+    visibility(false, hub_has(name))
+}
+
+fn visibility(claude_active: bool, on_hub: bool) -> Visibility {
+    let mut visible = Vec::new();
+    let mut skipped = Vec::new();
+    if claude_active {
+        visible.push(Harness::Claude);
+    }
+    for h in [Harness::Pi, Harness::Grok, Harness::Codex] {
+        if on_hub {
+            visible.push(h);
+        }
+    }
+    for h in [Harness::Hermes, Harness::Kimi] {
+        if let Some(r) = h.skill_skip_reason() {
+            skipped.push((h, r));
+        }
+    }
+    Visibility { visible, skipped }
+}
+
+pub fn print_mcp_skips(harnesses: &[Harness]) {
+    for h in harnesses {
+        if h.mcp_supported() {
+            continue;
+        }
+        println!(
+            "  {} mcp: {} unsupported ({})",
+            "·".dimmed(),
+            h.as_str(),
+            h.mcp_skip_reason()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_accepts_six_harnesses() {
+        assert_eq!(Harness::parse_name("claude").unwrap(), Harness::Claude);
+        assert_eq!(Harness::parse_name("codex").unwrap(), Harness::Codex);
+    }
+
+    #[test]
+    fn parse_name_rejects_directory_tokens() {
+        assert!(Harness::parse_name("agents").is_err());
+        assert!(Harness::parse_name("project").is_err());
+    }
+
+    #[test]
+    fn hub_is_enough_for_pi_grok_codex() {
+        assert!(Harness::Pi.hub_is_enough());
+        assert!(Harness::Grok.hub_is_enough());
+        assert!(Harness::Codex.hub_is_enough());
+        assert!(!Harness::Claude.hub_is_enough());
+        assert!(!Harness::Hermes.hub_is_enough());
+        assert!(!Harness::Kimi.hub_is_enough());
+    }
+
+    #[test]
+    fn resolve_cli_wins() {
+        let got = resolve(
+            &[Harness::Pi],
+            &["claude".into()],
+            &["grok".into()],
+            default_plugin(),
+        )
+        .unwrap();
+        assert_eq!(got, vec![Harness::Pi]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod commands;
 mod error;
 mod git;
+mod harness;
 mod interactive;
 mod inventory;
 mod lockfile;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -39,6 +39,20 @@ pub struct Manifest {
     /// `update` and `upgrade` from floating a tap off the ref you chose.
     #[serde(default)]
     pub marketplaces: Vec<MarketplaceEntry>,
+
+    /// Default harness lists. Missing = today's 1.0 behaviour (plugin → Claude
+    /// only, Agent Skill → hub only, MCP → Claude json only).
+    #[serde(default)]
+    pub defaults: Defaults,
+}
+
+/// `[defaults]` in skills.toml.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Defaults {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub harnesses: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_harnesses: Vec<String>,
 }
 
 impl Manifest {
@@ -86,6 +100,10 @@ pub struct SkillEntry {
     pub marketplace: Option<String>,
     #[serde(default)]
     pub version: Option<String>,
+    /// Harnesses this plugin should be visible to. Empty = inherit `[defaults].harnesses`,
+    /// or Claude only when `[defaults]` is missing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub harnesses: Vec<String>,
 }
 
 impl SkillEntry {
@@ -133,6 +151,10 @@ pub struct McpEntry {
     /// `"user"` (default) | `"project"` | `"local"`.
     #[serde(default)]
     pub scope: Option<String>,
+    /// Harnesses this MCP server should be declared in. Empty = inherit
+    /// `[defaults].mcp_harnesses`, or Claude only when `[defaults]` is missing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_harnesses: Vec<String>,
 }
 
 impl McpEntry {
@@ -258,6 +280,9 @@ pub struct AgentSkillEntry {
     /// to take ownership of them. Example: `claims = ["gsd-*"]`.
     #[serde(default)]
     pub claims: Vec<String>,
+    /// Harnesses this Agent Skill should be visible to. Empty = inherit `[defaults].harnesses`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub harnesses: Vec<String>,
 }
 
 /// Find the user-level manifest. Does NOT look at `./skills.toml` — that path
@@ -357,7 +382,7 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
 
 /// Append a `[[skills]]` entry. Skips if `name@marketplace` already present.
 pub fn append_skill(path: &Path, entry: &SkillEntry) -> Result<bool> {
-    use toml_edit::{value, ArrayOfTables, DocumentMut, Item, Table};
+    use toml_edit::{value, Array, ArrayOfTables, DocumentMut, Item, Table};
 
     let raw = if path.exists() {
         std::fs::read_to_string(path)
@@ -405,6 +430,13 @@ pub fn append_skill(path: &Path, entry: &SkillEntry) -> Result<bool> {
     }
     if let Some(v) = &entry.version {
         t["version"] = value(v);
+    }
+    if !entry.harnesses.is_empty() {
+        let mut arr = Array::new();
+        for h in &entry.harnesses {
+            arr.push(h.as_str());
+        }
+        t["harnesses"] = toml_edit::Item::Value(arr.into());
     }
     aot.push(t);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -15,6 +15,7 @@ fn zskills(home: &TempDir) -> Command {
     // `<tempdir>/skills/` is the install target (mirrors the production layout
     // where ~/.agents/skills/ lives alongside ~/.claude/).
     cmd.env("AGENTS_HOME", home.path());
+    cmd.env("PI_HOME", home.path().join("pi"));
     // Sandbox the clone cache too, so repo-install tests never touch ~/.cache.
     cmd.env("XDG_CACHE_HOME", home.path().join("cache"));
     // Sandbox manifest discovery. `manifest::discover()` reads
@@ -619,6 +620,7 @@ fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
     cmd.env("CLAUDE_HOME", claude_home);
     // Pin the cross-client Agent Skills home next to CLAUDE_HOME so tests stay sandboxed.
     cmd.env("AGENTS_HOME", parent.path().join(".agents"));
+    cmd.env("PI_HOME", parent.path().join(".pi-home"));
     cmd.env("NO_COLOR", "1");
     cmd.env("ZSKILLS_NO_CLAUDE_CLI", "1");
     cmd.env("XDG_CONFIG_HOME", parent.path().join("config"));
@@ -2857,4 +2859,193 @@ fn mcp_add_and_remove_write_intent_then_runtime() {
     assert!(!toml.contains("name = \"honcho\""));
     let json: serde_json::Value = serde_json::from_slice(&fs::read(&claude_json).unwrap()).unwrap();
     assert!(json["mcpServers"].get("honcho").is_none());
+}
+
+// ──── harness targets (`[defaults].harnesses` / `--harness` / list) ─────────
+
+/// Marketplace clone that ships nested `skills/<plugin>/SKILL.md`, the layout
+/// `pi@zot24-skills` uses.
+fn stage_marketplace_plugin_with_nested_skill(home: &TempDir, mp: &str, plugin: &str) {
+    let mp_dir = home.path().join("plugins").join("marketplaces").join(mp);
+    fs::create_dir_all(mp_dir.join(".claude-plugin")).unwrap();
+    fs::write(
+        mp_dir.join(".claude-plugin").join("marketplace.json"),
+        format!(
+            r#"{{"name":"{mp}","plugins":[{{"name":"{plugin}","source":"./skills/{plugin}"}}]}}"#
+        ),
+    )
+    .unwrap();
+    let nested = mp_dir
+        .join("skills")
+        .join(plugin)
+        .join("skills")
+        .join(plugin);
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(
+        nested.join("SKILL.md"),
+        format!("---\nname: {plugin}\ndescription: d\n---\n"),
+    )
+    .unwrap();
+    fs::write(nested.join("notes.md"), "not a symlink\n").unwrap();
+
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    known[mp] = json!({
+        "source": { "source": "github", "repo": format!("o/{mp}") },
+        "installLocation": mp_dir.to_string_lossy(),
+        "autoUpdate": true,
+        "lastUpdated": "2026-08-24T00:00:00.000Z"
+    });
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+}
+
+#[test]
+fn list_active_plugin_shows_claude_not_pi() {
+    let home = fake_home();
+    let out = zskills(&home)
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["plugins"]["active"][0], "foo@test-mp");
+    let vis = v["plugins"]["harnesses"]["foo@test-mp"]["visible"]
+        .as_array()
+        .unwrap();
+    assert!(vis.iter().any(|x| x == "claude"));
+    assert!(!vis.iter().any(|x| x == "pi"));
+}
+
+#[test]
+fn plugin_install_harness_pi_copies_nested_skill_to_hub_not_symlink() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+
+    zskills(&home)
+        .args(["plugin", "install", "pi@zot24-skills", "--harness", "pi"])
+        .assert()
+        .success();
+
+    let dest = home.path().join("skills").join("pi").join("SKILL.md");
+    assert!(dest.is_file(), "SKILL.md must sit at the hub scan root");
+    let meta = fs::symlink_metadata(home.path().join("skills").join("pi")).unwrap();
+    assert!(!meta.file_type().is_symlink(), "owner forbade symlinks");
+    assert!(home
+        .path()
+        .join("skills")
+        .join("pi")
+        .join("notes.md")
+        .is_file());
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(home.path().join("settings.json")).unwrap()).unwrap();
+    assert!(
+        settings["enabledPlugins"]
+            .get("pi@zot24-skills")
+            .is_none_or(|v| v == false),
+        "pi-only harness must not enable the Claude plugin"
+    );
+}
+
+#[test]
+fn list_after_hub_copy_shows_pi_visible_to_pi() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    zskills(&home)
+        .args(["plugin", "install", "pi@zot24-skills", "--harness", "pi"])
+        .assert()
+        .success();
+
+    let out = zskills(&home)
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    let skill_vis = v["agent_skills"]["harnesses"]["pi"]["visible"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        skill_vis.iter().any(|x| x == "pi"),
+        "list must show the hub copy visible to Pi: {v}"
+    );
+    assert!(
+        !skill_vis.iter().any(|x| x == "claude"),
+        "a hub-only copy is not a Claude plugin: {v}"
+    );
+}
+
+#[test]
+fn unknown_harness_is_refused() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["plugin", "install", "foo@test-mp", "--harness", "agents"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn hermes_and_kimi_are_skipped_not_invented() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    zskills(&home)
+        .args([
+            "plugin",
+            "install",
+            "pi@zot24-skills",
+            "--harness",
+            "hermes,kimi",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unsupported"));
+    assert!(
+        !home
+            .path()
+            .join("skills")
+            .join("pi")
+            .join("SKILL.md")
+            .is_file(),
+        "unsupported harnesses must not invent a hub copy"
+    );
+}
+
+#[test]
+fn sync_applies_harnesses_on_plugin_row() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    let manifest_dir = home.path().join("config").join("zskills");
+    fs::create_dir_all(&manifest_dir).unwrap();
+    fs::write(
+        manifest_dir.join("skills.toml"),
+        r#"
+[defaults]
+harnesses = ["claude", "pi", "hermes", "kimi", "grok", "codex"]
+mcp_harnesses = ["claude", "pi", "hermes", "kimi", "grok", "codex"]
+
+[[skills]]
+name = "pi"
+marketplace = "zot24-skills"
+harnesses = ["pi"]
+"#,
+    )
+    .unwrap();
+    zskills(&home).args(["sync", "--force"]).assert().success();
+    assert!(home
+        .path()
+        .join("skills")
+        .join("pi")
+        .join("SKILL.md")
+        .is_file());
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(home.path().join("settings.json")).unwrap()).unwrap();
+    assert!(settings["enabledPlugins"]
+        .get("pi@zot24-skills")
+        .is_none_or(|v| v == false));
 }


### PR DESCRIPTION
<!--
WRITE THIS DESCRIPTION IN ASD-STE100 (Simplified Technical English). HARD RULE.

  One idea per sentence · the same word for the same thing (plugin, marketplace,
  Agent Skill, MCP server, manifest, inventory — no synonyms in one PR) · active
  voice, imperative in steps · no filler (basically, simply, just, in order to) ·
  exact technical names (known_marketplaces.json, enabledPlugins, ~/.agents/skills/).

Produce this body in a FORKED CHAT, not in the conversation that wrote the code
— that conversation already understands the change and writes for itself. Fork
it, hand the fork the diff summary + the mermaid text + the linked issues, let it
write the description SO A COMMON REVIEWER UNDERSTANDS THE CHANGE and post it,
then drop the fork and continue the main chat.

The description does NOT have to be short. Give the reviewer the context, the
mechanism, and the risk. STE100 makes the text clear; it does not cap length.
Cut filler, not information.

Card: docs/guides/PR_DESCRIPTION_STANDARD.md
-->

## Labels (REQUIRED)
<!--
Every PR carries four labels. Set them with `gh pr edit <n> --add-label "..."`.
A PR without all four is not ready for review.
-->
- [x] Type: `enhancement`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`, `area:docs`

## Summary
- zskills names which harnesses can see a plugin or an Agent Skill.
- The harness names are `claude`, `pi`, `hermes`, `kimi`, `grok`, and `codex`.
- The public CLI groups stay `plugin`, `skill`, and `mcp`.
- `zskills list` prints harness visibility for each plugin and each Agent Skill.
- A Claude-only marketplace plugin is not a Pi install.
- The manifest grows `[defaults].harnesses` and `[defaults].mcp_harnesses`.
- Each `[[skills]]` row and each `[[agent_skills]]` row may set `harnesses`.
- Each MCP server row may set `mcp_harnesses`.
- Missing `[defaults]` keeps 1.0 behaviour.
- A plugin with no harness list goes to Claude only.
- An Agent Skill with no harness list goes to `~/.agents/skills/` only.
- An MCP server with no harness list goes to Claude json only.
- `--harness claude,pi` is a one-shot override of `[defaults].harnesses`.
- The flag is not `--to`. `--to` named directories. The owner rejected that shape.
- Pi, Grok, and Codex already scan the shared hub `~/.agents/skills/<name>/`.
- A hub harness copies nested marketplace `skills/<name>/` into that hub.
- The copy places `SKILL.md` at the scan root. The copy is a real directory. The copy is not a symlink.
- Hermes and Kimi print `unsupported`. They do not invent a folder.
- MCP writes stay on Claude. Other harnesses print `mcp: <harness> unsupported`.
- `list --json` keeps `plugins.active` as a string array.
- New sibling keys are `plugins.harnesses` and `agent_skills.harnesses`. Each value has `{visible, skipped}`.

## How It Works (diagram — REQUIRED)
<!--
Every PR MUST include a mermaid diagram of how the change works: data flow,
sequence of calls, or architecture of the pieces touched. GitHub renders
```mermaid blocks natively as images. Pick the type that fits —
sequenceDiagram (call flows), flowchart (branching logic). Scope it to the
pieces this PR touches.

MERMAID THAT BREAKS GITHUB SILENTLY — no `;` inside note or message text, no
HTML (<br/>) in a participant alias, no bare `%%` line (use `%% ---`). GitHub
renders unparseable mermaid as a plain code block with no error, and no CI job
ever reads this description. Open the PR page and look at the diagram.
-->

```mermaid
flowchart TD
  Install[plugin install]
  Flag{CLI --harness set}
  Defaults["manifest defaults.harnesses"]
  ClaudeOnly[Claude only]
  Set[resolved harness list]
  Claude{claude in list}
  Hub{pi or grok or codex in list}
  Enable[write enabledPlugins]
  Copy[copy nested skills name into agents hub]
  Skip[print hermes and kimi unsupported]
  List[zskills list]
  Vis[print visible harnesses and skipped]
  Install --> Flag
  Flag -->|yes| Set
  Flag -->|no| Defaults
  Defaults -->|missing| ClaudeOnly
  Defaults -->|present| Set
  ClaudeOnly --> Enable
  Set --> Claude
  Claude -->|yes| Enable
  Set --> Hub
  Hub -->|yes| Copy
  Set --> Skip
  Enable --> List
  Copy --> List
  List --> Vis
```

`src/harness.rs` is the new module. It owns the six harness names. `parse_name` accepts `claude`, `pi`, `hermes`, `kimi`, `grok`, and `codex`. It refuses directory tokens such as `agents` and `project`.

`resolve` picks the harness list in this order:

1. Use CLI `--harness` when the flag is set.
2. Use the row `harnesses` or `mcp_harnesses` when the row sets a list.
3. Use `[defaults].harnesses` or `[defaults].mcp_harnesses` when that list is not empty.
4. Use the 1.0 fallback.

The plugin fallback is Claude only. The Agent Skill fallback is the hub (`pi`, `grok`, `codex`). The MCP server fallback is Claude json only.

`plugin install` calls `resolve` with the CLI flag and `[defaults].harnesses`. `claude` in the resolved list writes `enabledPlugins` and records inventory. `pi`, `grok`, or `codex` in the list calls `materialize_hub`.

`materialize_hub` finds nested `skills/<name>/SKILL.md` in the marketplace plugin tree. It copies each tree into `~/.agents/skills/<name>/`. `SKILL.md` then sits at the hub scan root. The copy is a real directory. The function does not create a symlink.

The inventory source for a hub copy is `plugin:<name@marketplace>`. If the hub already holds an Agent Skill whose `source` is not that plugin prefix, the copy fails. The function does not overwrite a foreign Agent Skill.

Hermes prints `unsupported (category tree ~/.hermes/skills/<cat>/<name>/; not writing)`. Kimi prints `unsupported (no cited skills directory; not inventing a folder)`. Neither harness gets a new folder.

`sync` uses the same `resolve` path for each `[[skills]]` row. `claude` in the list still drives `enabledPlugins`. Hub harnesses copy nested trees in the same pass.

`mcp add` writes Claude json when Claude is in the resolved MCP list. Other harnesses print `mcp: <harness> unsupported` with a skip reason. This PR does not write `~/.grok/config.toml`. This PR does not write `~/.codex/config.toml`.

`list` computes visibility from disk. It does not replay the last `--harness` flag. Claude is visible when the plugin is active. Pi, Grok, and Codex are visible when `SKILL.md` exists in the hub. Hermes and Kimi stay in `skipped`.

Human output appends a location suffix such as `[pi · grok · codex | skipped hermes, kimi]`. JSON keeps `plugins.active` as a string array. The new maps live at `plugins.harnesses` and `agent_skills.harnesses`. Each map value has `visible` (string array) and `skipped` (name to reason).

`list` hides a hub copy from the managed Agent Skill section when an active plugin already owns that name. The plugin line names those locations.

`README.md`, `docs/commands.md`, and `docs/index.md` document `--harness` and `[defaults]`.

A user who omits `[defaults]` and omits `--harness` still gets Claude only for a plugin. That is 1.0 behaviour.

`--harness pi` does not write `enabledPlugins`. The plugin stays disabled in Claude.

## Linked Issues / ADRs
- Resolves: #34
- Part of:

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

```
$ cargo fmt --check
(exit 0, no output)

$ cargo clippy --all-targets -- -D warnings
(exit 0)

$ cargo test
running 70 tests
...
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 92 tests
...
test result: ok. 92 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Sandbox. `CLAUDE_HOME` and `AGENTS_HOME` point at `/tmp/zs-harness-XD53`. `ZSKILLS_NO_CLAUDE_CLI=1` is set. The real home is not used.

```
export CLAUDE_HOME=/tmp/zs-harness-XD53 AGENTS_HOME=/tmp/zs-harness-XD53
export ZSKILLS_NO_CLAUDE_CLI=1

./target/release/zskills plugin install pi@zot24-skills --harness pi
```

Before: `/tmp/zs-harness-XD53/skills/pi/SKILL.md` is absent.

After:

- Wrote `/tmp/zs-harness-XD53/skills/pi/SKILL.md`.
- The path is a file. The parent is not a symlink.
- Did not enable `pi@zot24-skills` in `enabledPlugins`.

```
./target/release/zskills list --json
```

Skill `pi`:

- `visible`: `pi`, `grok`, `codex`
- `skipped`: `hermes`, `kimi`

## Additional Notes for Reviewers
- Branch: `feat/harness-targets` on `zot24/zskills`. Worktree: `.worktrees/harness-targets`. Home `/Users/anon/code/zskills` was not used.
- The public CLI groups stay `plugin`, `skill`, and `mcp`. Do not add a fourth group for harnesses.
- `--to pi` versus `--to agents` named directories. The product uses harness names.
- Hermes and Kimi stay skipped until a later PR cites a scan root. Do not invent `~/.hermes/skills/` or a Kimi folder in this PR.
- MCP writes stay on Claude. `mcp_harnesses` that name other harnesses print `mcp: <harness> unsupported`. This PR does not write `~/.grok/config.toml` or `~/.codex/config.toml`.
- `plugins.active` stays a string array. Existing JSON consumers keep that shape. Read `plugins.harnesses` for visibility.
- A hub copy records inventory with `source = plugin:<name@marketplace>`. A later Agent Skill install of the same name is refused.
- Open the PR page and confirm the mermaid renders as a diagram, not as a plain code block.
