### PR TITLE
feat: register the Agent Skill hub in Pi settings

### DIFF
--- a/docs/closeouts/CLOSEOUT.md
+++ b/docs/closeouts/CLOSEOUT.md
@@ -1,0 +1,53 @@
+# Closeout: sparse-install (PR #24)
+
+Date: 2026-07-21. PR #24 squash-merged to `main` as `9623646`; all CI checks
+(clippy, rustfmt, tests on macOS + Ubuntu) green. Local `feat/sparse-install`
+branch deleted (remote deleted at merge).
+
+## Binary
+
+- Reinstalled from merged `main` via `cargo install --path . --force` →
+  `~/.cargo/bin/zskills`.
+- Reports **0.7.0** — correct: release-please owns versioning
+  (`.release-please-manifest.json` = 0.7.0, release-type `rust`). No hand-bump;
+  the `feat:` commit will produce a 0.8.0 release PR. The new sparse-install
+  code is in the installed binary regardless of the version string.
+
+## Live doctor run (real `~/.agents/skills/`)
+
+`zskills doctor` found:
+
+1. **`ogulcancelik-herdr` — full-repo install** (the motivating case): whole
+   source tree with embedded `.git/`, `src/`, `vendor/`, `Cargo.lock`,
+   `website/`, `flake.nix`, … **48 MB**.
+2. `mercator` — tracked in inventory but bytes already missing on disk
+   (pre-existing stale entry, unrelated to this work).
+
+No other full-repo installs were flagged — `ogulcancelik-herdr` was the only
+one.
+
+## Fix applied (`zskills doctor --fix`)
+
+- `ogulcancelik-herdr` re-installed slim from `ogulcancelik/herdr`:
+  **48 MB → 1.4 MB**. Verified after: `SKILL.md` intact; `src/`, `vendor/`,
+  `.git/`, `Cargo.lock`, `website/` all gone. Remaining contents: `SKILL.md`,
+  `assets/`, `scripts/` (the conventional-dir rule; herdr keeps project dev
+  scripts at the repo root, so ~1.4 MB of those ride along — known heuristic
+  trade-off, documented in the PR).
+- `mercator` stale inventory entry dropped.
+- A follow-up `zskills doctor` reports: *All good — disk, inventory, and
+  settings are in sync.*
+
+## Left open
+
+- **Release**: wait for/merge the release-please PR to cut v0.8.0 and publish;
+  then `cargo install zskills` users get sparse installs.
+- **Heuristic refinement (optional)**: only include conventional dirs
+  (`scripts/`, `assets/`, `references/`) when SKILL.md references them, to
+  avoid dragging in project-level dirs like herdr's — at the risk of dropping
+  files skills rely on silently.
+- **Naming (deliberate non-change)**: root-level skills still install under
+  the cache-derived name (`ogulcancelik-herdr`, not frontmatter `herdr`);
+  switching would break `upgrade` for existing manifests.
+- Old local topic branches (`feat/install-from-repo`, `docs/zot24-home-link`,
+  …) remain; prune at leisure per the usual worktree/branch hygiene.

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -823,11 +823,10 @@ mod tests {
         assert!(!glob_match("foo", "foobar"));
     }
 
-    /// Process-global `AGENTS_HOME` must not leak across tests.
-    static AGENTS_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn with_agents_home<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
-        let _guard = AGENTS_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::paths::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
         let skills = home.join("skills");
@@ -837,7 +836,7 @@ mod tests {
         fs::write(skills.join("beta").join("SKILL.md"), "b").unwrap();
         fs::create_dir_all(home.join(".claude")).unwrap();
         fs::write(home.join(".claude").join("keep"), "x").unwrap();
-        // SAFETY: held under AGENTS_HOME_LOCK; restored before the guard drops.
+        // SAFETY: held under HOME_ENV_LOCK; restored before the guard drops.
         let prev = std::env::var_os("AGENTS_HOME");
         std::env::set_var("AGENTS_HOME", home);
         let out = f(home);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,6 +292,8 @@ pub enum AgentSkillCmd {
     },
     /// Refresh git/npm Agent Skills (and marketplace caches)
     Upgrade { names: Vec<String> },
+    /// Ensure the Agent Skill hub path is listed once in Pi's settings.json
+    RegisterPiHub,
     /// Hidden. `skill migrate` is not a verb. Point at `migrate-skill`.
     #[command(hide = true, disable_help_flag = true)]
     Migrate {
@@ -410,6 +412,7 @@ impl Cli {
                     crate::commands::agent_skills::remove(names, force, file)
                 }
                 AgentSkillCmd::Upgrade { names } => crate::commands::agent_skills::upgrade(names),
+                AgentSkillCmd::RegisterPiHub => crate::commands::agent_skills::register_pi_hub(),
                 AgentSkillCmd::Migrate { rest } => {
                     crate::commands::stub::run("skill-migrate", &rest)
                 }

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -26,6 +26,11 @@ pub fn upgrade(names: Vec<String>) -> Result<()> {
     crate::commands::upgrade::run(names)
 }
 
+pub fn register_pi_hub() -> Result<()> {
+    crate::harness::register_pi_hub()?;
+    Ok(())
+}
+
 pub fn remove(names: Vec<String>, force: bool, file: Option<PathBuf>) -> Result<()> {
     if names.is_empty() {
         anyhow::bail!("specify at least one Agent Skill name");

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -83,6 +83,7 @@ fn install_from_repo(
 ) -> Result<()> {
     let (defaults, _) = crate::harness::load_defaults();
     let hs = crate::harness::resolve(harness, &defaults, &[], crate::harness::default_skill())?;
+    crate::harness::ensure_pi_hub_if_targeted(&hs)?;
     for h in &hs {
         if let Some(reason) = h.skill_skip_reason() {
             println!("  {} {}: {reason}", "·".dimmed(), h.as_str());
@@ -268,7 +269,7 @@ fn install_plugin_specs(specs: Vec<String>, harness: &[crate::harness::Harness])
     let targets =
         crate::harness::resolve(harness, &defaults, &[], crate::harness::default_plugin())?;
     let want_claude = targets.contains(&crate::harness::Harness::Claude);
-    let want_hub = targets.iter().any(|h| h.hub_is_enough());
+    let want_hub = targets.iter().any(|h| h.uses_hub());
 
     let settings_path = crate::paths::settings_json()?;
     let mut settings = crate::settings::load(&settings_path)?;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -64,7 +64,7 @@ pub fn run(
         }
         if targets
             .iter()
-            .any(|h| h.hub_is_enough() || h.skill_skip_reason().is_some())
+            .any(|h| h.uses_hub() || h.skill_skip_reason().is_some())
         {
             plugin_copies.push((qualified, targets));
         }
@@ -246,7 +246,7 @@ pub fn run(
     for (q, hs) in &plugin_copies {
         let dests = hs
             .iter()
-            .filter(|h| h.hub_is_enough())
+            .filter(|h| h.uses_hub())
             .map(|h| h.as_str())
             .collect::<Vec<_>>()
             .join(", ");
@@ -466,6 +466,13 @@ pub fn run(
     }
 
     for entry in &manifest.agent_skills {
+        let hs = crate::harness::resolve(
+            &[],
+            &manifest.defaults.harnesses,
+            &entry.harnesses,
+            crate::harness::default_skill(),
+        )?;
+        crate::harness::ensure_pi_hub_if_targeted(&hs)?;
         if let Some(pkg) = entry.npm.as_deref() {
             match crate::agent_skill::install_npm(pkg, entry.install_cmd.as_deref(), &entry.claims)
             {

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,17 +1,20 @@
 //! Which coding harness can see a name.
 //!
 //! Tokens are harnesses (`claude`, `pi`, `hermes`, `kimi`, `grok`, `codex`),
-//! not directories. Pi, Grok, and the Agent Skills spec already scan the
-//! shared hub `~/.agents/skills/<name>/`. This module copies a nested
-//! marketplace `skills/<name>/` tree into that hub. It does not symlink.
-//! Extra per-harness trees are not invented when the hub is enough.
+//! not directories. Grok and Codex scan the shared hub
+//! `~/.agents/skills/<name>/`. Pi scans the hub only after the absolute hub
+//! path is listed in `~/.pi/agent/settings.json` `skills: []`. This module
+//! copies a nested marketplace `skills/<name>/` tree into that hub. It does
+//! not symlink. Extra per-harness trees are not invented when the hub is
+//! enough.
 
 use anyhow::{Context, Result};
 use clap::ValueEnum;
 use owo_colors::OwoColorize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, ValueEnum)]
 pub enum Harness {
@@ -21,6 +24,26 @@ pub enum Harness {
     Kimi,
     Grok,
     Codex,
+}
+
+/// How a hub copy at `~/.agents/skills/<name>/` relates to this harness.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HubSufficiency {
+    /// The harness scans the hub by itself.
+    Always,
+    /// The harness scans the hub only after the hub path is in its settings.
+    WhenRegistered,
+    /// The harness does not scan the hub.
+    Never,
+}
+
+/// Outcome of ensuring the hub path is in Pi's `skills` array.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PiHubRegister {
+    /// Wrote the file (created the key, added the path, or dropped duplicates).
+    Wrote,
+    /// Path was already present exactly once; the file was not rewritten.
+    Already,
 }
 
 impl Harness {
@@ -49,11 +72,32 @@ impl Harness {
         }
     }
 
+    /// How this harness learns about skills that live on the hub.
+    pub fn hub_sufficiency(self) -> HubSufficiency {
+        match self {
+            Self::Grok | Self::Codex => HubSufficiency::Always,
+            Self::Pi => HubSufficiency::WhenRegistered,
+            Self::Claude | Self::Hermes | Self::Kimi => HubSufficiency::Never,
+        }
+    }
+
+    /// True when this harness can use a hub copy, possibly after registration.
+    pub fn uses_hub(self) -> bool {
+        !matches!(self.hub_sufficiency(), HubSufficiency::Never)
+    }
+
     /// True when a hub copy at `~/.agents/skills/<name>/SKILL.md` is enough
-    /// for this harness to load the skill. Cited from the harness's own docs
-    /// or from this crate's Agent Skills path. Hermes and Kimi are not.
+    /// for this harness to load the skill *right now*.
+    ///
+    /// Grok and Codex scan the hub natively. Pi scans the hub only after
+    /// [`register_pi_hub`] has listed the absolute hub path in
+    /// `~/.pi/agent/settings.json`. Returning true for unregistered Pi is a lie.
     pub fn hub_is_enough(self) -> bool {
-        matches!(self, Self::Pi | Self::Grok | Self::Codex)
+        match self.hub_sufficiency() {
+            HubSufficiency::Always => true,
+            HubSufficiency::WhenRegistered => pi_hub_is_registered(),
+            HubSufficiency::Never => false,
+        }
     }
 
     pub fn mcp_supported(self) -> bool {
@@ -264,10 +308,117 @@ fn hub_has(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(format!("{:x}", Sha256::digest(&bytes)))
+}
+
+fn hub_path_string() -> Result<String> {
+    Ok(crate::paths::user_skills_dir()?
+        .to_string_lossy()
+        .into_owned())
+}
+
+/// True when Pi's settings list the absolute hub path at least once.
+pub fn pi_hub_is_registered() -> bool {
+    let Ok(path) = crate::paths::pi_settings_json() else {
+        return false;
+    };
+    let Ok(hub) = hub_path_string() else {
+        return false;
+    };
+    let Ok(map) = crate::settings::load(&path) else {
+        return false;
+    };
+    map.get("skills")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(hub.as_str())))
+}
+
+/// If `harnesses` includes Pi, ensure the hub path is listed once in Pi settings.
+pub fn ensure_pi_hub_if_targeted(harnesses: &[Harness]) -> Result<()> {
+    if harnesses.contains(&Harness::Pi) {
+        register_pi_hub()?;
+    }
+    Ok(())
+}
+
+/// Ensure the absolute hub path is present exactly once in
+/// `~/.pi/agent/settings.json` `skills: []`. Creates the key if absent.
+/// Preserves every other key. Does not rewrite when the path is already unique.
+pub fn register_pi_hub() -> Result<PiHubRegister> {
+    let path = crate::paths::pi_settings_json()?;
+    let hub = hub_path_string()?;
+
+    if path.exists() {
+        // Hash before rewriting a file we did not last write. Failure here
+        // refuses the rewrite.
+        sha256_file(&path)?;
+    }
+
+    let mut map = crate::settings::load(&path)?;
+    match map.get("skills") {
+        None => {}
+        Some(Value::Array(_)) => {}
+        Some(_) => anyhow::bail!(
+            "{} has a non-array `skills` key; refusing to overwrite it",
+            path.display()
+        ),
+    }
+
+    let skills = map
+        .entry("skills")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let arr = skills
+        .as_array_mut()
+        .expect("skills is an array after the check above");
+
+    let n = arr
+        .iter()
+        .filter(|v| v.as_str() == Some(hub.as_str()))
+        .count();
+    if n == 1 {
+        println!(
+            "  {} hub path {} already in {} skills[]",
+            "·".dimmed(),
+            hub,
+            path.display()
+        );
+        return Ok(PiHubRegister::Already);
+    }
+
+    if n == 0 {
+        arr.push(Value::String(hub.clone()));
+    } else {
+        let mut kept = false;
+        arr.retain(|v| {
+            if v.as_str() == Some(hub.as_str()) {
+                if kept {
+                    return false;
+                }
+                kept = true;
+                true
+            } else {
+                true
+            }
+        });
+    }
+
+    crate::settings::save(&path, &map)?;
+    println!(
+        "  {} registered {} in {} skills[]",
+        "+".green(),
+        hub,
+        path.display()
+    );
+    Ok(PiHubRegister::Wrote)
+}
+
 /// Copy nested plugin skill trees into the shared Agent Skill hub.
 /// Prints a skip line for harnesses that need a tree we will not invent.
 pub fn materialize_hub(qualified: &str, harnesses: &[Harness]) -> Result<Vec<String>> {
-    let want_hub = harnesses.iter().any(|h| h.hub_is_enough());
+    ensure_pi_hub_if_targeted(harnesses)?;
+    let want_hub = harnesses.iter().any(|h| h.uses_hub());
     for h in harnesses {
         if let Some(reason) = h.skill_skip_reason() {
             println!("  {} {}: {reason}", "·".dimmed(), h.as_str());
@@ -390,7 +541,7 @@ fn visibility(claude_active: bool, on_hub: bool) -> Visibility {
         visible.push(Harness::Claude);
     }
     for h in [Harness::Pi, Harness::Grok, Harness::Codex] {
-        if on_hub {
+        if on_hub && h.hub_is_enough() {
             visible.push(h);
         }
     }
@@ -432,14 +583,111 @@ mod tests {
         assert!(Harness::parse_name("project").is_err());
     }
 
+    fn with_pi_home<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = crate::paths::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let agents = home.join("agents");
+        std::fs::create_dir_all(agents.join("skills")).unwrap();
+        // SAFETY: held under HOME_ENV_LOCK; restored before the guard drops.
+        let prev_pi = std::env::var_os("PI_HOME");
+        let prev_agents = std::env::var_os("AGENTS_HOME");
+        std::env::set_var("PI_HOME", home);
+        std::env::set_var("AGENTS_HOME", &agents);
+        let out = f(home);
+        match prev_pi {
+            Some(v) => std::env::set_var("PI_HOME", v),
+            None => std::env::remove_var("PI_HOME"),
+        }
+        match prev_agents {
+            Some(v) => std::env::set_var("AGENTS_HOME", v),
+            None => std::env::remove_var("AGENTS_HOME"),
+        }
+        out
+    }
+
     #[test]
-    fn hub_is_enough_for_pi_grok_codex() {
-        assert!(Harness::Pi.hub_is_enough());
-        assert!(Harness::Grok.hub_is_enough());
-        assert!(Harness::Codex.hub_is_enough());
-        assert!(!Harness::Claude.hub_is_enough());
-        assert!(!Harness::Hermes.hub_is_enough());
-        assert!(!Harness::Kimi.hub_is_enough());
+    fn hub_sufficiency_marks_pi_conditional() {
+        assert_eq!(
+            Harness::Pi.hub_sufficiency(),
+            HubSufficiency::WhenRegistered
+        );
+        assert_eq!(Harness::Grok.hub_sufficiency(), HubSufficiency::Always);
+        assert_eq!(Harness::Codex.hub_sufficiency(), HubSufficiency::Always);
+        assert_eq!(Harness::Claude.hub_sufficiency(), HubSufficiency::Never);
+        assert_eq!(Harness::Hermes.hub_sufficiency(), HubSufficiency::Never);
+        assert_eq!(Harness::Kimi.hub_sufficiency(), HubSufficiency::Never);
+    }
+
+    #[test]
+    fn hub_is_enough_for_grok_codex_not_unregistered_pi() {
+        with_pi_home(|_| {
+            assert!(!Harness::Pi.hub_is_enough());
+            assert!(Harness::Grok.hub_is_enough());
+            assert!(Harness::Codex.hub_is_enough());
+            assert!(!Harness::Claude.hub_is_enough());
+            assert!(!Harness::Hermes.hub_is_enough());
+            assert!(!Harness::Kimi.hub_is_enough());
+        });
+    }
+
+    #[test]
+    fn register_pi_hub_is_idempotent() {
+        with_pi_home(|home| {
+            assert!(!Harness::Pi.hub_is_enough());
+            assert_eq!(register_pi_hub().unwrap(), PiHubRegister::Wrote);
+            assert!(Harness::Pi.hub_is_enough());
+            assert_eq!(register_pi_hub().unwrap(), PiHubRegister::Already);
+            assert_eq!(register_pi_hub().unwrap(), PiHubRegister::Already);
+            let settings: serde_json::Value = serde_json::from_slice(
+                &std::fs::read(home.join("agent").join("settings.json")).unwrap(),
+            )
+            .unwrap();
+            let hub = hub_path_string().unwrap();
+            let count = settings["skills"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|v| v.as_str() == Some(hub.as_str()))
+                .count();
+            assert_eq!(count, 1);
+        });
+    }
+
+    #[test]
+    fn register_pi_hub_preserves_other_keys() {
+        with_pi_home(|home| {
+            let path = home.join("agent").join("settings.json");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                r#"{
+  "defaultModel": "grok-4.6",
+  "defaultProvider": "xai",
+  "theme": "dark"
+}
+"#,
+            )
+            .unwrap();
+            register_pi_hub().unwrap();
+            let settings: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            assert_eq!(settings["defaultModel"], "grok-4.6");
+            assert_eq!(settings["defaultProvider"], "xai");
+            assert_eq!(settings["theme"], "dark");
+            let hub = hub_path_string().unwrap();
+            assert_eq!(
+                settings["skills"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .filter(|v| v.as_str() == Some(hub.as_str()))
+                    .count(),
+                1
+            );
+        });
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,6 +1,10 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
+/// Tests that mutate `AGENTS_HOME` or `PI_HOME` must hold this for the duration.
+#[cfg(test)]
+pub(crate) static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub fn claude_home() -> Result<PathBuf> {
     if let Ok(p) = std::env::var("CLAUDE_HOME") {
         return Ok(PathBuf::from(p));
@@ -62,6 +66,20 @@ pub fn agents_home() -> Result<PathBuf> {
 /// visible to any compliant client (Claude Code, Grok CLI, …), not just Claude.
 pub fn user_skills_dir() -> Result<PathBuf> {
     Ok(agents_home()?.join("skills"))
+}
+
+/// `~/.pi/` — Pi's agent home. Override with `PI_HOME` (mirrors `CLAUDE_HOME`).
+pub fn pi_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("PI_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".pi"))
+}
+
+/// `~/.pi/agent/settings.json` — Pi's settings, including the `skills: []` scan roots.
+pub fn pi_settings_json() -> Result<PathBuf> {
+    Ok(pi_home()?.join("agent").join("settings.json"))
 }
 
 /// ~/.agents/skills/.zskills.json — our inventory of which Agent Skills we manage and where they came from.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -15,6 +15,7 @@ fn zskills(home: &TempDir) -> Command {
     // `<tempdir>/skills/` is the install target (mirrors the production layout
     // where ~/.agents/skills/ lives alongside ~/.claude/).
     cmd.env("AGENTS_HOME", home.path());
+    // Sandbox Pi settings so tests never write the developer's `~/.pi`.
     cmd.env("PI_HOME", home.path().join("pi"));
     // Sandbox the clone cache too, so repo-install tests never touch ~/.cache.
     cmd.env("XDG_CACHE_HOME", home.path().join("cache"));
@@ -3048,4 +3049,114 @@ harnesses = ["pi"]
     assert!(settings["enabledPlugins"]
         .get("pi@zot24-skills")
         .is_none_or(|v| v == false));
+}
+
+#[test]
+fn hub_skill_is_not_visible_to_unregistered_pi() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    zskills(&home)
+        .args(["plugin", "install", "pi@zot24-skills", "--harness", "grok"])
+        .assert()
+        .success();
+
+    let out = zskills(&home)
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    let vis = v["agent_skills"]["harnesses"]["pi"]["visible"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        vis.iter().any(|x| x == "grok"),
+        "Grok scans the hub natively: {v}"
+    );
+    assert!(
+        !vis.iter().any(|x| x == "pi"),
+        "unregistered Pi must not look hub-enough: {v}"
+    );
+    assert!(
+        !home
+            .path()
+            .join("pi")
+            .join("agent")
+            .join("settings.json")
+            .is_file(),
+        "grok-only install must not write Pi settings"
+    );
+}
+
+#[test]
+fn skill_register_pi_hub_is_idempotent_and_preserves_keys() {
+    let home = fake_home();
+    let settings_path = home.path().join("pi").join("agent").join("settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(
+        &settings_path,
+        r#"{
+  "defaultModel": "grok-4.6",
+  "defaultProvider": "xai",
+  "theme": "dark"
+}
+"#,
+    )
+    .unwrap();
+
+    zskills(&home)
+        .args(["skill", "register-pi-hub"])
+        .assert()
+        .success();
+    zskills(&home)
+        .args(["skill", "register-pi-hub"])
+        .assert()
+        .success();
+
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    let hub = home.path().join("skills");
+    let hub_s = hub.to_string_lossy().into_owned();
+    let count = settings["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|v| v.as_str() == Some(hub_s.as_str()))
+        .count();
+    assert_eq!(
+        count, 1,
+        "second run must not duplicate the hub path: {settings}"
+    );
+    assert_eq!(settings["defaultModel"], "grok-4.6");
+    assert_eq!(settings["defaultProvider"], "xai");
+    assert_eq!(settings["theme"], "dark");
+}
+
+#[test]
+fn plugin_install_harness_pi_registers_hub_in_pi_settings() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    zskills(&home)
+        .args(["plugin", "install", "pi@zot24-skills", "--harness", "pi"])
+        .assert()
+        .success();
+
+    let settings_path = home.path().join("pi").join("agent").join("settings.json");
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    let hub = home.path().join("skills");
+    let hub_s = hub.to_string_lossy().into_owned();
+    let count = settings["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|v| v.as_str() == Some(hub_s.as_str()))
+        .count();
+    assert_eq!(
+        count, 1,
+        "plugin --harness pi must register the hub: {settings}"
+    );
 }


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `bug`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`

## Summary
- `hub_is_enough()` treated Pi as a harness that already scans `~/.agents/skills`. That is false.
- Pi loads skills from `~/.pi/agent/skills/`, from `<cwd>/.pi/skills/`, and from the `skills: []` array in `~/.pi/agent/settings.json`. It does not scan the Agent Skill hub until that array lists the hub path.
- This change adds `zskills skill register-pi-hub`. The command writes the absolute hub path into `skills: []` exactly once. A second run does not rewrite the file.
- Agent Skill install and `sync` apply call the same registration when Pi is a target.
- `hub_is_enough()` now follows `HubSufficiency`. Grok and Codex stay `Always`. Pi is `WhenRegistered`. Claude, Hermes, and Kimi stay `Never`. Unregistered Pi is not reported as visible.
- The first commit archives the untracked PR #24 `CLOSEOUT.md` at `docs/closeouts/CLOSEOUT.md`.

## How It Works (diagram — REQUIRED)

Pi does not scan the hub by itself. The CLI reads `~/.pi/agent/settings.json`, hashes the existing bytes so a read failure refuses the write, and inserts `user_skills_dir()` into `skills: []` when the path is missing or duplicated.

```mermaid
sequenceDiagram
    participant User
    participant CLI as zskills skill register-pi-hub
    participant Reg as register_pi_hub
    participant Hub as paths user_skills_dir
    participant File as pi settings.json
    User->>CLI: run
    CLI->>Reg: invoke
    Reg->>Hub: absolute hub path
    Hub-->>Reg: AGENTS_HOME/skills
    Reg->>File: SHA-256 existing bytes
    Reg->>File: load JSON object
    alt skills key missing
        Reg->>File: create skills array
    end
    alt hub path already present once
        Reg-->>CLI: Already
        CLI-->>User: already registered
    else hub path absent or duplicated
        Reg->>File: write unique hub path
        File-->>CLI: Wrote
        CLI-->>User: registered
    end
```

```mermaid
flowchart TD
    start[hub_is_enough]
    start --> policy[hub_sufficiency]
    policy -->|Grok or Codex| always[Always true]
    policy -->|Pi| check[WhenRegistered]
    policy -->|Claude Hermes Kimi| never[Never false]
    check --> file{hub path in Pi skills array}
    file -->|yes| yes[true]
    file -->|no| no[false]
```

## Linked Issues / ADRs
- Resolves: #38
- Part of: #37 (harness roots stay on `feat/harness-skill-roots`)

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Registration tests use `PI_HOME` and `AGENTS_HOME` temp dirs. They do not write the developer `~/.pi`.

```
$ cargo fmt --check
(exit 0, no diff)

$ cargo clippy --all-targets -- -D warnings
    Checking zskills v1.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.28s

$ cargo test
running 73 tests
test result: ok. 73 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 95 tests
test result: ok. 95 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Live machine (hash before rewrite, then two runs of `cargo run --quiet -- skill register-pi-hub` with `PI_HOME` and `AGENTS_HOME` unset):

```
before  43530d7f92321cd3329474cb783a9e9e1fcf3e9d1d57c012263198abb940754c
after1  b1f51789cea1405a28bd337ad16b5ad955d6a8ca5a9ea456e5ba1564aa0886ea
after2  b1f51789cea1405a28bd337ad16b5ad955d6a8ca5a9ea456e5ba1564aa0886ea

$ python3 -c "import json;s=json.load(open('/Users/anon/.pi/agent/settings.json'));print(s.get('skills',[]).count('/Users/anon/.agents/skills'))"
1
```

Keys after the write: `lastChangelogVersion`, `defaultProvider`, `defaultModel`, `packages`, `extensions`, `theme`, `defaultThinkingLevel`, `hideThinkingBlock`, `skills`. No copy was written under `~/.pi/agent/skills/`.

## Additional Notes for Reviewers
- Owner decision: register the hub in Pi settings. Do not copy Agent Skills into `~/.pi/agent/skills/`.
- Evidence that Pi does not scan the hub: zero `.agents/skills` literals in the Pi bundle. Pi honours `skills: []` via `getSkillPaths` / `setSkillPaths` and a repeatable `--skill <path>` flag.
- `sha256_file` on the existing settings file refuses the write when the read fails. The function does not compare the digest at save time. A concurrent edit between load and save is not detected.
- The `zskills 1.1.0` binary on PATH was installed from `main`. It does not contain `register-pi-hub`. The live registration used `cargo run` from this branch.
- Do not merge this PR from the agent seat. Do not close #38 from `gh issue close`.
