### PR TITLE
feat: symlink hub skills into per-harness roots

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -227,6 +227,9 @@ pub enum PluginCmd {
             value_name = "HARNESS"
         )]
         harness: Vec<crate::harness::Harness>,
+        /// Hermes skills category. Default: software-development.
+        #[arg(long, default_value = "software-development", value_name = "CATEGORY")]
+        category: String,
         skills: Vec<String>,
     },
     /// Drop enabledPlugins + inventory; keep bytes
@@ -275,6 +278,9 @@ pub enum AgentSkillCmd {
             value_name = "HARNESS"
         )]
         harness: Vec<crate::harness::Harness>,
+        /// Hermes skills category. Default: software-development.
+        #[arg(long, default_value = "software-development", value_name = "CATEGORY")]
+        category: String,
         #[arg(
             value_name = "SOURCE",
             help = "owner/repo, https://, git@ or file:// URL"
@@ -379,6 +385,7 @@ impl Cli {
                     skills,
                     interactive,
                     harness,
+                    category,
                 } => {
                     if skills
                         .iter()
@@ -388,7 +395,14 @@ impl Cli {
                             "plugin install takes name or name@marketplace; use `zskills skill install` for owner/repo"
                         );
                     }
-                    crate::commands::install::run(skills, interactive, false, None, harness)
+                    crate::commands::install::run(
+                        skills,
+                        interactive,
+                        false,
+                        None,
+                        harness,
+                        category,
+                    )
                 }
                 PluginCmd::Remove {
                     skills,
@@ -405,9 +419,15 @@ impl Cli {
                     all,
                     skill,
                     harness,
-                } => {
-                    crate::commands::agent_skills::install(skills, interactive, all, skill, harness)
-                }
+                    category,
+                } => crate::commands::agent_skills::install(
+                    skills,
+                    interactive,
+                    all,
+                    skill,
+                    harness,
+                    category,
+                ),
                 AgentSkillCmd::Remove { names, force, file } => {
                     crate::commands::agent_skills::remove(names, force, file)
                 }

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -10,6 +10,7 @@ pub fn install(
     all: bool,
     skill: Option<String>,
     harness: Vec<crate::harness::Harness>,
+    category: String,
 ) -> Result<()> {
     if specs
         .iter()
@@ -19,7 +20,7 @@ pub fn install(
             "skill install takes owner/repo or a git URL; use `zskills plugin install` for name@marketplace"
         );
     }
-    crate::commands::install::run(specs, interactive, all, skill, harness)
+    crate::commands::install::run(specs, interactive, all, skill, harness, category)
 }
 
 pub fn upgrade(names: Vec<String>) -> Result<()> {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -23,9 +23,10 @@ pub fn run(
     all: bool,
     skill: Option<String>,
     harness: Vec<crate::harness::Harness>,
+    category: String,
 ) -> Result<()> {
     if interactive && specs.is_empty() {
-        return run_interactive_browse_marketplaces(harness);
+        return run_interactive_browse_marketplaces(harness, category);
     }
 
     if specs.is_empty() {
@@ -43,14 +44,21 @@ pub fn run(
 
     let mut failures = 0usize;
     for spec in &repo_specs {
-        if let Err(e) = install_from_repo(spec, interactive, all, skill.as_deref(), &harness) {
+        if let Err(e) = install_from_repo(
+            spec,
+            interactive,
+            all,
+            skill.as_deref(),
+            &harness,
+            &category,
+        ) {
             eprintln!("{} {}: {}", "✗".red(), spec, e);
             failures += 1;
         }
     }
 
     if !plugin_specs.is_empty() {
-        failures += install_plugin_specs(plugin_specs, &harness)?;
+        failures += install_plugin_specs(plugin_specs, &harness, &category)?;
     }
 
     // Printing an error and exiting 0 makes every failure invisible to `set -e`,
@@ -80,6 +88,7 @@ fn install_from_repo(
     all: bool,
     skill: Option<&str>,
     harness: &[crate::harness::Harness],
+    category: &str,
 ) -> Result<()> {
     let (defaults, _) = crate::harness::load_defaults();
     let hs = crate::harness::resolve(harness, &defaults, &[], crate::harness::default_skill())?;
@@ -159,7 +168,7 @@ fn install_from_repo(
                 .collect::<Vec<_>>()
                 .join(", ")
         );
-        return install_chosen(spec, &[name.to_string()]);
+        return install_chosen(spec, &[name.to_string()], &hs, category);
     }
 
     const AUTO_INSTALL_MAX: usize = 5;
@@ -186,13 +195,19 @@ fn install_from_repo(
         return Ok(());
     }
 
-    install_chosen(spec, &chosen)
+    install_chosen(spec, &chosen, &hs, category)
 }
 
-fn install_chosen(spec: &str, chosen: &[String]) -> Result<()> {
+fn install_chosen(
+    spec: &str,
+    chosen: &[String],
+    hs: &[crate::harness::Harness],
+    category: &str,
+) -> Result<()> {
     for name in chosen {
         match crate::agent_skill::install(spec, Some(name)) {
             Ok(installed) => {
+                crate::harness::link_hub_to_harnesses(&installed, hs, category)?;
                 for n in installed {
                     println!(
                         "{} {} {}",
@@ -255,7 +270,11 @@ fn print_large_collection_summary(
     );
 }
 
-fn install_plugin_specs(specs: Vec<String>, harness: &[crate::harness::Harness]) -> Result<usize> {
+fn install_plugin_specs(
+    specs: Vec<String>,
+    harness: &[crate::harness::Harness],
+    category: &str,
+) -> Result<usize> {
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
     if known.is_empty() {
         println!(
@@ -269,7 +288,7 @@ fn install_plugin_specs(specs: Vec<String>, harness: &[crate::harness::Harness])
     let targets =
         crate::harness::resolve(harness, &defaults, &[], crate::harness::default_plugin())?;
     let want_claude = targets.contains(&crate::harness::Harness::Claude);
-    let want_hub = targets.iter().any(|h| h.uses_hub());
+    let want_hub = targets.iter().any(|h| h.needs_hub_copy());
 
     let settings_path = crate::paths::settings_json()?;
     let mut settings = crate::settings::load(&settings_path)?;
@@ -325,7 +344,7 @@ fn install_plugin_specs(specs: Vec<String>, harness: &[crate::harness::Harness])
     }
     if want_hub || targets.iter().any(|h| h.skill_skip_reason().is_some()) {
         for q in &resolved {
-            match crate::harness::materialize_hub(q, &targets) {
+            match crate::harness::materialize_hub(q, &targets, category) {
                 Ok(names) if !names.is_empty() => {
                     println!(
                         "  {} copied {} nested skill(s) from {} into the Agent Skill hub",
@@ -408,7 +427,10 @@ pub(crate) fn materialize_plugins(qualified: &[String]) -> Result<usize> {
     Ok(installed)
 }
 
-fn run_interactive_browse_marketplaces(harness: Vec<crate::harness::Harness>) -> Result<()> {
+fn run_interactive_browse_marketplaces(
+    harness: Vec<crate::harness::Harness>,
+    category: String,
+) -> Result<()> {
     use crate::interactive::Item;
 
     let known = crate::marketplace::load_known(&crate::paths::known_marketplaces_json()?)?;
@@ -457,6 +479,7 @@ fn run_interactive_browse_marketplaces(harness: Vec<crate::harness::Harness>) ->
             false,
             None,
             harness,
+            category,
         )?,
     }
     Ok(())

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -129,7 +129,14 @@ fn install_from_hits(hits: &[Hit]) -> Result<()> {
         Some(idx) => {
             let h = &hits[idx];
             let spec = format!("{}@{}", h.name, h.marketplace);
-            crate::commands::install::run(vec![spec], false, false, None, Vec::new())?;
+            crate::commands::install::run(
+                vec![spec],
+                false,
+                false,
+                None,
+                Vec::new(),
+                crate::harness::DEFAULT_HERMES_CATEGORY.to_string(),
+            )?;
             // search -i always produces name@marketplace (plugin path).
         }
     }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -64,7 +64,7 @@ pub fn run(
         }
         if targets
             .iter()
-            .any(|h| h.uses_hub() || h.skill_skip_reason().is_some())
+            .any(|h| h.needs_hub_copy() || h.skill_skip_reason().is_some())
         {
             plugin_copies.push((qualified, targets));
         }
@@ -246,7 +246,7 @@ pub fn run(
     for (q, hs) in &plugin_copies {
         let dests = hs
             .iter()
-            .filter(|h| h.uses_hub())
+            .filter(|h| h.needs_hub_copy())
             .map(|h| h.as_str())
             .collect::<Vec<_>>()
             .join(", ");
@@ -450,7 +450,7 @@ pub fn run(
     }
 
     for (q, hs) in &plugin_copies {
-        match crate::harness::materialize_hub(q, hs) {
+        match crate::harness::materialize_hub(q, hs, crate::harness::DEFAULT_HERMES_CATEGORY) {
             Ok(names) => {
                 if !names.is_empty() {
                     println!(
@@ -477,6 +477,11 @@ pub fn run(
             match crate::agent_skill::install_npm(pkg, entry.install_cmd.as_deref(), &entry.claims)
             {
                 Ok(names) => {
+                    crate::harness::link_hub_to_harnesses(
+                        &names,
+                        &hs,
+                        crate::harness::DEFAULT_HERMES_CATEGORY,
+                    )?;
                     println!(
                         "  {} npm:{}  ({} skill{})",
                         "✓".green(),
@@ -508,6 +513,11 @@ pub fn run(
                 };
                 if already_present {
                     if let Some(n) = name {
+                        crate::harness::link_hub_to_harnesses(
+                            &[n.to_string()],
+                            &hs,
+                            crate::harness::DEFAULT_HERMES_CATEGORY,
+                        )?;
                         println!(
                             "  {} {}  {}",
                             "·".dimmed(),
@@ -519,6 +529,11 @@ pub fn run(
                 }
                 match crate::agent_skill::install(src, name) {
                     Ok(names) => {
+                        crate::harness::link_hub_to_harnesses(
+                            &names,
+                            &hs,
+                            crate::harness::DEFAULT_HERMES_CATEGORY,
+                        )?;
                         for n in &names {
                             println!("  installed agent skill {}", n.bold());
                         }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,12 +1,13 @@
 //! Which coding harness can see a name.
 //!
 //! Tokens are harnesses (`claude`, `pi`, `hermes`, `kimi`, `grok`, `codex`),
-//! not directories. Grok and Codex scan the shared hub
-//! `~/.agents/skills/<name>/`. Pi scans the hub only after the absolute hub
-//! path is listed in `~/.pi/agent/settings.json` `skills: []`. This module
-//! copies a nested marketplace `skills/<name>/` tree into that hub. It does
-//! not symlink. Extra per-harness trees are not invented when the hub is
-//! enough.
+//! not directories. Grok scans the shared hub `~/.agents/skills/<name>/`.
+//! Pi scans the hub only after the absolute hub path is listed in
+//! `~/.pi/agent/settings.json` `skills: []`. Plugin nested skills are **copied**
+//! into the hub (a plugin cache path is version-stamped, so a link would break
+//! on upgrade). Hub → harness is a **symlink** into `~/.claude/skills/<name>`,
+//! `~/.codex/skills/<name>`, or `~/.hermes/skills/<category>/<name>/`, because
+//! the hub path is stable and `skill upgrade` must propagate.
 
 use anyhow::{Context, Result};
 use clap::ValueEnum;
@@ -75,9 +76,9 @@ impl Harness {
     /// How this harness learns about skills that live on the hub.
     pub fn hub_sufficiency(self) -> HubSufficiency {
         match self {
-            Self::Grok | Self::Codex => HubSufficiency::Always,
+            Self::Grok => HubSufficiency::Always,
             Self::Pi => HubSufficiency::WhenRegistered,
-            Self::Claude | Self::Hermes | Self::Kimi => HubSufficiency::Never,
+            Self::Claude | Self::Hermes | Self::Kimi | Self::Codex => HubSufficiency::Never,
         }
     }
 
@@ -117,13 +118,69 @@ impl Harness {
 
     pub fn skill_skip_reason(self) -> Option<&'static str> {
         match self {
-            Self::Hermes => {
-                Some("unsupported (category tree ~/.hermes/skills/<cat>/<name>/; not writing)")
+            Self::Kimi => {
+                Some("unsupported (no cited skills directory under ~/.kimi-code/; not inventing a folder)")
             }
-            Self::Kimi => Some("unsupported (no cited skills directory; not inventing a folder)"),
             _ => None,
         }
     }
+
+    /// Home directory used to detect whether this harness is present.
+    pub fn home_dir(self) -> Result<PathBuf> {
+        match self {
+            Self::Claude => crate::paths::claude_home(),
+            Self::Pi => crate::paths::pi_home(),
+            Self::Grok => crate::paths::grok_home(),
+            Self::Hermes => crate::paths::hermes_home(),
+            Self::Kimi => crate::paths::kimi_home(),
+            Self::Codex => crate::paths::codex_home(),
+        }
+    }
+
+    pub fn home_dir_exists(self) -> bool {
+        self.home_dir().map(|p| p.is_dir()).unwrap_or(false)
+    }
+
+    /// Per-harness skill directory for `name`, or `None` when the hub is enough
+    /// (Pi, Grok) or the harness is unsupported (Kimi).
+    pub fn skill_root(self, name: &str, category: &str) -> Result<Option<PathBuf>> {
+        crate::agent_skill::validate_skill_name(name)?;
+        match self {
+            Self::Pi | Self::Grok | Self::Kimi => Ok(None),
+            Self::Claude => Ok(Some(crate::paths::claude_home()?.join("skills").join(name))),
+            Self::Codex => Ok(Some(crate::paths::codex_home()?.join("skills").join(name))),
+            Self::Hermes => {
+                validate_hermes_category(category)?;
+                Ok(Some(
+                    crate::paths::hermes_home()?
+                        .join("skills")
+                        .join(category)
+                        .join(name),
+                ))
+            }
+        }
+    }
+
+    /// True when a hub copy is required as the symlink source or as the scan root.
+    pub fn needs_hub_copy(self) -> bool {
+        self.uses_hub() || matches!(self, Self::Codex | Self::Hermes)
+    }
+}
+
+/// Default Hermes category. `--category` overrides this. Do not invent others.
+pub const DEFAULT_HERMES_CATEGORY: &str = "software-development";
+
+pub fn validate_hermes_category(category: &str) -> Result<()> {
+    anyhow::ensure!(!category.is_empty(), "category must not be empty");
+    anyhow::ensure!(
+        category != "." && category != "..",
+        "category must not be . or .."
+    );
+    anyhow::ensure!(
+        !category.contains('/') && !category.contains('\\'),
+        "category must be a single path segment"
+    );
+    Ok(())
 }
 
 pub fn parse_names(names: &[String]) -> Result<Vec<Harness>> {
@@ -152,9 +209,20 @@ pub fn default_plugin() -> Vec<Harness> {
     vec![Harness::Claude]
 }
 
-/// Agent Skill with no `[defaults].harnesses` and no `--harness`: hub only.
+/// Agent Skill with no `[defaults].harnesses` and no `--harness`: every
+/// harness whose home directory exists, minus those with `skill_skip_reason`.
 pub fn default_skill() -> Vec<Harness> {
-    vec![Harness::Pi, Harness::Grok, Harness::Codex]
+    [
+        Harness::Claude,
+        Harness::Pi,
+        Harness::Hermes,
+        Harness::Kimi,
+        Harness::Grok,
+        Harness::Codex,
+    ]
+    .into_iter()
+    .filter(|h| h.home_dir_exists() && h.skill_skip_reason().is_none())
+    .collect()
 }
 
 /// CLI `--harness` wins. Else `[defaults].harnesses`. Else today's default.
@@ -414,11 +482,115 @@ pub fn register_pi_hub() -> Result<PiHubRegister> {
     Ok(PiHubRegister::Wrote)
 }
 
+fn skill_md_resolves(dir: &Path) -> bool {
+    dir.join("SKILL.md").is_file()
+}
+
+fn claude_skills_dir() -> Result<PathBuf> {
+    Ok(crate::paths::claude_home()?.join("skills"))
+}
+
+/// True when Claude's user-skill root has `name`. A hub copy sitting at the
+/// same path (collapsed `CLAUDE_HOME`/`AGENTS_HOME` in tests) does not count
+/// unless that path is a symlink.
+fn claude_has_skill(name: &str) -> bool {
+    let Ok(dest) = claude_skills_dir().map(|d| d.join(name)) else {
+        return false;
+    };
+    if !skill_md_resolves(&dest) {
+        return false;
+    }
+    let Ok(hub) = crate::paths::user_skills_dir() else {
+        return true;
+    };
+    if dest.parent() == Some(hub.as_path()) {
+        return dest
+            .symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false);
+    }
+    true
+}
+
+/// Symlink hub `<name>` into each targeted harness that has a `skill_root`.
+/// Plugin → hub stays a copy; this is hub → harness only.
+pub fn link_hub_to_harnesses(
+    names: &[String],
+    harnesses: &[Harness],
+    category: &str,
+) -> Result<()> {
+    let hub_root = crate::paths::user_skills_dir()?;
+    for h in unique(harnesses) {
+        if h.skill_skip_reason().is_some() {
+            continue;
+        }
+        for name in names {
+            let hub = hub_root.join(name);
+            if !skill_md_resolves(&hub) {
+                continue;
+            }
+            let Some(dest) = h.skill_root(name, category)? else {
+                continue;
+            };
+            symlink_hub_into(&hub, &dest)?;
+        }
+    }
+    Ok(())
+}
+
+fn symlink_hub_into(hub: &Path, dest: &Path) -> Result<()> {
+    if dest == hub {
+        return Ok(());
+    }
+    if let Ok(meta) = dest.symlink_metadata() {
+        if meta.file_type().is_symlink() {
+            if let Ok(target) = std::fs::read_link(dest) {
+                if target == hub {
+                    return Ok(());
+                }
+            }
+            std::fs::remove_file(dest)
+                .with_context(|| format!("replacing symlink at {}", dest.display()))?;
+        } else {
+            println!(
+                "  {} leaving {} (not a symlink; hub → harness will not clobber it)",
+                "·".dimmed(),
+                dest.display()
+            );
+            return Ok(());
+        }
+    }
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(hub, dest)
+        .with_context(|| format!("linking {} → {}", dest.display(), hub.display()))?;
+    #[cfg(not(unix))]
+    anyhow::bail!(
+        "hub → harness symlink is not supported on this OS ({} → {})",
+        dest.display(),
+        hub.display()
+    );
+    println!(
+        "  {} {} → {} (link)",
+        "+".green(),
+        dest.display(),
+        hub.display()
+    );
+    Ok(())
+}
+
 /// Copy nested plugin skill trees into the shared Agent Skill hub.
 /// Prints a skip line for harnesses that need a tree we will not invent.
-pub fn materialize_hub(qualified: &str, harnesses: &[Harness]) -> Result<Vec<String>> {
+pub fn materialize_hub(
+    qualified: &str,
+    harnesses: &[Harness],
+    category: &str,
+) -> Result<Vec<String>> {
     ensure_pi_hub_if_targeted(harnesses)?;
-    let want_hub = harnesses.iter().any(|h| h.uses_hub());
+    let want_hub = harnesses.iter().any(|h| h.needs_hub_copy());
     for h in harnesses {
         if let Some(reason) = h.skill_skip_reason() {
             println!("  {} {}: {reason}", "·".dimmed(), h.as_str());
@@ -442,6 +614,8 @@ pub fn materialize_hub(qualified: &str, harnesses: &[Harness]) -> Result<Vec<Str
     }
     if !copied.is_empty() {
         record_plugin_copies(qualified, &copied)?;
+        let names: Vec<String> = copied.iter().cloned().collect();
+        link_hub_to_harnesses(&names, harnesses, category)?;
     }
     Ok(copied.into_iter().collect())
 }
@@ -527,28 +701,44 @@ impl Visibility {
 pub fn visibility_for_plugin(qualified: &str, active: bool) -> Visibility {
     let names = plugin_skill_names(qualified);
     let on_hub = names.iter().any(|n| hub_has(n));
-    visibility(active, on_hub)
+    visibility(active, on_hub, &names)
 }
 
 pub fn visibility_for_skill(name: &str) -> Visibility {
-    visibility(false, hub_has(name))
+    visibility(claude_has_skill(name), hub_has(name), &[name.to_string()])
 }
 
-fn visibility(claude_active: bool, on_hub: bool) -> Visibility {
+fn visibility(claude_active: bool, on_hub: bool, names: &[String]) -> Visibility {
     let mut visible = Vec::new();
     let mut skipped = Vec::new();
     if claude_active {
         visible.push(Harness::Claude);
     }
-    for h in [Harness::Pi, Harness::Grok, Harness::Codex] {
+    for h in [Harness::Pi, Harness::Grok] {
         if on_hub && h.hub_is_enough() {
             visible.push(h);
         }
     }
-    for h in [Harness::Hermes, Harness::Kimi] {
-        if let Some(r) = h.skill_skip_reason() {
-            skipped.push((h, r));
-        }
+    if names.iter().any(|n| {
+        Harness::Codex
+            .skill_root(n, DEFAULT_HERMES_CATEGORY)
+            .ok()
+            .flatten()
+            .is_some_and(|p| skill_md_resolves(&p))
+    }) {
+        visible.push(Harness::Codex);
+    }
+    if names.iter().any(|n| {
+        Harness::Hermes
+            .skill_root(n, DEFAULT_HERMES_CATEGORY)
+            .ok()
+            .flatten()
+            .is_some_and(|p| skill_md_resolves(&p))
+    }) {
+        visible.push(Harness::Hermes);
+    }
+    if let Some(r) = Harness::Kimi.skill_skip_reason() {
+        skipped.push((Harness::Kimi, r));
     }
     Visibility { visible, skipped }
 }
@@ -615,22 +805,30 @@ mod tests {
             HubSufficiency::WhenRegistered
         );
         assert_eq!(Harness::Grok.hub_sufficiency(), HubSufficiency::Always);
-        assert_eq!(Harness::Codex.hub_sufficiency(), HubSufficiency::Always);
+        assert_eq!(Harness::Codex.hub_sufficiency(), HubSufficiency::Never);
         assert_eq!(Harness::Claude.hub_sufficiency(), HubSufficiency::Never);
         assert_eq!(Harness::Hermes.hub_sufficiency(), HubSufficiency::Never);
         assert_eq!(Harness::Kimi.hub_sufficiency(), HubSufficiency::Never);
     }
 
     #[test]
-    fn hub_is_enough_for_grok_codex_not_unregistered_pi() {
+    fn hub_is_enough_for_grok_not_unregistered_pi_or_codex() {
         with_pi_home(|_| {
             assert!(!Harness::Pi.hub_is_enough());
             assert!(Harness::Grok.hub_is_enough());
-            assert!(Harness::Codex.hub_is_enough());
+            assert!(!Harness::Codex.hub_is_enough());
             assert!(!Harness::Claude.hub_is_enough());
             assert!(!Harness::Hermes.hub_is_enough());
             assert!(!Harness::Kimi.hub_is_enough());
         });
+    }
+
+    #[test]
+    fn kimi_skip_reason_names_kimi_code_not_kimi() {
+        let reason = Harness::Kimi.skill_skip_reason().unwrap();
+        assert!(reason.contains("~/.kimi-code/"), "{reason}");
+        assert!(!reason.contains("~/.kimi/"), "{reason}");
+        assert!(Harness::Hermes.skill_skip_reason().is_none());
     }
 
     #[test]
@@ -688,6 +886,112 @@ mod tests {
                 1
             );
         });
+    }
+
+    #[test]
+    fn default_skill_hybrid_present_homes_minus_skipped() {
+        let _guard = crate::paths::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("claude")).unwrap();
+        std::fs::create_dir_all(root.join("grok")).unwrap();
+        std::fs::create_dir_all(root.join("kimi-code")).unwrap();
+        let keys = [
+            ("CLAUDE_HOME", root.join("claude")),
+            ("PI_HOME", root.join("pi")),
+            ("GROK_HOME", root.join("grok")),
+            ("HERMES_HOME", root.join("hermes")),
+            ("KIMI_HOME", root.join("kimi-code")),
+            ("CODEX_HOME", root.join("codex")),
+        ];
+        // SAFETY: held under HOME_ENV_LOCK; restored before the guard drops.
+        let prev: Vec<_> = keys
+            .iter()
+            .map(|(k, v)| {
+                let old = std::env::var_os(k);
+                std::env::set_var(k, v);
+                (*k, old)
+            })
+            .collect();
+        let got = default_skill();
+        for (k, old) in prev {
+            match old {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+        assert_eq!(got, vec![Harness::Claude, Harness::Grok]);
+    }
+
+    #[test]
+    fn skill_root_paths() {
+        let _guard = crate::paths::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let keys = [
+            ("CLAUDE_HOME", root.join("claude")),
+            ("CODEX_HOME", root.join("codex")),
+            ("HERMES_HOME", root.join("hermes")),
+        ];
+        // SAFETY: held under HOME_ENV_LOCK; restored before the guard drops.
+        let prev: Vec<_> = keys
+            .iter()
+            .map(|(k, v)| {
+                let old = std::env::var_os(k);
+                std::env::set_var(k, v);
+                (*k, old)
+            })
+            .collect();
+        let claude = Harness::Claude
+            .skill_root("demo", DEFAULT_HERMES_CATEGORY)
+            .unwrap()
+            .unwrap();
+        let codex = Harness::Codex
+            .skill_root("demo", DEFAULT_HERMES_CATEGORY)
+            .unwrap()
+            .unwrap();
+        let hermes = Harness::Hermes
+            .skill_root("demo", DEFAULT_HERMES_CATEGORY)
+            .unwrap()
+            .unwrap();
+        let custom = Harness::Hermes
+            .skill_root("demo", "devops")
+            .unwrap()
+            .unwrap();
+        assert!(Harness::Pi
+            .skill_root("demo", DEFAULT_HERMES_CATEGORY)
+            .unwrap()
+            .is_none());
+        assert!(Harness::Grok
+            .skill_root("demo", DEFAULT_HERMES_CATEGORY)
+            .unwrap()
+            .is_none());
+        for (k, old) in prev {
+            match old {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+        assert_eq!(claude, root.join("claude").join("skills").join("demo"));
+        assert_eq!(codex, root.join("codex").join("skills").join("demo"));
+        assert_eq!(
+            hermes,
+            root.join("hermes")
+                .join("skills")
+                .join("software-development")
+                .join("demo")
+        );
+        assert_eq!(
+            custom,
+            root.join("hermes")
+                .join("skills")
+                .join("devops")
+                .join("demo")
+        );
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -82,6 +82,42 @@ pub fn pi_settings_json() -> Result<PathBuf> {
     Ok(pi_home()?.join("agent").join("settings.json"))
 }
 
+/// `~/.grok/` — Grok's home. Override with `GROK_HOME`.
+pub fn grok_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("GROK_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".grok"))
+}
+
+/// `~/.hermes/` — Hermes home. Override with `HERMES_HOME`.
+pub fn hermes_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("HERMES_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".hermes"))
+}
+
+/// `~/.kimi-code/` — Kimi's home. Override with `KIMI_HOME`.
+pub fn kimi_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("KIMI_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".kimi-code"))
+}
+
+/// `~/.codex/` — Codex home. Override with `CODEX_HOME`.
+pub fn codex_home() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("CODEX_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".codex"))
+}
+
 /// ~/.agents/skills/.zskills.json — our inventory of which Agent Skills we manage and where they came from.
 pub fn agent_skills_inventory() -> Result<PathBuf> {
     Ok(user_skills_dir()?.join(".zskills.json"))

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,6 +17,13 @@ fn zskills(home: &TempDir) -> Command {
     cmd.env("AGENTS_HOME", home.path());
     // Sandbox Pi settings so tests never write the developer's `~/.pi`.
     cmd.env("PI_HOME", home.path().join("pi"));
+    // Sandbox every other harness home. Directories are not created here, so
+    // `default_skill()` hybrid detection does not pick them up unless a test
+    // mkdirs them, and visibility never reads the developer's real roots.
+    cmd.env("GROK_HOME", home.path().join("grok"));
+    cmd.env("HERMES_HOME", home.path().join("hermes"));
+    cmd.env("CODEX_HOME", home.path().join("codex"));
+    cmd.env("KIMI_HOME", home.path().join("kimi-code"));
     // Sandbox the clone cache too, so repo-install tests never touch ~/.cache.
     cmd.env("XDG_CACHE_HOME", home.path().join("cache"));
     // Sandbox manifest discovery. `manifest::discover()` reads
@@ -622,6 +629,10 @@ fn zskills_nested(parent: &TempDir, claude_home: &std::path::Path) -> Command {
     // Pin the cross-client Agent Skills home next to CLAUDE_HOME so tests stay sandboxed.
     cmd.env("AGENTS_HOME", parent.path().join(".agents"));
     cmd.env("PI_HOME", parent.path().join(".pi-home"));
+    cmd.env("GROK_HOME", parent.path().join(".grok-home"));
+    cmd.env("HERMES_HOME", parent.path().join(".hermes-home"));
+    cmd.env("CODEX_HOME", parent.path().join(".codex-home"));
+    cmd.env("KIMI_HOME", parent.path().join(".kimi-code-home"));
     cmd.env("NO_COLOR", "1");
     cmd.env("ZSKILLS_NO_CLAUDE_CLI", "1");
     cmd.env("XDG_CONFIG_HOME", parent.path().join("config"));
@@ -2992,7 +3003,28 @@ fn unknown_harness_is_refused() {
 }
 
 #[test]
-fn hermes_and_kimi_are_skipped_not_invented() {
+fn kimi_is_skipped_not_invented() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    zskills(&home)
+        .args(["plugin", "install", "pi@zot24-skills", "--harness", "kimi"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unsupported"))
+        .stdout(predicate::str::contains("~/.kimi-code/"));
+    assert!(
+        !home
+            .path()
+            .join("skills")
+            .join("pi")
+            .join("SKILL.md")
+            .is_file(),
+        "kimi must not invent a hub copy"
+    );
+}
+
+#[test]
+fn hermes_links_hub_under_default_category() {
     let home = fake_home();
     stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
     zskills(&home)
@@ -3001,20 +3033,61 @@ fn hermes_and_kimi_are_skipped_not_invented() {
             "install",
             "pi@zot24-skills",
             "--harness",
-            "hermes,kimi",
+            "hermes",
         ])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("unsupported"));
+        .success();
+    let hub = home.path().join("skills").join("pi");
+    assert!(hub.join("SKILL.md").is_file(), "plugin → hub is a copy");
+    let meta = fs::symlink_metadata(&hub).unwrap();
+    assert!(!meta.file_type().is_symlink(), "plugin → hub stays a copy");
+    let linked = home
+        .path()
+        .join("hermes")
+        .join("skills")
+        .join("software-development")
+        .join("pi");
+    let link_meta = fs::symlink_metadata(&linked).unwrap();
     assert!(
-        !home
-            .path()
-            .join("skills")
-            .join("pi")
-            .join("SKILL.md")
-            .is_file(),
-        "unsupported harnesses must not invent a hub copy"
+        link_meta.file_type().is_symlink(),
+        "hub → hermes is a symlink"
     );
+    assert!(linked.join("SKILL.md").is_file());
+}
+
+#[test]
+fn hermes_category_flag_overrides_default() {
+    let home = fake_home();
+    stage_marketplace_plugin_with_nested_skill(&home, "zot24-skills", "pi");
+    zskills(&home)
+        .args([
+            "plugin",
+            "install",
+            "pi@zot24-skills",
+            "--harness",
+            "hermes",
+            "--category",
+            "devops",
+        ])
+        .assert()
+        .success();
+    let linked = home
+        .path()
+        .join("hermes")
+        .join("skills")
+        .join("devops")
+        .join("pi");
+    assert!(fs::symlink_metadata(&linked)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert!(!home
+        .path()
+        .join("hermes")
+        .join("skills")
+        .join("software-development")
+        .join("pi")
+        .exists());
 }
 
 #[test]
@@ -3159,4 +3232,106 @@ fn plugin_install_harness_pi_registers_hub_in_pi_settings() {
         count, 1,
         "plugin --harness pi must register the hub: {settings}"
     );
+}
+
+fn zskills_split_hub(home: &TempDir) -> Command {
+    fs::create_dir_all(home.path().join(".agents").join("skills")).unwrap();
+    fs::create_dir_all(home.path().join("grok")).unwrap();
+    fs::create_dir_all(home.path().join("hermes")).unwrap();
+    fs::create_dir_all(home.path().join("codex")).unwrap();
+    fs::create_dir_all(home.path().join("pi")).unwrap();
+    let mut cmd = zskills(home);
+    cmd.env("AGENTS_HOME", home.path().join(".agents"));
+    cmd
+}
+
+/// G6: every harness printed as visible must resolve the skill on its real root.
+/// A filter matching zero tests fails the CHECK (`[1-9][0-9]* passed`).
+#[test]
+fn harness_visibility() {
+    let home = fake_home();
+    let repo = home.path().join("src-repo");
+    write_skill(&repo, "demo", "d");
+    git_init_and_commit(&repo);
+    zskills_split_hub(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--harness",
+            "claude,pi,grok,hermes,codex",
+        ])
+        .assert()
+        .success();
+
+    let out = zskills_split_hub(&home)
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    let vis = v["agent_skills"]["harnesses"]["demo"]["visible"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !vis.is_empty(),
+        "harness_visibility must observe at least one visible harness: {v}"
+    );
+
+    let name = "demo";
+    let hub = home.path().join(".agents").join("skills").join(name);
+    for h in &vis {
+        let label = h.as_str().expect("visible entry is a string");
+        let skill_md = match label {
+            "claude" => home.path().join("skills").join(name).join("SKILL.md"),
+            "pi" | "grok" => hub.join("SKILL.md"),
+            "codex" => home
+                .path()
+                .join("codex")
+                .join("skills")
+                .join(name)
+                .join("SKILL.md"),
+            "hermes" => home
+                .path()
+                .join("hermes")
+                .join("skills")
+                .join("software-development")
+                .join(name)
+                .join("SKILL.md"),
+            other => panic!("unexpected visible harness {other}: {v}"),
+        };
+        assert!(
+            skill_md.is_file(),
+            "{label} is visible but {} does not resolve: {v}",
+            skill_md.display()
+        );
+    }
+    assert!(
+        !vis.iter().any(|x| x == "kimi"),
+        "kimi stays unsupported: {v}"
+    );
+}
+
+#[test]
+fn hub_to_claude_is_symlink_plugin_to_hub_is_copy() {
+    let home = fake_home();
+    let repo = home.path().join("src-repo");
+    write_skill(&repo, "demo", "d");
+    git_init_and_commit(&repo);
+    zskills_split_hub(&home)
+        .args(["skill", "install", &file_url(&repo), "--harness", "claude"])
+        .assert()
+        .success();
+    let hub = home.path().join(".agents").join("skills").join("demo");
+    assert!(hub.join("SKILL.md").is_file());
+    assert!(!fs::symlink_metadata(&hub).unwrap().file_type().is_symlink());
+    let claude = home.path().join("skills").join("demo");
+    assert!(fs::symlink_metadata(&claude)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert!(claude.join("SKILL.md").is_file());
 }


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `bug`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`

## Summary
- `zskills skill install` copied Agent Skills into `~/.agents/skills`. Claude Code does not scan that hub. Only Grok does so natively. Pi scans it after Phase 1 registration.
- This change gives each harness a `skill_root`. Hub → harness is a **symlink**. Plugin → hub stays a **copy**.
- A plugin cache path is version-stamped (`cache/…/1.0.4/`). A link there breaks on upgrade. `~/.agents/skills/<name>` is stable, so a link is what makes `skill upgrade` propagate.
- Claude Code follows symlinks. It counted 16 of them as user skills before this work.
- Roots:
  - `claude` → `~/.claude/skills/<name>`
  - `codex` → `~/.codex/skills/<name>`
  - `hermes` → `~/.hermes/skills/<category>/<name>/` (`--category`, default `software-development`)
  - `pi`, `grok` → hub only
  - `kimi` → unsupported. The skip reason names `~/.kimi-code/`.
- `default_skill()` lists harnesses whose home directory exists, minus any with `skill_skip_reason`. `[defaults].harnesses` and CLI `--harness` still win through `resolve()`.
- `visibility_for_skill()` reports `claude` when `~/.claude/skills/<name>/SKILL.md` resolves. The hardcoded `false` is gone.

This PR stacks on #45 (`feat/pi-hub-registration`).

## How It Works (diagram — REQUIRED)

```mermaid
flowchart TD
    src[plugin nested skills or Agent Skill source]
    hub["~/.agents/skills/name copy"]
    src --> hub
    hub --> pi[Pi: hub scan after register]
    hub --> grok[Grok: hub scan]
    hub --> claude["~/.claude/skills/name symlink"]
    hub --> codex["~/.codex/skills/name symlink"]
    hub --> hermes["~/.hermes/skills/category/name symlink"]
    kimi[Kimi: skip ~/.kimi-code]
```

```mermaid
sequenceDiagram
    participant CLI as zskills skill install
    participant Hub as agents skills name
    participant Dest as harness skill_root
    CLI->>Hub: copy SKILL.md tree
    CLI->>Dest: symlink dest to hub
    Note over Hub: real directory
    Note over Dest: symlink so upgrade propagates
```

## Linked Issues / ADRs
- Resolves: #37
- Part of: #38 (base branch `feat/pi-hub-registration`, PR #45)

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Tests set `CLAUDE_HOME`, `AGENTS_HOME`, `PI_HOME`, `GROK_HOME`, `HERMES_HOME`, `CODEX_HOME`, `KIMI_HOME` to a temp dir. They do not write the developer homes.

```
$ cargo fmt --check
(exit 0, no diff)

$ cargo clippy --all-targets -- -D warnings
    Checking zskills v1.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.65s

$ cargo test
running 76 tests
test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 99 tests
test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test harness_visibility 2>&1 | grep -qE "[1-9][0-9]* passed" && echo VIS_OK
VIS_OK
```

`harness_visibility` installs `demo` for `claude,pi,grok,hermes,codex`. For each harness in `list --json` `visible`, it asserts `SKILL.md` on that harness's real root. Kimi is not listed.

## Additional Notes for Reviewers
- Owner decisions: hub→harness symlink. Plugin→hub copy. Hermes `--category` default `software-development`. `default_skill()` hybrid (runtime presence, manifest override).
- `hub_is_enough` docs at `src/harness.rs:93-95` still say Codex scans the hub. Codex is `HubSufficiency::Never`. That leftover sentence is the same class of lie Phase 1 fixed for Pi. It does not change the runtime match.
- `visibility` reports Hermes only under `DEFAULT_HERMES_CATEGORY`. A skill linked with `--category devops` is not listed as Hermes-visible.
- Default `plugin install` is Claude only (`default_plugin`). `needs_hub_copy()` is false for Claude, so that path does not copy nested plugin skills to the hub. Agent Skill install still copies then links.
- Do not merge from the agent seat. Do not close #37 from `gh issue close`. Merge #45 first, or keep this PR stacked on `feat/pi-hub-registration`.
