### PR TITLE
fix(doctor): guard the shipped SKILL.md against verbs removed in 1.0

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -397,6 +397,22 @@ fn check_mcp_intent() -> usize {
     issues
 }
 
+/// Bare verbs removed in 1.0, when each one moved under a typed group
+/// (`zskills plugin install`, `zskills skill install`, `zskills mcp add`). The
+/// trailing space stops `zskills plugin install ` from matching `zskills install `.
+///
+/// `check_stale_zskills_skill_md` reads this list at run time. The test
+/// `shipped_skill_md_teaches_no_removed_verb` reads the same list against the
+/// `SKILL.md` this repo ships, so the checker and the guard cannot drift apart.
+pub(crate) const REMOVED_BARE_VERBS: &[&str] = &[
+    "zskills install ",
+    "zskills remove ",
+    "zskills purge ",
+    "zskills enable ",
+    "zskills disable ",
+    "zskills upgrade ",
+];
+
 /// Warn if a SKILL.md named zskills still teaches bare verbs.
 fn check_stale_zskills_skill_md() -> usize {
     let mut issues = 0;
@@ -415,14 +431,7 @@ fn check_stale_zskills_skill_md() -> usize {
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let stale = [
-            "zskills install ",
-            "zskills remove ",
-            "zskills purge ",
-            "zskills enable ",
-            "zskills disable ",
-        ];
-        if stale.iter().any(|s| text.contains(s)) {
+        if REMOVED_BARE_VERBS.iter().any(|s| text.contains(s)) {
             issues += 1;
             println!(
                 "{} {} still documents bare verbs removed in 1.0 — recopy skills/zskills/SKILL.md from this version",
@@ -432,4 +441,77 @@ fn check_stale_zskills_skill_md() -> usize {
         }
     }
     issues
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `doctor` tells a user to recopy `skills/zskills/SKILL.md` "from this
+    /// version". That advice is circular while the shipped file is itself stale,
+    /// which is what happened between 1.0 and 1.2.0: the file taught 36 removed
+    /// verbs and every `doctor` run reported the copy the user had just made.
+    ///
+    /// Guard the shipped file with the checker's own list.
+    #[test]
+    fn shipped_skill_md_teaches_no_removed_verb() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("skills")
+            .join("zskills")
+            .join("SKILL.md");
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+        let mut found: Vec<String> = Vec::new();
+        for (n, line) in text.lines().enumerate() {
+            for verb in REMOVED_BARE_VERBS {
+                if line.contains(verb) {
+                    found.push(format!("  {}:{}: {}", path.display(), n + 1, line.trim()));
+                }
+            }
+        }
+
+        assert!(
+            found.is_empty(),
+            "the shipped SKILL.md teaches {} verb(s) removed in 1.0.\n\
+             Each verb moved under a typed group: `zskills plugin install`, \
+             `zskills skill install`, `zskills mcp add`.\n{}",
+            found.len(),
+            found.join("\n")
+        );
+    }
+
+    /// The trailing space in each pattern is load-bearing. Without it every
+    /// typed form would match its own removed verb and the guard would fire on
+    /// correct documentation.
+    #[test]
+    fn typed_forms_do_not_match_removed_verbs() {
+        for typed in [
+            "zskills plugin install foo",
+            "zskills plugin remove foo",
+            "zskills plugin purge foo",
+            "zskills plugin enable foo",
+            "zskills plugin disable foo",
+            "zskills skill install owner/repo",
+            "zskills skill remove foo",
+            "zskills skill upgrade foo",
+        ] {
+            assert!(
+                !REMOVED_BARE_VERBS.iter().any(|v| typed.contains(v)),
+                "typed form `{typed}` must not match a removed bare verb"
+            );
+        }
+    }
+
+    /// Every removed verb is still detected in its bare form.
+    #[test]
+    fn removed_verbs_are_detected_in_bare_form() {
+        for verb in REMOVED_BARE_VERBS {
+            let line = format!("Run `{verb}foo` to do the thing.");
+            assert!(
+                REMOVED_BARE_VERBS.iter().any(|v| line.contains(v)),
+                "bare form of `{verb}` must be detected"
+            );
+        }
+    }
 }


### PR DESCRIPTION
> **Builds on #48, which is merged.** The guard reads the `skills/zskills/SKILL.md` that #48 rewrote. The base is `main` at 470abd2 or later. Against `main` before that merge the guard fails by design, because the earlier `main` shipped 36 bare verbs.

## Labels (REQUIRED)
- [x] Type: `bug`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:small`
- [x] Area: `area:cli`

## Summary

- `zskills doctor` reads the **installed** `SKILL.md` at `~/.agents/skills/zskills/SKILL.md` and at `~/.claude/skills/zskills/SKILL.md`. It warns when that file teaches a bare verb that 1.0 removed.
- The warning names one remedy: "recopy `skills/zskills/SKILL.md` from this version". That remedy is circular when the **shipped** `skills/zskills/SKILL.md` is the stale file. A user who follows the advice copies the stale text back and sees the same warning.
- This state held from 1.0 to 1.2.0. The shipped `SKILL.md` taught 36 bare verbs. No test read the shipped file, so nothing caught the drift.
- Move the verb list out of `check_stale_zskills_skill_md()` into `pub(crate) const REMOVED_BARE_VERBS` in `src/commands/doctor.rs`. The run-time checker and the new test read the same constant. The two cannot drift apart.
- Add `"zskills upgrade "` to `REMOVED_BARE_VERBS`. That verb also moved under a typed group in 1.0. The old list omitted it, so three occurrences of `zskills upgrade` survived the first documentation pass on #48.
- Add three tests to a new `#[cfg(test)] mod tests` at the end of `src/commands/doctor.rs`.

## How It Works (diagram — REQUIRED)

```mermaid
flowchart TD
    C["REMOVED_BARE_VERBS in src/commands/doctor.rs"]

    C --> R["check_stale_zskills_skill_md at run time"]
    C --> T["shipped_skill_md_teaches_no_removed_verb at test time"]

    R --> R1["Reads the installed copy under .agents/skills/zskills/"]
    R --> R2["Reads the installed copy under .claude/skills/zskills/"]
    R1 --> RW["Prints a warning that says recopy from this version"]
    R2 --> RW

    T --> T1["Reads CARGO_MANIFEST_DIR/skills/zskills/SKILL.md"]
    T1 --> TW["Fails the build and prints every hit with a file and a line number"]

    RW --> G["The advice stays true, because the shipped file cannot go stale"]
    TW --> G
```

One constant now feeds two consumers. The checker covers the copy on a user machine. The guard covers the copy this repository ships. The warning tells a user to recopy the shipped file, and the guard holds that file correct, so the advice stays true.

`shipped_skill_md_teaches_no_removed_verb` reads `$CARGO_MANIFEST_DIR/skills/zskills/SKILL.md`. It walks the file line by line. It collects every line that contains a member of `REMOVED_BARE_VERBS`, and it reports each hit with a file name and a line number.

Each pattern in `REMOVED_BARE_VERBS` ends with a space. The space is load-bearing. `zskills plugin install foo` contains the string `zskills plugin install `. It does not contain `zskills install `. Without the trailing space the guard would fire on correct documentation. `typed_forms_do_not_match_removed_verbs` holds that property for eight typed forms. `removed_verbs_are_detected_in_bare_form` holds the opposite direction, so a shortened pattern cannot silently stop matching.

## Linked Issues / ADRs
- Part of: #44

#44 is already closed. This PR completes one part of it that the closure left open in fact.

| Part of #44 | State after this PR |
|---|---|
| 1. The shipped `SKILL.md` teaches removed verbs | Fixed by #48, merged as 470abd2 |
| 1b. A test that stops part 1 from returning | **Fixed here** |
| 2. Doctor's "recopy from this version" advice is circular | Correct, and now guarded |
| 3. `zskills doctor` exits 0 with findings | **Open. This PR does not change it.** |

Part 3 is untouched. I verified it against a sandboxed `CLAUDE_HOME`:

```console
$ CLAUDE_HOME=$SB/.claude AGENTS_HOME=$SB/.agents zskills doctor
! .../.agents/skills/zskills/SKILL.md still documents bare verbs removed in 1.0 — recopy skills/zskills/SKILL.md from this version

Nothing here is auto-fixable; see the notes above.
$ echo $?
0
```

`doctor` prints a finding and exits 0. A CI job, a pre-commit hook, or a provisioning script still cannot gate on it. A separate PR must add a non-zero exit or a `--strict` flag.

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only) — **not applicable.** This PR changes no command that writes state. It moves a constant and it adds tests. The sandboxed `zskills doctor` run above is read-only, and it evidences the open part 3 of #44 rather than this change.

```console
$ cargo fmt --check
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s

$ cargo test
running 79 tests
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
running 99 tests
test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.32s
```

The unit count moves from 76 to 79. The three new tests are the difference.

### The guard fails when it must

A guard that cannot fail is decoration. Append one bare verb to the shipped file, and the guard fails with an exact location:

```console
$ printf '\nRun `zskills install foo` to install.\n' >> skills/zskills/SKILL.md
$ cargo test shipped_skill_md_teaches_no_removed_verb
running 1 test
test commands::doctor::tests::shipped_skill_md_teaches_no_removed_verb ... FAILED

---- commands::doctor::tests::shipped_skill_md_teaches_no_removed_verb stdout ----
thread '...' panicked at src/commands/doctor.rs:474:9:
the shipped SKILL.md teaches 1 verb(s) removed in 1.0.
Each verb moved under a typed group: `zskills plugin install`, `zskills skill install`, `zskills mcp add`.
  /Users/anon/code/zskills/skills/zskills/SKILL.md:298: Run `zskills install foo` to install.

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 78 filtered out; finished in 0.00s
```

Revert the line, and the guard passes:

```console
$ git checkout skills/zskills/SKILL.md
$ cargo test shipped_skill_md_teaches_no_removed_verb
test commands::doctor::tests::shipped_skill_md_teaches_no_removed_verb ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out; finished in 0.00s
```

## Additional Notes for Reviewers

**Base.** This branch carries one commit on top of `main` at 470abd2. #48 merged first, and it supplies the corrected `skills/zskills/SKILL.md` that the guard reads. I wrote the branch against #48 before that merge, and I rebased it onto `main` afterwards, so the diff holds `src/commands/doctor.rs` alone.

**Scope of the guard.** The guard reads one file: `skills/zskills/SKILL.md`. It does not read `README.md`, `docs/`, or `AGENTS.md`. #48 corrects those files, and no test holds them. A reviewer who wants the wider guard should ask for it as separate work, because three files in the repository record a past state on purpose: `CHANGELOG.md`, `DESIGN-sparse-install.md`, and `IMPLEMENTATION-REPORT.md`. A repository-wide grep needs an allow-list for those three.

**The new `zskills upgrade ` pattern raises the run-time check as well.** An installed `SKILL.md` that teaches `zskills upgrade` now triggers the doctor warning, where it did not before. This is the intended behaviour. A user on an older installed copy sees one more warning, and `zskills skill upgrade` clears it.

**Risk.** The constant is `pub(crate)`, so it is not a public API change. No behaviour changes for any command other than the added `zskills upgrade ` pattern in `doctor`.

**What I did not do.** I did not change the exit code of `doctor`. Part 3 of #44 stays open, and the evidence above records it.
