### PR TITLE
fix: print plugins and next install command after marketplace add

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -376,6 +376,16 @@ zskills marketplace update [<name>]
 
 `add` clones the marketplace repo into `~/.claude/plugins/marketplaces/<name>/` and writes both `known_marketplaces.json` and `settings.json`'s `extraKnownMarketplaces`. Mirrors what `/plugin marketplace add` does inside Claude Code.
 
+Adding a marketplace does **not** install plugins and does **not** change the manifest. `sync` only applies `[[skills]]` entries already in `skills.toml`. After a successful add, zskills reads `.claude-plugin/marketplace.json` and prints the plugins the marketplace offers, plus the next command:
+
+```
+✓ added marketplace llm-wiki
+  1 plugin: wiki
+  Next: zskills plugin install wiki@llm-wiki
+```
+
+If `marketplace.json` is missing, add still registers the clone and warns. `list` also prints a dimmed hint when no plugins are active and a registered marketplace offers at least one.
+
 `add-recommended` seeds the trusted defaults (currently just `anthropics/claude-plugins-official`). Idempotent — safe to re-run; existing marketplaces are left as-is.
 
 ### Pinning a marketplace

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,29 @@ Two registered marketplaces both expose a skill with the same name. zskills can'
 zskills plugin install firecrawl@zot24-skills        # instead of just firecrawl
 ```
 
+## `marketplace add` succeeded but `list` shows no plugins
+
+`marketplace add` registers a catalog. It does not install plugins and it does not add a `[[skills]]` entry to the manifest. `sync` then reports no changes. `list` reports plugins that are enabled and installed, so it stays empty.
+
+Install the plugin the marketplace offers:
+
+```bash
+zskills marketplace list              # how many plugins the clone lists
+zskills plugin install wiki@llm-wiki  # nvk/llm-wiki offers `wiki`
+# or
+zskills plugin install -i             # browse every registered marketplace
+```
+
+To keep the plugin across later `sync` runs, also add it to `skills.toml`:
+
+```toml
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+```
+
+`marketplace add` now prints the plugins and the `plugin install` command. `list` prints a dimmed hint when a registered marketplace offers a plugin and none are active.
+
 ## "enabled but NOT installed (broken)"
 
 `doctor` is flagging an `enabledPlugins` entry that has no corresponding inventory record. Three legitimate causes:

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use owo_colors::OwoColorize;
 use serde_json::json;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
     let report = crate::reconcile::run()?;
@@ -116,6 +116,7 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
     );
     if report.active.is_empty() {
         println!("  (none)");
+        print_empty_plugin_hint();
     } else {
         for k in &report.active {
             print_plugin_line("✓", k, paths, &plugin_inv, true);
@@ -197,6 +198,56 @@ pub fn run(json_out: bool, verbose: bool, paths: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// When nothing is active, point at plugins a registered marketplace already offers.
+///
+/// `marketplace add` does not install plugins (zot24/zskills#55). Users then run
+/// `list` and see `(none)` with no path to `plugin install`.
+fn print_empty_plugin_hint() {
+    let Ok(path) = crate::paths::known_marketplaces_json() else {
+        return;
+    };
+    let Ok(known) = crate::marketplace::load_known(&path) else {
+        return;
+    };
+    let mut offered: Vec<(String, String)> = Vec::new();
+    for (mp_name, entry) in &known {
+        if crate::commands::marketplace::is_remote_index(entry) {
+            continue;
+        }
+        let Ok(manifest_path) = crate::paths::marketplace_manifest(mp_name) else {
+            continue;
+        };
+        let Ok(m) = crate::marketplace::load_manifest(&manifest_path) else {
+            continue;
+        };
+        for p in m.plugins {
+            offered.push((p.name, mp_name.clone()));
+        }
+    }
+    if offered.is_empty() {
+        return;
+    }
+    if offered.len() == 1 {
+        let (plugin, mp) = &offered[0];
+        println!(
+            "  {}",
+            format!("marketplace {mp} offers {plugin} — zskills plugin install {plugin}@{mp}")
+                .dimmed()
+        );
+        return;
+    }
+    let mp_count = offered
+        .iter()
+        .map(|(_, mp)| mp.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    println!(
+        "  {}",
+        format!("{mp_count} marketplace(s) registered. Browse with `zskills plugin install -i`.")
+            .dimmed()
+    );
 }
 
 fn print_group(

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -82,7 +82,54 @@ fn add(source: String) -> Result<()> {
     crate::settings::save(&settings_path, &settings)?;
 
     println!("{} added marketplace {}", "✓".green(), name);
+    print_add_followup(&name, &install_location);
     Ok(())
+}
+
+/// After a marketplace is registered, say what it offers and how to install it.
+///
+/// `marketplace add` only writes `known_marketplaces.json` and
+/// `extraKnownMarketplaces`. It does not install plugins and it does not
+/// change the manifest. Users who then run `sync` / `list` see no plugins
+/// and no next command (zot24/zskills#55).
+fn print_add_followup(name: &str, install_location: &std::path::Path) {
+    let manifest_path = install_location
+        .join(".claude-plugin")
+        .join("marketplace.json");
+    if !manifest_path.exists() {
+        println!(
+            "  {} no .claude-plugin/marketplace.json — plugin install and search will not find anything here",
+            "!".yellow()
+        );
+        return;
+    }
+    match crate::marketplace::load_manifest(&manifest_path) {
+        Ok(m) if m.plugins.is_empty() => {
+            println!("  {} marketplace.json lists 0 plugins", "!".yellow());
+        }
+        Ok(m) => {
+            let names: Vec<&str> = m.plugins.iter().map(|p| p.name.as_str()).collect();
+            if names.len() <= 8 {
+                println!(
+                    "  {} plugin{}: {}",
+                    names.len(),
+                    if names.len() == 1 { "" } else { "s" },
+                    names.join(", ")
+                );
+            } else {
+                println!("  {} plugins", names.len());
+            }
+            if names.len() == 1 {
+                println!("  Next: zskills plugin install {}@{}", names[0], name);
+            } else {
+                println!("  Next: zskills plugin install <plugin>@{}", name);
+                println!("        zskills plugin install -i");
+            }
+        }
+        Err(e) => {
+            println!("  {} could not read marketplace.json ({e})", "!".yellow());
+        }
+    }
 }
 
 fn add_recommended() -> Result<()> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1662,6 +1662,71 @@ fn marketplace_add_writes_last_updated_as_a_string() {
     assert!(entry["installLocation"].is_string());
 }
 
+#[test]
+fn marketplace_add_prints_plugins_and_the_next_install_command() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = write_marketplace_repo(upstream.path(), "llm-wiki", "wiki");
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&repo)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("added marketplace llm-wiki"))
+        .stdout(predicate::str::contains("1 plugin: wiki"))
+        .stdout(predicate::str::contains(
+            "zskills plugin install wiki@llm-wiki",
+        ));
+}
+
+#[test]
+fn marketplace_add_warns_when_marketplace_json_is_missing() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = upstream.path().join("not-a-marketplace");
+    fs::create_dir_all(&repo).unwrap();
+    fs::write(repo.join("README.md"), "not a plugin catalog").unwrap();
+    git_init_and_commit(&repo);
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&repo)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "added marketplace not-a-marketplace",
+        ))
+        .stdout(predicate::str::contains("marketplace.json"));
+}
+
+#[test]
+fn list_hints_when_a_marketplace_offers_a_plugin_but_none_are_active() {
+    let home = fake_home();
+    let settings_path = home.path().join("settings.json");
+    let mut settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(&settings_path).unwrap()).unwrap();
+    settings["enabledPlugins"] = json!({});
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&settings).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        home.path().join("plugins").join("installed_plugins.json"),
+        serde_json::to_string_pretty(&json!({ "version": 2, "plugins": {} })).unwrap(),
+    )
+    .unwrap();
+    register_marketplace(&home, "llm-wiki", "wiki", Some("2026-08-20T00:00:00.000Z"));
+
+    zskills(&home)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(none)"))
+        .stdout(predicate::str::contains(
+            "zskills plugin install wiki@llm-wiki",
+        ));
+}
+
 // --- Fix 2: doctor reports a missing `lastUpdated`, and --fix stamps it ------
 
 #[test]


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `bug`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:small`
- [x] Area: `area:cli`, `area:dx`, `area:docs`

## Summary

`marketplace add` registers a marketplace. It writes `known_marketplaces.json` and `settings.json` → `extraKnownMarketplaces`. It does not install plugins. It does not write `skills.toml`.

Issue #55 reports this sequence:

1. Run `zskills marketplace add nvk/llm-wiki`.
2. Run `zskills sync`.
3. Run `zskills list`.

`list` shows no plugins. The marketplace offers the plugin `wiki`. The terminal has no next command.

This PR prints that next command. After a successful add, zskills reads `<clone>/.claude-plugin/marketplace.json` and prints what the marketplace offers. When `list` has no active plugins, it prints a dimmed hint with the same install command.

The command still only registers the catalog. It does not auto-install plugins.

## How It Works (diagram — REQUIRED)

After `marketplace add` writes `known_marketplaces.json` and `extraKnownMarketplaces`, it calls `print_add_followup` in `src/commands/marketplace.rs`. That function reads `<clone>/.claude-plugin/marketplace.json`.

Five outcomes:

- The file is missing. zskills prints a yellow warning. Plugin install and search will not find anything. The clone stays registered.
- The plugins array is empty. zskills prints a yellow warning that `marketplace.json` lists 0 plugins.
- Parse fails. zskills prints a yellow warning with the error.
- One plugin. zskills prints `1 plugin: <name>` and `Next: zskills plugin install <name>@<marketplace>`.
- Two or more plugins. For 2–8 plugins, zskills prints the names. For more than 8 plugins, zskills prints the count. Both cases print `zskills plugin install <plugin>@<marketplace>` and `zskills plugin install -i`.

`print_empty_plugin_hint` in `src/commands/list.rs` runs when active plugins are empty. It walks `known_marketplaces.json`. It skips remote-index entries. It loads each `marketplace.json`.

- One offered plugin: a dimmed line `marketplace <mp> offers <plugin> — zskills plugin install <plugin>@<mp>`.
- Several offered plugins: a dimmed line with the marketplace count and `zskills plugin install -i`.

JSON `list --json` does not change.

`docs/commands.md` records that add does not install plugins and does not change the manifest. It shows the new add output for a one-plugin marketplace. It notes the list hint.

`docs/troubleshooting.md` adds a section for this case. It tells the user to run `plugin install` (example: `wiki@llm-wiki`) or `plugin install -i`. It tells the user to add a `[[skills]]` row to `skills.toml` if later `sync` runs must keep the plugin.

```mermaid
flowchart TD
    Add["marketplace add"]
    Write["Write known_marketplaces.json and extraKnownMarketplaces"]
    Read{"Read marketplace.json"}
    Missing["Warn: file missing"]
    Empty["Warn: 0 plugins"]
    One["Print the plugin name and plugin install command"]
    Many["Print the count and plugin install -i"]
    Bad["Warn: parse failed"]
    List["list with no active plugins"]
    Hint{"Registered marketplace offers plugins?"}
    HintOne["Print plugin install for the one plugin"]
    HintMany["Print plugin install -i"]
    Add --> Write --> Read
    Read -->|missing| Missing
    Read -->|empty| Empty
    Read -->|one plugin| One
    Read -->|two or more| Many
    Read -->|unreadable| Bad
    List --> Hint
    Hint -->|one plugin| HintOne
    Hint -->|many plugins| HintMany
```

## Linked Issues / ADRs
- Resolves: #55

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

New tests in `tests/cli.rs`:

- `marketplace_add_prints_plugins_and_the_next_install_command`
- `marketplace_add_warns_when_marketplace_json_is_missing`
- `list_hints_when_a_marketplace_offers_a_plugin_but_none_are_active`

```
$ cargo fmt --check
(exit 0)

$ cargo clippy --all-targets -- -D warnings
    Checking zskills v1.2.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.38s

$ cargo test
running 79 tests
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 102 tests
test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Sandboxed `CLAUDE_HOME` / `AGENTS_HOME` (temporary directories, not the developer home). Local git repo shaped like `nvk/llm-wiki` (one plugin named `wiki`):

```
=== marketplace add ===
Cloning file:///tmp/zs-mp-upstream-WOKb/llm-wiki into /tmp/zs-marketplace-add-YgUA/.claude/plugins/marketplaces/llm-wiki ...
✓ added marketplace llm-wiki
  1 plugin: wiki
  Next: zskills plugin install wiki@llm-wiki

=== marketplace list ===
  llm-wiki  1 plugin(s)  [autoUpdate]

=== zskills list ===
Plugins — active (enabled + installed)
  (none)
  marketplace llm-wiki offers wiki — zskills plugin install wiki@llm-wiki

Agent Skills — managed by zskills
  (none)

MCP Servers
  (none configured)
```

`marketplace add` still writes `known_marketplaces.json` and `settings.json`. The new lines are stdout only. The sandbox dirs were deleted after the run.

## Additional Notes for Reviewers

- This PR does not auto-install plugins. Adding a marketplace still only registers the catalog.
- `sync` is unchanged. It still applies `[[skills]]` in the manifest.
- Reproduce of #55: `zskills marketplace add nvk/llm-wiki` then `zskills sync` then `zskills list` showed no plugins. The marketplace offers `wiki`. The next command is `zskills plugin install wiki@llm-wiki`.
- Commit `1ccacde` on branch `fix/marketplace-add-next-steps`. Five files. 197 insertions, 1 deletion.
