### PR TITLE
feat: select an Agent Skill tree with path inside a source clone

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -128,7 +128,7 @@ zskills sync [--file <path>] [--dry-run] [--prune | --adopt]
 What sync does:
 1. For each `[[marketplaces]]` entry with `repo` or `url` that is not yet registered: clone the source and write `known_marketplaces.json` plus `extraKnownMarketplaces` (same as `marketplace add`). This runs **before** plugin resolve, so a fresh machine can recreate the clone. Unqualified `[[skills]]` names (`name` only) are resolved against the map **after** that clone, so they can match a marketplace that did not exist at plan time.
 2. For each `[[skills]]` entry: resolve `name@marketplace`. If `harnesses` (or `[defaults].harnesses`) contains `claude`, write to `enabledPlugins`. Entries currently enabled but not in the manifest get flipped off. Hub-backed harnesses (`pi`, `grok`, `codex`) copy nested `skills/<name>/` trees into `~/.agents/skills/` in the same pass. **`sync` refuses to write an `enabledPlugins` key whose marketplace is not registered.** It reports the unresolved plugins and exits non-zero instead of printing `✓ applied.` Hub copies for those plugins are skipped too.
-3. For each `[[agent_skills]]` entry: if `source` is present, clone/pull and copy `skills/<name>/` to `~/.agents/skills/`. If `npm` is present, run `npm install -g --no-fund --no-audit <pkg>` (or `install_cmd`), then claim all matching `claims` globs. If neither is present (just `name`), register the existing on-disk skill in inventory without fetching anything.
+3. For each `[[agent_skills]]` entry: if `source` is present, clone/pull and copy `skills/<name>/` to `~/.agents/skills/`. If `path` is set, copy from that relative directory inside the clone instead of the default skill roots. If `npm` is present, run `npm install -g --no-fund --no-audit <pkg>` (or `install_cmd`), then claim all matching `claims` globs. If neither is present (just `name`), register the existing on-disk skill in inventory without fetching anything. A copy or resolve error increments a failure count: `sync` then skips `✓ applied.` and exits non-zero.
 4. Agent skills tracked in inventory but missing from the manifest are reported. With `--prune` they're deleted; with `--adopt` they're appended to the manifest; otherwise they're skipped.
 
 ### `--adopt` details
@@ -138,7 +138,7 @@ When you pass `--adopt`, sync writes new entries to `skills.toml` instead of rem
 - **Registered marketplace** not in manifest → new `[[marketplaces]]` row with `name` plus `repo` (`owner/repo`) or `url` (non-GitHub git source). Source comes from `known_marketplaces.json` / `extraKnownMarketplaces`. Remote-index entries are skipped. This is what makes a later `sync` on a fresh machine able to clone.
 - **Registered marketplace** already in the manifest with only `name` / `pin` → fill `repo` or `url`. Existing `pin` is left untouched. A row that already has a source is skipped.
 - **Enabled plugin** not in manifest → new `[[skills]]` row with `name` + `marketplace`.
-- **Agent skill** in inventory but not in manifest → new `[[agent_skills]]` row. The `source` / `npm` / `name` fields are reconstructed from the inventory tag (`local` becomes a name-only entry, `npm:pkg` becomes `npm = "pkg"`, anything else becomes `source = "..."`).
+- **Agent skill** in inventory but not in manifest → new `[[agent_skills]]` row. The fields are reconstructed from the inventory tag: `local` becomes a name-only entry, `npm:pkg` becomes `npm = "pkg"`, `source:<git>:<path>` becomes `source` plus `path` (rsplit on the last `:`, so a git URL that contains `:` stays intact), and any other string becomes `source = "..."` only.
 - **MCP server** configured but not in manifest → new `[[mcps]]` row with full transport details (`command`/`args`/`env` for stdio, `url`/`headers` for http/sse), `scope` preserved. **Env and header values are copied verbatim** — if any contain literal secrets, eyeball the resulting manifest and replace them with `${VAR}` references before committing.
 
 Adoption is idempotent and de-duplicates against existing entries, so re-running `sync --adopt` after editing the manifest is safe.
@@ -158,7 +158,7 @@ zskills skill upgrade [<name>...]
 | Source kind | What `upgrade` does |
 |---|---|
 | Plugins (marketplace-based) | For each registered marketplace tap, `git pull --ff-only` if it's a git working tree; otherwise fetch the GitHub archive tarball from the source recorded in `known_marketplaces.json` and atomically swap the tree. Claude Code picks up new plugin versions on next start. |
-| Git agent skills (`source = "owner/repo"`) | `git pull` the cached source clone + re-copy bytes |
+| Git agent skills (`source = "owner/repo"`) | `git pull` the cached source clone + re-copy bytes. Honour `path` when set. |
 | npm agent skills (`npm = "pkg"`) | Run `npm install -g <pkg>` (or `install_cmd`), then re-apply the `claims` glob to retag inventory |
 
 Pass specific names to upgrade just those; empty = upgrade everything. The `name` filter matches against the manifest's `npm`, `source`, or `name` fields.
@@ -228,7 +228,7 @@ scope = "user"
 
 ## Agent skills manifest schema
 
-The `[[agent_skills]]` table supports four orthogonal fields, used in combination:
+The `[[agent_skills]]` table supports these fields, used in combination:
 
 ```toml
 # Git-sourced single skill
@@ -239,6 +239,12 @@ source = "jakubkrehel/make-interfaces-feel-better"
 [[agent_skills]]
 source = "owner/multi-skill-repo"
 name = "specific-skill"
+
+# Nested tree: Agent Skills that are not at `.agents/skills` or `skills/`
+[[agent_skills]]
+source = "owner/odd-layout"
+path = "packages/foo/skills"
+name = "foo"
 
 # npm-distributed package
 [[agent_skills]]
@@ -258,6 +264,7 @@ name = "my-internal-tool"
 | Field | Purpose |
 |---|---|
 | `source` | Git source: `owner/repo` (GitHub) or full git URL. `sync`/`upgrade` clone/pull and copy. |
+| `path` | Relative directory inside the cloned `source`. Replaces the default walk of `.agents/skills` and `skills/`. If `path/SKILL.md` exists, that directory is the skill (name = last segment). Else every child with `SKILL.md` is a skill. Requires `source`. Must be relative: no `..`, no absolute form, no `\`, no `:`. Inventory tag is `source:<source>:<path>`. |
 | `npm` | npm package name. `sync`/`upgrade` runs `npm install -g <pkg>`. |
 | `install_cmd` | Custom installer command — overrides the default `npm install -g`. Used for packages with their own setup CLI. |
 | `name` | Optional. For source entries, pick a single skill out of a multi-skill repo. For local-only entries, required — names the on-disk skill to track. |

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -11,7 +11,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -31,6 +31,29 @@ pub struct Entry {
     /// Empty means today's default: `agents` only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub to: Vec<String>,
+}
+
+/// Where an Agent Skill tree is copied from.
+#[derive(Debug, Clone)]
+pub struct SkillOrigin {
+    pub kind: OriginKind,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum OriginKind {
+    Git { source: String },
+}
+
+impl SkillOrigin {
+    pub fn git(source: impl Into<String>, path: Option<String>) -> Self {
+        Self {
+            kind: OriginKind::Git {
+                source: source.into(),
+            },
+            path,
+        }
+    }
 }
 
 pub fn load_inventory() -> Result<Inventory> {
@@ -101,20 +124,6 @@ pub fn ensure_cache(source: &str) -> Result<PathBuf> {
     Ok(cache)
 }
 
-/// List the skill directories present under <cache>/skills/.
-/// Returns `(name, source_dir)` pairs, sorted by name.
-///
-/// Two layouts are supported:
-/// - flat:   `skills/<name>/SKILL.md`
-/// - nested: `skills/<category>/<name>/SKILL.md`
-///
-/// Nested is what larger collections use to group skills (e.g. `engineering/`,
-/// `productivity/`). A directory holding its own `SKILL.md` is always treated as
-/// a skill and is never descended into, so a skill containing helper
-/// subdirectories cannot be mistaken for a category.
-///
-/// Names are unique in the result: if two categories expose the same skill name,
-/// the first by sorted path wins and the other is dropped.
 /// Roots a repository may keep its Agent Skills under, in precedence order.
 ///
 /// `.agents/skills/` is the cross-client convention from the Agent Skills spec and is
@@ -152,6 +161,36 @@ pub fn skills_in_cache(cache: &Path) -> Vec<(String, PathBuf)> {
     out.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
     out.dedup_by(|a, b| a.0 == b.0);
     out
+}
+
+/// Walk one directory the same way `skills_in_cache` walks each `SKILL_ROOTS`
+/// entry: a dir with `SKILL.md` is a skill; a dir without is a one-level category.
+pub fn skills_in_dir(root: &Path) -> Vec<(String, PathBuf)> {
+    let mut out = Vec::new();
+    collect_skills_under(root, &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    out.dedup_by(|a, b| a.0 == b.0);
+    out
+}
+
+/// Discover Agent Skills under an explicit `path` selector.
+///
+/// If `root/SKILL.md` exists, `root` itself is the skill (name = last segment).
+/// `collect_skills_under` would miss that case because it lists children, not the root.
+pub fn skills_at_path(root: &Path) -> Result<Vec<(String, PathBuf)>> {
+    if root.join("SKILL.md").is_file() {
+        let name = root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| anyhow::anyhow!("invalid skill directory name"))?;
+        validate_skill_name(name)?;
+        return Ok(vec![(name.to_string(), root.to_path_buf())]);
+    }
+    let found = skills_in_dir(root);
+    if found.is_empty() {
+        anyhow::bail!("no Agent Skills under path {}", root.display());
+    }
+    Ok(found)
 }
 
 /// Walk one skill root, appending every skill directory it holds.
@@ -196,13 +235,26 @@ fn collect_skills_under(root: &Path, out: &mut Vec<(String, PathBuf)>) {
 }
 
 /// Copy a skill directory into ~/.agents/skills/<name>/ (deletes existing first).
+/// `allowed_root` for this helper is `src_dir` itself (local migrate copies).
 pub fn install_to_user_dir(skill_name: &str, src_dir: &Path) -> Result<()> {
-    install_to_root(&crate::paths::user_skills_dir()?, skill_name, src_dir)
+    install_to_root(
+        &crate::paths::user_skills_dir()?,
+        skill_name,
+        src_dir,
+        src_dir,
+    )
 }
 
 /// Copy a skill directory into `<root>/<name>/`. Replaces an existing directory
-/// or leftover symlink. Never creates a symlink.
-pub fn install_to_root(root: &Path, skill_name: &str, src_dir: &Path) -> Result<()> {
+/// or leftover symlink. Never creates a symlink. Follows in-tree symlinks only
+/// when the canonical target stays inside `allowed_root`. On copy error the
+/// dest is removed so a half-written hub name is not left behind.
+pub fn install_to_root(
+    root: &Path,
+    skill_name: &str,
+    src_dir: &Path,
+    allowed_root: &Path,
+) -> Result<()> {
     validate_skill_name(skill_name)?;
     let dest = root.join(skill_name);
     if let Ok(meta) = dest.symlink_metadata() {
@@ -216,7 +268,10 @@ pub fn install_to_root(root: &Path, skill_name: &str, src_dir: &Path) -> Result<
         }
     }
     std::fs::create_dir_all(&dest)?;
-    copy_dir_recursive(src_dir, &dest)?;
+    if let Err(e) = copy_dir_recursive(src_dir, &dest, allowed_root) {
+        let _ = std::fs::remove_dir_all(&dest);
+        return Err(e);
+    }
     anyhow::ensure!(
         !dest
             .symlink_metadata()
@@ -242,12 +297,30 @@ pub fn install_root_skill_sparse_to(root: &Path, skill_name: &str, cache: &Path)
         std::fs::remove_dir_all(&dest)?;
     }
     std::fs::create_dir_all(&dest)?;
+    if let Err(e) = copy_sparse_root(cache, &dest) {
+        let _ = std::fs::remove_dir_all(&dest);
+        return Err(e);
+    }
+    Ok(())
+}
+
+fn copy_sparse_root(cache: &Path, dest: &Path) -> Result<()> {
+    let allowed = cache
+        .canonicalize()
+        .with_context(|| format!("canonicalizing allowed_root {}", cache.display()))?;
+    let mut visiting = BTreeSet::new();
     for rel in sparse_root_paths(cache) {
         let src = cache.join(&rel);
         let target = dest.join(&rel);
-        if src.is_dir() {
-            copy_dir_recursive(&src, &target)?;
-        } else {
+        let meta = src
+            .symlink_metadata()
+            .with_context(|| format!("reading {}", src.display()))?;
+        let ft = meta.file_type();
+        if ft.is_symlink() {
+            copy_symlink(&src, &target, &allowed, &mut visiting)?;
+        } else if ft.is_dir() {
+            copy_dir_recursive(&src, &target, cache)?;
+        } else if ft.is_file() {
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)?;
             }
@@ -341,7 +414,42 @@ pub(crate) fn referenced_relative_paths(skill_md: &str) -> Vec<String> {
     out
 }
 
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+/// Copy `src` into `dst`. Follow a file or directory symlink only when its
+/// canonical target stays inside `allowed_root`. Copy those targets as real
+/// files, never as a symlink.
+pub(crate) fn copy_dir_recursive(src: &Path, dst: &Path, allowed_root: &Path) -> Result<()> {
+    let allowed = allowed_root
+        .canonicalize()
+        .with_context(|| format!("canonicalizing allowed_root {}", allowed_root.display()))?;
+    let mut visiting = BTreeSet::new();
+    copy_dir_recursive_inner(src, dst, &allowed, &mut visiting)
+}
+
+fn copy_dir_recursive_inner(
+    src: &Path,
+    dst: &Path,
+    allowed: &Path,
+    visiting: &mut BTreeSet<PathBuf>,
+) -> Result<()> {
+    let src_canon = src.canonicalize().ok();
+    if let Some(c) = &src_canon {
+        if !visiting.insert(c.clone()) {
+            anyhow::bail!("symlink cycle at {}", src.display());
+        }
+    }
+    let result = copy_dir_recursive_walk(src, dst, allowed, visiting);
+    if let Some(c) = src_canon {
+        visiting.remove(&c);
+    }
+    result
+}
+
+fn copy_dir_recursive_walk(
+    src: &Path,
+    dst: &Path,
+    allowed: &Path,
+    visiting: &mut BTreeSet<PathBuf>,
+) -> Result<()> {
     let walker = walkdir::WalkDir::new(src)
         .follow_links(false)
         .into_iter()
@@ -350,9 +458,12 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         let entry = entry?;
         let rel = entry.path().strip_prefix(src)?;
         let target = dst.join(rel);
-        if entry.file_type().is_dir() {
+        let ft = entry.file_type();
+        if ft.is_symlink() {
+            copy_symlink(entry.path(), &target, allowed, visiting)?;
+        } else if ft.is_dir() {
             std::fs::create_dir_all(&target)?;
-        } else if entry.file_type().is_file() {
+        } else if ft.is_file() {
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent)?;
             }
@@ -360,6 +471,69 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn copy_symlink(
+    src: &Path,
+    dst: &Path,
+    allowed: &Path,
+    visiting: &mut BTreeSet<PathBuf>,
+) -> Result<()> {
+    let canon = src
+        .canonicalize()
+        .with_context(|| format!("resolving symlink {}", src.display()))?;
+    if !is_within(&canon, allowed) {
+        anyhow::bail!(
+            "symlink {} escapes allowed root {} (target {})",
+            src.display(),
+            allowed.display(),
+            canon.display()
+        );
+    }
+    let meta = std::fs::metadata(&canon)?;
+    if meta.is_dir() {
+        std::fs::create_dir_all(dst)?;
+        copy_dir_recursive_inner(&canon, dst, allowed, visiting)?;
+    } else if meta.is_file() {
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&canon, dst)?;
+    }
+    Ok(())
+}
+
+/// Component-wise prefix on canonical paths. Avoids the `/foo` vs `/foo-evil`
+/// string-prefix hole and the macOS `/tmp` vs `/private/tmp` alias.
+fn is_within(path: &Path, root: &Path) -> bool {
+    path == root || path.starts_with(root)
+}
+
+/// Join `rel` onto `clone` and require the canonical result to stay inside
+/// the canonical clone root.
+pub fn resolve_path_in_clone(clone: &Path, rel: &str) -> Result<PathBuf> {
+    let rel = crate::manifest::normalize_skill_path(rel)?;
+    let joined = clone.join(&rel);
+    let clone_canon = clone
+        .canonicalize()
+        .with_context(|| format!("canonicalizing clone {}", clone.display()))?;
+    let dest_canon = joined
+        .canonicalize()
+        .with_context(|| format!("path {rel} not found in clone"))?;
+    if !is_within(&dest_canon, &clone_canon) {
+        anyhow::bail!("path {rel} is not inside the clone");
+    }
+    Ok(dest_canon)
+}
+
+/// HEAD of an already-cloned Agent Skill cache, if any. Does not clone or pull.
+pub fn cached_head(source: &str) -> Option<String> {
+    let (_, name) = parse_source(source).ok()?;
+    let cache = crate::paths::agent_skills_cache_dir().ok()?.join(name);
+    if !cache.exists() {
+        return None;
+    }
+    crate::git::head_sha(&cache).ok()
 }
 
 /// Reject names that would make `user_skills_dir().join(name)` escape that
@@ -648,20 +822,34 @@ pub fn installed_on_disk() -> Result<Vec<String>> {
     Ok(out)
 }
 
-/// Install (or refresh) an Agent Skill from a source repo. If `name` is given,
-/// only that skill is installed; otherwise all skills under `skills/` are.
-/// Returns the list of installed skill names.
+/// Install (or refresh) an Agent Skill from a git source with no `path`.
+/// Thin wrapper around [`install_from`].
 pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
+    install_from(&SkillOrigin::git(source, None), name)
+}
+
+/// Install (or refresh) an Agent Skill from `origin`. If `name` is given, only
+/// that skill is installed; otherwise every skill the origin yields.
+pub fn install_from(origin: &SkillOrigin, name: Option<&str>) -> Result<Vec<String>> {
+    let OriginKind::Git { source } = &origin.kind;
     let cache = ensure_cache(source)?;
     let head_sha = crate::git::head_sha(&cache).unwrap_or_else(|_| "unknown".to_string());
     let installed_at = chrono_now_iso();
-    let available = skills_in_cache(&cache);
-    if available.is_empty() {
-        anyhow::bail!(
-            "no skills found in {} (expected skills/<name>/SKILL.md)",
-            source
-        );
-    }
+    let (available, source_tag) = if let Some(rel) = origin.path.as_deref() {
+        let rel = crate::manifest::normalize_skill_path(rel)?;
+        let root = resolve_path_in_clone(&cache, &rel)?;
+        let found = skills_at_path(&root)?;
+        (found, format!("source:{source}:{rel}"))
+    } else {
+        let found = skills_in_cache(&cache);
+        if found.is_empty() {
+            anyhow::bail!(
+                "no skills found in {} (expected skills/<name>/SKILL.md)",
+                source
+            );
+        }
+        (found, source.clone())
+    };
     let chosen: Vec<_> = match name {
         Some(n) => available
             .into_iter()
@@ -670,26 +858,35 @@ pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
         None => available,
     };
     if chosen.is_empty() {
+        if let Some(rel) = origin.path.as_deref() {
+            anyhow::bail!(
+                "skill '{}' not found under path '{}' in {}",
+                name.unwrap_or("?"),
+                rel,
+                source
+            );
+        }
         anyhow::bail!(
             "skill '{}' not found in {} (skills/<name>/ not present)",
             name.unwrap_or("?"),
             source
         );
     }
+    let hub = crate::paths::user_skills_dir()?;
     let mut inv = load_inventory()?;
     let mut installed_names = Vec::new();
     for (skill_name, src_dir) in &chosen {
         if src_dir == &cache {
             // Root-level SKILL.md in a larger project — materialize sparsely
             // instead of copying the whole source tree.
-            install_root_skill_sparse_to(&crate::paths::user_skills_dir()?, skill_name, &cache)?;
+            install_root_skill_sparse_to(&hub, skill_name, &cache)?;
         } else {
-            install_to_user_dir(skill_name, src_dir)?;
+            install_to_root(&hub, skill_name, src_dir, &cache)?;
         }
         inv.agent_skills.insert(
             skill_name.clone(),
             Entry {
-                source: source.to_string(),
+                source: source_tag.clone(),
                 installed_at: installed_at.clone(),
                 head_sha: head_sha.clone(),
                 to: vec!["agents".into()],
@@ -897,5 +1094,109 @@ mod tests {
             assert_eq!(surviving_skills(home), ["beta"]);
             assert!(!super::remove("alpha").unwrap());
         });
+    }
+
+    #[test]
+    fn skills_at_path_treats_skill_dir_as_one_and_parent_as_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("packages/foo/skills");
+        fs::create_dir_all(parent.join("wiki-manager")).unwrap();
+        fs::write(parent.join("wiki-manager").join("SKILL.md"), "wm").unwrap();
+        fs::create_dir_all(parent.join("wiki-query")).unwrap();
+        fs::write(parent.join("wiki-query").join("SKILL.md"), "wq").unwrap();
+
+        let parent_found = super::skills_at_path(&parent).unwrap();
+        let names: Vec<_> = parent_found.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, ["wiki-manager", "wiki-query"]);
+
+        let one = super::skills_at_path(&parent.join("wiki-manager")).unwrap();
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].0, "wiki-manager");
+    }
+
+    #[test]
+    fn copy_follows_in_clone_symlink_as_regular_file() {
+        // Previously copy_dir_recursive dropped symlinks (is_file/is_dir false
+        // when follow_links is false). Dest references/hub-resolution.md must
+        // now be a regular file, not a symlink and not missing.
+        let tmp = tempfile::tempdir().unwrap();
+        let clone = tmp.path().join("clone");
+        let refs = clone.join("claude-plugin/skills/wiki-manager/references");
+        fs::create_dir_all(&refs).unwrap();
+        fs::write(refs.join("hub-resolution.md"), "notes\n").unwrap();
+        let skill = clone.join("packages/foo/skills/wiki-manager");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "openc\n").unwrap();
+        std::os::unix::fs::symlink(
+            "../../../../claude-plugin/skills/wiki-manager/references",
+            skill.join("references"),
+        )
+        .unwrap();
+
+        let dest = tmp.path().join("hub/wiki-manager");
+        super::copy_dir_recursive(&skill, &dest, &clone).unwrap();
+        let copied = dest.join("references/hub-resolution.md");
+        assert!(copied.is_file(), "dereferenced contents must be present");
+        assert!(
+            !copied.symlink_metadata().unwrap().file_type().is_symlink(),
+            "hub copy must be a regular file, not a symlink"
+        );
+        assert_eq!(fs::read_to_string(&copied).unwrap(), "notes\n");
+    }
+
+    #[test]
+    fn copy_refuses_symlink_escape_and_leaves_no_partial_dest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let clone = tmp.path().join("clone");
+        let skill = clone.join("skills/evil");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "x\n").unwrap();
+        std::os::unix::fs::symlink("/etc/passwd", skill.join("secret")).unwrap();
+
+        let hub = tmp.path().join("hub");
+        let err = super::install_to_root(&hub, "evil", &skill, &clone)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("escapes allowed root"), "{err}");
+        assert!(
+            !hub.join("evil").exists(),
+            "failed copy must not leave a partial dest"
+        );
+    }
+
+    #[test]
+    fn sparse_copy_refuses_file_symlink_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        fs::create_dir_all(&cache).unwrap();
+        std::os::unix::fs::symlink("/etc/passwd", cache.join("SKILL.md")).unwrap();
+        let hub = tmp.path().join("hub");
+        let err = super::install_root_skill_sparse_to(&hub, "evil", &cache)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("escapes allowed root"), "{err}");
+        assert!(
+            !hub.join("evil").exists(),
+            "failed sparse copy must not leave a partial dest"
+        );
+    }
+
+    #[test]
+    fn copy_refuses_in_clone_symlink_cycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let clone = tmp.path().join("clone");
+        let skill = clone.join("skills/loop");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(skill.join("SKILL.md"), "x\n").unwrap();
+        std::os::unix::fs::symlink("..", skill.join("parent")).unwrap();
+        let hub = tmp.path().join("hub");
+        let err = super::install_to_root(&hub, "loop", &skill, &clone)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("cycle"), "{err}");
+        assert!(
+            !hub.join("loop").exists(),
+            "cycle must not leave a partial dest"
+        );
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -205,7 +205,10 @@ fn install_chosen(
     category: &str,
 ) -> Result<()> {
     for name in chosen {
-        match crate::agent_skill::install(spec, Some(name)) {
+        match crate::agent_skill::install_from(
+            &crate::agent_skill::SkillOrigin::git(spec, None),
+            Some(name),
+        ) {
             Ok(installed) => {
                 crate::harness::link_hub_to_harnesses(&installed, hs, category)?;
                 for n in installed {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -227,30 +227,90 @@ pub fn run(
         .cloned()
         .collect();
 
+    // Live sync must pull path-backed clones before the HEAD comparison, or
+    // `nothing` returns with the unpulled cache still matching inventory.
+    // `--dry-run` keeps the on-disk cache HEAD and does not clone or pull.
+    if !dry_run {
+        let mut pulled = BTreeSet::new();
+        for entry in &manifest.agent_skills {
+            if entry.path.is_none() {
+                continue;
+            }
+            let Some(src) = entry.source.as_deref() else {
+                continue;
+            };
+            if pulled.insert(src.to_string()) {
+                let _ = crate::agent_skill::ensure_cache(src);
+            }
+        }
+    }
+
     // For source-only entries: only show "install" if at least one of the skills the
     // repo would provide isn't yet on disk OR tagged with this source. Otherwise we'd
     // re-install every sync, which is wasteful and noisy.
     let deferred_sources_to_install: Vec<&crate::manifest::AgentSkillEntry> = deferred_sources
         .iter()
         .filter(|e| {
-            let Some(src) = &e.source else { return false };
+            let Some(tag) = e.inventory_tag() else {
+                return false;
+            };
             // If we've already inventoried anything from this source AND those entries
-            // are all on disk, treat as "already present".
-            let inventoried_from_source: Vec<&String> = inv
+            // are all on disk, treat as "already present" unless a path-backed HEAD moved.
+            let inventoried_from_source: Vec<(&String, &crate::agent_skill::Entry)> = inv
                 .agent_skills
                 .iter()
-                .filter(|(_, entry)| entry.source == *src)
-                .map(|(name, _)| name)
+                .filter(|(_, entry)| entry.source == tag)
                 .collect();
             if inventoried_from_source.is_empty() {
                 return true;
             }
-            inventoried_from_source
+            if inventoried_from_source
                 .iter()
-                .any(|n| !on_disk.contains(n.as_str()))
+                .any(|(n, _)| !on_disk.contains(n.as_str()))
+            {
+                return true;
+            }
+            if e.path.is_some() {
+                if let Some(src) = &e.source {
+                    if let Some(head) = crate::agent_skill::cached_head(src) {
+                        return inventoried_from_source
+                            .iter()
+                            .any(|(_, ent)| ent.head_sha != head);
+                    }
+                }
+            }
+            false
         })
         .copied()
         .collect();
+    // Named source+path rows whose bytes are on disk but the clone HEAD moved.
+    let mut path_refresh: Vec<(&str, &str, &str)> = Vec::new();
+    for entry in &manifest.agent_skills {
+        let (Some(n), Some(src), Some(p)) = (
+            entry.name.as_deref(),
+            entry.source.as_deref(),
+            entry.path.as_deref(),
+        ) else {
+            continue;
+        };
+        if !on_disk.contains(n) {
+            continue;
+        }
+        let Some(tag) = entry.inventory_tag() else {
+            continue;
+        };
+        let Some(inv_e) = inv.agent_skills.get(n) else {
+            continue;
+        };
+        if inv_e.source != tag {
+            continue;
+        }
+        if let Some(head) = crate::agent_skill::cached_head(src) {
+            if inv_e.head_sha != head {
+                path_refresh.push((n, src, p));
+            }
+        }
+    }
     // Don't propose removing a skill that's owned by any manifest entry — either:
     //   (a) it came from a source-only [[agent_skills]] entry (we'll re-resolve), or
     //   (b) its inventory source is "npm:<pkg>" matching an [[agent_skills]] npm= entry, or
@@ -261,8 +321,8 @@ pub fn run(
         .filter(|n| {
             let inv_src = inv.agent_skills.get(*n).map(|e| e.source.clone());
             let owned_by_manifest = manifest.agent_skills.iter().any(|e| {
-                // (a) source-only entry whose source matches the inventory tag
-                if e.source.is_some() && e.name.is_none() && e.source == inv_src {
+                // (a) unnamed entry whose inventory tag matches (git-source or source+path)
+                if e.name.is_none() && e.inventory_tag() == inv_src {
                     return true;
                 }
                 // (b) npm entry whose tag matches
@@ -322,6 +382,7 @@ pub fn run(
         && agent_to_install_named.is_empty()
         && agent_to_remove.is_empty()
         && deferred_sources_to_install.is_empty()
+        && path_refresh.is_empty()
         && mcps_to_install.is_empty()
         && mcps_to_update.is_empty()
         && mcps_to_remove.is_empty()
@@ -418,9 +479,23 @@ pub fn run(
         }
     }
     for n in &agent_to_install_named {
+        if let Some(entry) = manifest
+            .agent_skills
+            .iter()
+            .find(|e| e.name.as_deref() == Some(n.as_str()))
+        {
+            if let (Some(src), Some(p)) = (&entry.source, &entry.path) {
+                println!("  {} install {} ← source:{} ({})", "+".green(), n, src, p);
+                continue;
+            }
+        }
         println!("  {} install agent   {}", "+".green(), n);
     }
     for entry in &deferred_sources_to_install {
+        if let (Some(s), Some(p)) = (&entry.source, &entry.path) {
+            println!("  {} install all ← source:{} ({})", "+".green(), s, p);
+            continue;
+        }
         if let Some(s) = &entry.source {
             println!(
                 "  {} install agent   {} {}",
@@ -429,6 +504,9 @@ pub fn run(
                 "(all skills in repo)".dimmed()
             );
         }
+    }
+    for (n, src, p) in &path_refresh {
+        println!("  {} refresh {} ← source:{} ({})", "~".cyan(), n, src, p);
     }
     for n in &agent_to_remove {
         if adopt {
@@ -542,24 +620,12 @@ pub fn run(
             }
         }
         for n in &agent_to_remove {
-            let inv_entry = inv.agent_skills.get(n);
-            let src = inv_entry.map(|e| e.source.as_str());
-            let manifest_entry = match src {
-                Some("local") | None => crate::manifest::AgentSkillEntry {
-                    name: Some(n.clone()),
-                    ..Default::default()
-                },
-                Some(s) if s.starts_with("npm:") => crate::manifest::AgentSkillEntry {
-                    npm: Some(s.trim_start_matches("npm:").to_string()),
-                    name: Some(n.clone()),
-                    ..Default::default()
-                },
-                Some(s) => crate::manifest::AgentSkillEntry {
-                    source: Some(s.to_string()),
-                    name: Some(n.clone()),
-                    ..Default::default()
-                },
-            };
+            let tag = inv
+                .agent_skills
+                .get(n)
+                .map(|e| e.source.as_str())
+                .unwrap_or("local");
+            let manifest_entry = crate::manifest::agent_skill_from_inventory_tag(n, tag);
             if crate::manifest::append_agent_skill(&path, &manifest_entry)? {
                 adopted += 1;
             }
@@ -693,6 +759,8 @@ pub fn run(
         crate::settings::save(&settings_path, &settings)?;
     }
 
+    let mut failures = 0usize;
+
     for (q, hs) in &plugin_copies {
         if unresolved.contains(q) {
             continue;
@@ -708,7 +776,10 @@ pub fn run(
                     );
                 }
             }
-            Err(e) => eprintln!("{} {q}: {e}", "✗".red()),
+            Err(e) => {
+                eprintln!("{} {q}: {e}", "✗".red());
+                failures += 1;
+            }
         }
     }
 
@@ -737,14 +808,21 @@ pub fn run(
                         if names.len() == 1 { "" } else { "s" }
                     );
                 }
-                Err(e) => eprintln!("{} npm:{}: {}", "✗".red(), pkg, e),
+                Err(e) => {
+                    eprintln!("{} npm:{}: {}", "✗".red(), pkg, e);
+                    failures += 1;
+                }
             }
             continue;
         }
         match (entry.source.as_deref(), entry.name.as_deref()) {
             (Some(src), name) => {
                 // Skip the (re-)install if the skill is already on disk + tagged
-                // with this same source. `upgrade` is the deliberate refresh path.
+                // with this same source. Path-backed rows also skip only when
+                // head_sha still matches the clone HEAD; otherwise re-copy.
+                // `upgrade` is the deliberate refresh path for git-source without path.
+                let origin = crate::agent_skill::SkillOrigin::git(src, entry.path.clone());
+                let tag = entry.inventory_tag().unwrap_or_else(|| src.to_string());
                 let inv_now = crate::agent_skill::load_inventory()?;
                 let on_disk: std::collections::BTreeSet<String> =
                     crate::agent_skill::installed_on_disk()
@@ -753,8 +831,18 @@ pub fn run(
                         .collect();
                 let already_present = match name {
                     Some(n) => {
-                        on_disk.contains(n)
-                            && inv_now.agent_skills.get(n).is_some_and(|e| e.source == src)
+                        let tagged = on_disk.contains(n)
+                            && inv_now.agent_skills.get(n).is_some_and(|e| e.source == tag);
+                        if tagged && entry.path.is_some() {
+                            let cache_ok = crate::agent_skill::ensure_cache(src).ok();
+                            let head = cache_ok.as_ref().and_then(|c| crate::git::head_sha(c).ok());
+                            inv_now
+                                .agent_skills
+                                .get(n)
+                                .is_some_and(|e| head.as_deref().is_some_and(|h| e.head_sha == h))
+                        } else {
+                            tagged
+                        }
                     }
                     None => false,
                 };
@@ -774,7 +862,7 @@ pub fn run(
                     }
                     continue;
                 }
-                match crate::agent_skill::install(src, name) {
+                match crate::agent_skill::install_from(&origin, name) {
                     Ok(names) => {
                         crate::harness::link_hub_to_harnesses(
                             &names,
@@ -787,6 +875,7 @@ pub fn run(
                     }
                     Err(e) => {
                         eprintln!("{} {}: {}", "✗".red(), src, e);
+                        failures += 1;
                     }
                 }
             }
@@ -857,6 +946,7 @@ pub fn run(
                     "{} agent_skill entry needs either `source` or `name`",
                     "✗".red()
                 );
+                failures += 1;
             }
             (None, Some(_)) => {
                 // npm path; already handled by the early `if let Some(pkg) = entry.npm` continue.
@@ -930,7 +1020,9 @@ pub fn run(
     if !unresolved.is_empty() {
         anyhow::bail!("marketplace is not registered — not writing dangling enabledPlugins keys");
     }
-
+    if failures > 0 {
+        anyhow::bail!("{failures} operation(s) failed");
+    }
     println!("\n{} applied.", "✓".green());
     Ok(())
 }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -83,13 +83,15 @@ pub fn run(filter: Vec<String>) -> Result<()> {
                 // the survey (a new skill root, or upstream simply adding skills) would
                 // otherwise make an unattended `upgrade` install things nobody asked for.
                 // Refresh the names already in the inventory instead.
+                let tag = entry.inventory_tag().unwrap_or_else(|| src.to_string());
+                let origin = crate::agent_skill::SkillOrigin::git(src, entry.path.clone());
                 let owned: Vec<String> = match entry.name.as_deref() {
                     Some(n) => vec![n.to_string()],
                     None => {
                         let inv = crate::agent_skill::load_inventory().unwrap_or_default();
                         inv.agent_skills
                             .iter()
-                            .filter(|(_, e)| e.source == src)
+                            .filter(|(_, e)| e.source == tag)
                             .map(|(n, _)| n.clone())
                             .collect()
                     }
@@ -107,7 +109,7 @@ pub fn run(filter: Vec<String>) -> Result<()> {
 
                 let mut failures = 0;
                 for name in &owned {
-                    if let Err(e) = crate::agent_skill::install(src, Some(name)) {
+                    if let Err(e) = crate::agent_skill::install_from(&origin, Some(name)) {
                         eprintln!("\n  {} {}: {}", "✗".red(), name, e);
                         failures += 1;
                     }

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -600,10 +600,11 @@ pub fn materialize_hub(
         return Ok(Vec::new());
     }
     let trees = plugin_skill_trees(qualified)?;
+    let plugin = plugin_root(qualified)?;
     let root = crate::paths::user_skills_dir()?;
     let mut copied = BTreeSet::new();
     for (name, src) in &trees {
-        crate::agent_skill::install_to_root(&root, name, src)?;
+        crate::agent_skill::install_to_root(&root, name, src, &plugin)?;
         copied.insert(name.clone());
         println!(
             "  {} {} → {} (hub)",

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -19,7 +19,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Manifest {
@@ -287,6 +287,10 @@ impl McpEntry {
 ///
 /// - `source`: `owner/repo` (GitHub) or a git URL. `sync` clones/pulls and copies
 ///   skills under `skills/<name>/` into `~/.agents/skills/<name>/`.
+/// - `path`: relative directory inside the cloned `source`. Replaces the default
+///   walk of `.agents/skills` and `skills/`. If `path/SKILL.md` exists, that
+///   directory is the skill (name = last segment). Else every child with
+///   `SKILL.md` is a skill. Requires `source`. Ban `..`, absolute form, `\`, `:`.
 /// - `npm`: npm package name. `sync` runs `npm install -g <pkg>` and trusts the
 ///   package's post-install to place files under `~/.agents/skills/`. After install,
 ///   zskills diffs the directory and tags every new skill with `source: "npm:<pkg>"`.
@@ -304,6 +308,9 @@ pub struct AgentSkillEntry {
     pub install_cmd: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
+    /// Relative path inside the clone. Stored with a leading `./` stripped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     /// Optional glob patterns matching skill directory names in `~/.agents/skills/`.
     /// After install, every match gets tagged with this entry's source — useful when
     /// the install command updates pre-existing files (no diff) but you want zskills
@@ -313,6 +320,103 @@ pub struct AgentSkillEntry {
     /// Harnesses this Agent Skill should be visible to. Empty = inherit `[defaults].harnesses`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub harnesses: Vec<String>,
+}
+
+impl AgentSkillEntry {
+    /// Strip a leading `./` from `path` and reject a selector that would escape
+    /// the clone. `:` is banned so inventory tags can rsplit on it later.
+    pub fn validate(&mut self) -> Result<()> {
+        if let Some(raw) = self.path.take() {
+            let normalized = normalize_skill_path(&raw)?;
+            if self.source.is_none() {
+                anyhow::bail!("path requires source");
+            }
+            if self.npm.is_some() {
+                anyhow::bail!("path is not valid on an npm entry");
+            }
+            self.path = Some(normalized);
+        }
+        Ok(())
+    }
+
+    /// Inventory `source` tag this row owns. `source` + `path` uses
+    /// `source:<source>:<path>` so two paths from one repo do not collide.
+    pub fn inventory_tag(&self) -> Option<String> {
+        if let Some(pkg) = &self.npm {
+            return Some(format!("npm:{pkg}"));
+        }
+        let src = self.source.as_deref()?;
+        match &self.path {
+            Some(p) => Some(format!("source:{src}:{p}")),
+            None => Some(src.to_string()),
+        }
+    }
+}
+
+/// Reject a relative path that would escape the clone or break inventory tags.
+/// Drops `.` segments and a trailing `/` so `././packages/foo` and
+/// `packages/foo` share one inventory tag.
+pub fn normalize_skill_path(path: &str) -> Result<String> {
+    let p = path.trim();
+    let p = p.trim_end_matches('/');
+    if p.is_empty() || p == "." || p == ".." {
+        anyhow::bail!("invalid path");
+    }
+    if p.starts_with('/') || p.contains('\\') || p.contains(':') {
+        anyhow::bail!("invalid path");
+    }
+    let mut parts: Vec<&str> = Vec::new();
+    for c in Path::new(p).components() {
+        match c {
+            Component::Normal(s) => {
+                let s = s.to_str().ok_or_else(|| anyhow::anyhow!("invalid path"))?;
+                parts.push(s);
+            }
+            Component::CurDir => {}
+            _ => anyhow::bail!("invalid path"),
+        }
+    }
+    if parts.is_empty() {
+        anyhow::bail!("invalid path");
+    }
+    Ok(parts.join("/"))
+}
+
+/// Rebuild an `[[agent_skills]]` row from an inventory `source` tag.
+///
+/// `source:<git>:<path>` rsplit on the last `:` so a git URL that contains `:`
+/// stays intact. Path cannot contain `:`.
+pub fn agent_skill_from_inventory_tag(name: &str, tag: &str) -> AgentSkillEntry {
+    if tag == "local" {
+        return AgentSkillEntry {
+            name: Some(name.to_string()),
+            ..Default::default()
+        };
+    }
+    if let Some(pkg) = tag.strip_prefix("npm:") {
+        return AgentSkillEntry {
+            npm: Some(pkg.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        };
+    }
+    if let Some(rest) = tag.strip_prefix("source:") {
+        if let Some((src, path)) = rest.rsplit_once(':') {
+            if !src.is_empty() && !path.is_empty() {
+                return AgentSkillEntry {
+                    source: Some(src.to_string()),
+                    path: Some(path.to_string()),
+                    name: Some(name.to_string()),
+                    ..Default::default()
+                };
+            }
+        }
+    }
+    AgentSkillEntry {
+        source: Some(tag.to_string()),
+        name: Some(name.to_string()),
+        ..Default::default()
+    }
 }
 
 /// Find the user-level manifest. Does NOT look at `./skills.toml` — that path
@@ -345,8 +449,11 @@ pub fn cwd_skills_toml() -> Option<PathBuf> {
 pub fn load(path: &Path) -> Result<Manifest> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("reading manifest {}", path.display()))?;
-    let m: Manifest =
+    let mut m: Manifest =
         toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    for entry in &mut m.agent_skills {
+        entry.validate()?;
+    }
     Ok(m)
 }
 
@@ -370,12 +477,13 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
         .parse()
         .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
 
-    // Check for duplicates
+    // Check for duplicates: (source, path, name)
     if let Some(Item::ArrayOfTables(existing)) = doc.get("agent_skills") {
         for t in existing.iter() {
             let src = t.get("source").and_then(|v| v.as_str()).map(str::to_string);
+            let path = t.get("path").and_then(|v| v.as_str()).map(str::to_string);
             let name = t.get("name").and_then(|v| v.as_str()).map(str::to_string);
-            if src == entry.source && name == entry.name {
+            if src == entry.source && path == entry.path && name == entry.name {
                 return Ok(false);
             }
         }
@@ -398,6 +506,9 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
     let mut t = Table::new();
     if let Some(src) = &entry.source {
         t["source"] = value(src);
+    }
+    if let Some(p) = &entry.path {
+        t["path"] = value(p);
     }
     if let Some(n) = &entry.name {
         t["name"] = value(n);
@@ -980,5 +1091,112 @@ mod marketplace_pin_tests {
         assert!(raw.contains("repo = \"nvk/llm-wiki\""));
         assert!(!raw.contains("other/repo"));
         assert!(raw.contains("pin = \"v0.23.0\""));
+    }
+}
+
+#[cfg(test)]
+mod agent_skill_path_tests {
+    use super::*;
+
+    fn validate_toml(toml_src: &str) -> Result<Manifest> {
+        let mut m: Manifest = toml::from_str(toml_src).expect("manifest parses");
+        for e in &mut m.agent_skills {
+            e.validate()?;
+        }
+        Ok(m)
+    }
+
+    #[test]
+    fn path_requires_source() {
+        let err = validate_toml("[[agent_skills]]\nname = \"x\"\npath = \"skills\"\n")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("path requires source"), "{err}");
+    }
+
+    #[test]
+    fn path_is_not_valid_on_npm() {
+        let err = validate_toml(
+            "[[agent_skills]]\nnpm = \"pkg\"\npath = \"skills\"\nsource = \"owner/repo\"\n",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("path is not valid on an npm entry"), "{err}");
+    }
+
+    #[test]
+    fn path_strips_dot_slash() {
+        for raw in ["./packages/foo/skills", "././packages/foo/skills"] {
+            let m = validate_toml(&format!(
+                "[[agent_skills]]\nsource = \"owner/repo\"\npath = \"{raw}\"\n"
+            ))
+            .unwrap();
+            assert_eq!(
+                m.agent_skills[0].path.as_deref(),
+                Some("packages/foo/skills"),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn path_rejects_parent_absolute_backslash_and_colon() {
+        for bad in [
+            "../escape",
+            "foo/../bar",
+            "/abs",
+            "foo\\bar",
+            "foo:bar",
+            "",
+            ".",
+            "..",
+        ] {
+            let err = normalize_skill_path(bad).unwrap_err().to_string();
+            assert!(err.contains("invalid path"), "{bad:?} → {err}");
+        }
+    }
+
+    #[test]
+    fn source_plus_path_inventory_tag() {
+        let m = validate_toml(
+            "[[agent_skills]]\nsource = \"owner/odd-layout\"\npath = \"packages/foo/skills\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            m.agent_skills[0].inventory_tag().as_deref(),
+            Some("source:owner/odd-layout:packages/foo/skills")
+        );
+    }
+
+    #[test]
+    fn source_without_path_inventory_tag_is_the_git_string() {
+        let m = validate_toml("[[agent_skills]]\nsource = \"owner/repo\"\n").unwrap();
+        assert_eq!(
+            m.agent_skills[0].inventory_tag().as_deref(),
+            Some("owner/repo")
+        );
+    }
+
+    #[test]
+    fn inventory_tag_rsplit_keeps_colon_in_git_source() {
+        let https = agent_skill_from_inventory_tag(
+            "foo",
+            "source:https://github.com/o/r.git:packages/foo/skills",
+        );
+        assert_eq!(https.source.as_deref(), Some("https://github.com/o/r.git"));
+        assert_eq!(https.path.as_deref(), Some("packages/foo/skills"));
+        assert_eq!(https.name.as_deref(), Some("foo"));
+
+        let ssh =
+            agent_skill_from_inventory_tag("foo", "source:git@github.com:o/r:packages/foo/skills");
+        assert_eq!(ssh.source.as_deref(), Some("git@github.com:o/r"));
+        assert_eq!(ssh.path.as_deref(), Some("packages/foo/skills"));
+    }
+
+    #[test]
+    fn inventory_tag_plain_git_stays_source_only() {
+        let e = agent_skill_from_inventory_tag("foo", "owner/repo");
+        assert_eq!(e.source.as_deref(), Some("owner/repo"));
+        assert!(e.path.is_none());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3727,3 +3727,274 @@ fn hub_to_claude_is_symlink_plugin_to_hub_is_copy() {
         .is_symlink());
     assert!(claude.join("SKILL.md").is_file());
 }
+
+/// Nested layout: Agent Skills live under `packages/foo/skills`, not `skills/`.
+/// `wiki-manager/references` is a relative symlink into `claude-plugin/.../references`.
+/// Previously `copy_dir_recursive` dropped that symlink (`is_file`/`is_dir` false).
+fn write_nested_path_repo(parent: &std::path::Path) -> std::path::PathBuf {
+    let repo = parent.join("odd-layout");
+    let refs = repo.join("claude-plugin/skills/wiki-manager/references");
+    fs::create_dir_all(&refs).unwrap();
+    fs::write(refs.join("hub-resolution.md"), "hub resolution notes\n").unwrap();
+    fs::write(
+        repo.join("claude-plugin/skills/wiki-manager/SKILL.md"),
+        "---\nname: wiki-manager\n---\nClaude flavour\n",
+    )
+    .unwrap();
+
+    let opencode = repo.join("packages/foo/skills");
+    let wm = opencode.join("wiki-manager");
+    fs::create_dir_all(&wm).unwrap();
+    fs::write(
+        wm.join("SKILL.md"),
+        "---\nname: wiki-manager\n---\nOpenCode flavour\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(
+        "../../../../claude-plugin/skills/wiki-manager/references",
+        wm.join("references"),
+    )
+    .unwrap();
+
+    let wq = opencode.join("wiki-query");
+    fs::create_dir_all(&wq).unwrap();
+    fs::write(wq.join("SKILL.md"), "---\nname: wiki-query\n---\nquery\n").unwrap();
+
+    git_init_and_commit(&repo);
+    repo
+}
+
+#[test]
+fn sync_source_path_copies_nested_tree_and_dereferences_in_clone_symlink() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_nested_path_repo(up.path());
+    let home = fake_home();
+    write_manifest(
+        &home,
+        &format!(
+            "[[agent_skills]]\nsource = \"{}\"\npath = \"packages/foo/skills\"\n",
+            file_url(&repo)
+        ),
+    );
+
+    zskills(&home).arg("sync").assert().success();
+
+    let wm = home.path().join("skills/wiki-manager");
+    assert_eq!(
+        fs::read_to_string(wm.join("SKILL.md")).unwrap(),
+        "---\nname: wiki-manager\n---\nOpenCode flavour\n"
+    );
+    let copied = wm.join("references/hub-resolution.md");
+    assert!(
+        copied.is_file(),
+        "in-clone symlink must be copied as a regular file"
+    );
+    assert!(
+        !copied.symlink_metadata().unwrap().file_type().is_symlink(),
+        "hub references/hub-resolution.md must not remain a symlink"
+    );
+    assert_eq!(
+        fs::read_to_string(&copied).unwrap(),
+        "hub resolution notes\n"
+    );
+    assert!(home.path().join("skills/wiki-query/SKILL.md").is_file());
+
+    let inv: serde_json::Value =
+        serde_json::from_slice(&fs::read(home.path().join("skills/.zskills.json")).unwrap())
+            .unwrap();
+    let tag = format!("source:{}:packages/foo/skills", file_url(&repo));
+    assert_eq!(inv["agent_skills"]["wiki-manager"]["source"], tag);
+    assert_eq!(inv["agent_skills"]["wiki-query"]["source"], tag);
+}
+
+#[test]
+fn sync_source_path_skill_dir_installs_one_name() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_nested_path_repo(up.path());
+    let home = fake_home();
+    write_manifest(
+        &home,
+        &format!(
+            "[[agent_skills]]\nsource = \"{}\"\npath = \"packages/foo/skills/wiki-manager\"\nname = \"wiki-manager\"\n",
+            file_url(&repo)
+        ),
+    );
+
+    zskills(&home).arg("sync").assert().success();
+
+    assert!(home.path().join("skills/wiki-manager/SKILL.md").is_file());
+    assert!(
+        !home.path().join("skills/wiki-query").exists(),
+        "a skill-dir path must not also install sibling skills"
+    );
+}
+
+#[test]
+fn sync_source_path_dry_run_prints_plan_line() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_nested_path_repo(up.path());
+    let home = fake_home();
+    write_manifest(
+        &home,
+        &format!(
+            "[[agent_skills]]\nsource = \"{}\"\npath = \"packages/foo/skills\"\nname = \"wiki-manager\"\n",
+            file_url(&repo)
+        ),
+    );
+
+    zskills(&home)
+        .args(["sync", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("install wiki-manager ← source:"))
+        .stdout(predicate::str::contains("packages/foo/skills"));
+
+    assert!(
+        !home.path().join("skills/wiki-manager").exists(),
+        "dry-run must not copy"
+    );
+}
+
+#[test]
+fn sync_rejects_path_escape() {
+    let home = fake_home();
+    write_manifest(
+        &home,
+        "[[agent_skills]]\nsource = \"owner/repo\"\npath = \"../escape\"\n",
+    );
+    zskills(&home)
+        .arg("sync")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid path"));
+}
+
+#[test]
+fn sync_copy_error_exits_nonzero_skips_applied_and_leaves_no_partial_dest() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = up.path().join("escape-repo");
+    let skill = repo.join("packages/foo/skills/evil");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(skill.join("SKILL.md"), "---\nname: evil\n---\n").unwrap();
+    std::os::unix::fs::symlink("/etc/passwd", skill.join("secret")).unwrap();
+    git_init_and_commit(&repo);
+
+    let home = fake_home();
+    write_manifest(
+        &home,
+        &format!(
+            "[[agent_skills]]\nsource = \"{}\"\npath = \"packages/foo/skills\"\nname = \"evil\"\n",
+            file_url(&repo)
+        ),
+    );
+
+    let out = zskills(&home)
+        .arg("sync")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("applied."),
+        "copy error must skip ✓ applied.: {stdout}"
+    );
+    assert!(
+        stderr.contains("escapes allowed root") || stderr.contains("operation(s) failed"),
+        "stderr={stderr}"
+    );
+    assert!(
+        !home.path().join("skills/evil").exists(),
+        "failed copy must not leave a partial dest"
+    );
+}
+
+#[test]
+fn sync_live_pulls_path_backed_clone_and_recopies_when_head_moved() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_nested_path_repo(up.path());
+    let home = fake_home();
+    write_manifest(
+        &home,
+        &format!(
+            "[[agent_skills]]\nsource = \"{}\"\npath = \"packages/foo/skills\"\nname = \"wiki-manager\"\n",
+            file_url(&repo)
+        ),
+    );
+
+    zskills(&home).arg("sync").assert().success();
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        "---\nname: wiki-manager\n---\nOpenCode flavour\n"
+    );
+
+    fs::write(
+        repo.join("packages/foo/skills/wiki-manager/SKILL.md"),
+        "---\nname: wiki-manager\n---\nOpenCode flavour v2\n",
+    )
+    .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["add", "-A"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["commit", "--quiet", "-m", "second"])
+        .status()
+        .unwrap();
+
+    zskills(&home)
+        .arg("sync")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("refresh wiki-manager ← source:"));
+
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        "---\nname: wiki-manager\n---\nOpenCode flavour v2\n"
+    );
+}
+
+#[test]
+fn sync_adopt_source_path_tag_writes_source_and_path() {
+    let home = fake_home();
+    let skill = home.path().join("skills/foo");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(skill.join("SKILL.md"), "x").unwrap();
+    fs::write(
+        home.path().join("skills/.zskills.json"),
+        json!({
+            "version": 1,
+            "agent_skills": {
+                "foo": {
+                    "source": "source:https://github.com/o/r.git:packages/foo/skills",
+                    "installed_at": "@0",
+                    "head_sha": "abc"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_manifest(&home, "");
+
+    zskills(&home).args(["sync", "--adopt"]).assert().success();
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    assert!(
+        raw.contains("source = \"https://github.com/o/r.git\""),
+        "adopt must write the git source, not the inventory tag: {raw}"
+    );
+    assert!(
+        raw.contains("path = \"packages/foo/skills\""),
+        "adopt must write path: {raw}"
+    );
+    assert!(
+        !raw.contains("source = \"source:"),
+        "adopt must not store the raw inventory tag as source: {raw}"
+    );
+}


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `enhancement`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`

## Summary
- A source-backed `[[agent_skills]]` row can name a relative `path` inside the cloned repo.
- That selector replaces the default walk of `.agents/skills` and `skills/`.
- If `path/SKILL.md` exists, that directory is one Agent Skill. The name is the last segment.
- If `path/SKILL.md` is absent, every child with `SKILL.md` is an Agent Skill. One-level category directories still count.
- The inventory tag is `source:<source>:<path>`. Two paths from one repo do not collide.
- `path` requires `source`. `path` is not valid on an npm entry.
- Absolute form, `..`, `\`, and `:` are rejected. A leading `./` is stripped. `././packages/foo` and `packages/foo` share one inventory tag.
- `copy_dir_recursive` follows a file or directory symlink only when the canonical target stays inside the canonical `allowed_root`. The dest is regular files, not a symlink.
- The previous walker skipped symlink entries. OpenCode `references/` trees were dropped.
- On copy error the dest is removed. A half-written hub name is not left behind.
- `sync` prints plan lines `+ install <name> ← source:<source> (<path>)`.
- Named `path` rows skip only when the inventory tag matches and clone HEAD matches `head_sha`.
- Copy failures increment a count. If the count is greater than 0, `sync` skips `✓ applied.` and exits non-zero.
- `upgrade` passes `path` into `install_from`.
- This PR does not add `marketplace` on Agent Skill rows. This PR does not add `OriginKind::Marketplace`. Those land in the next PR.

## How It Works (diagram — REQUIRED)

A source-backed row with `path` follows these steps:

1. `manifest::load` calls `AgentSkillEntry::validate`.
2. `normalize_skill_path` strips `.` segments and a trailing `/`. It refuses parent, absolute form, backslash, and colon.
3. Live `sync` (not `--dry-run`) calls `ensure_cache` for each `path`-backed `source` before it compares HEAD. The plan sees the pulled clone.
4. `SkillOrigin::git(source, path)` is passed to `install_from`.
5. `resolve_path_in_clone` joins `path` onto the clone. It requires the canonical result to stay inside the clone.
6. `skills_at_path` decides one Agent Skill or a one-level walk of children.
7. `install_to_root` copies into `~/.agents/skills/<name>/`. `allowed_root` is the clone. A symlink that escapes that root errors. A directory-symlink cycle errors. The dest is then removed.
8. Inventory writes `source:<source>:<path>` and the clone `head_sha`.

Plugin hub copies use the same copier. `materialize_hub` passes the plugin root as `allowed_root`.

`--adopt` rebuilds the row with `agent_skill_from_inventory_tag`. The tag `source:<git>:<path>` is split on the last `:`. A git URL that contains `:` stays intact. Path cannot contain `:`.

```toml
# Nested tree: Agent Skills that are not at `.agents/skills` or `skills/`
[[agent_skills]]
source = "owner/odd-layout"
path = "packages/foo/skills"
name = "foo"
```

```mermaid
flowchart TD
    A["[[agent_skills]] source plus path"] --> B{path valid?}
    B -->|no: parent, absolute, backslash, colon| C[refuse and exit non-zero]
    B -->|yes| D[clone source into Agent Skill cache]
    D --> P[pull clone before HEAD compare]
    P --> E{path/SKILL.md exists?}
    E -->|yes| F[one Agent Skill named last segment]
    E -->|no| G[children with SKILL.md]
    F --> H[copy_dir_recursive with allowed_root]
    G --> H
    H --> I{symlink target inside allowed_root?}
    I -->|no| J[error, remove dest, skip applied]
    I -->|yes| K[write regular files to ~/.agents/skills]
    K --> L["inventory tag source:source:path"]
```

## Linked Issues / ADRs
- Resolves: #57
- Stacked on: PR 0 / #51

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

```
cargo fmt --check
# pass

cargo clippy --all-targets -- -D warnings
# pass

cargo test
# 117 unit tests passed
# 145 CLI tests passed
# stack tip 12ecb40
```

CLI tests use `CLAUDE_HOME` / `AGENTS_HOME` sandboxes and `ZSKILLS_NO_CLAUDE_CLI=1`. No state-changing command ran against the real home.

Relevant CLI tests:

- `sync_source_path_copies_nested_tree_and_dereferences_in_clone_symlink`
- `sync_source_path_skill_dir_installs_one_name`
- `sync_source_path_dry_run_prints_plan_line`
- `sync_rejects_path_escape`
- `sync_copy_error_exits_nonzero_skips_applied_and_leaves_no_partial_dest`
- `sync_live_pulls_path_backed_clone_and_recopies_when_head_moved`
- `sync_adopt_source_path_tag_writes_source_and_path`

Relevant unit tests:

- `path_requires_source`
- `path_is_not_valid_on_npm`
- `path_strips_dot_slash`
- `path_rejects_parent_absolute_backslash_and_colon`
- `source_plus_path_inventory_tag`
- `inventory_tag_rsplit_keeps_colon_in_git_source`
- `skills_at_path_treats_skill_dir_as_one_and_parent_as_children`
- `copy_follows_in_clone_symlink_as_regular_file`
- `copy_refuses_symlink_escape_and_leaves_no_partial_dest`
- `sparse_copy_refuses_file_symlink_escape`
- `copy_refuses_in_clone_symlink_cycle`

What those tests lock:

- Nested `packages/foo/skills` copies `wiki-manager` and `wiki-query` into `~/.agents/skills/`.
- An in-clone `references/` symlink is written as a regular file. The hub copy is not a symlink.
- A path that points at one `SKILL.md` directory installs that name only.
- `--dry-run` prints the plan line and does not copy.
- `path = "../escape"` exits non-zero with `invalid path`.
- A symlink to `/etc/passwd` exits non-zero, skips `✓ applied.`, and leaves no dest.
- A second commit on the source is pulled. `sync` reprints `refresh …` and recopies.
- `--adopt` writes `source = "https://github.com/o/r.git"` and `path = "packages/foo/skills"`. It does not store the raw inventory tag as `source`.

## Additional Notes for Reviewers

Stacked unique range: `a7ab621..12ecb40`. Commits: `52b94d0` (feat), `62327ef` (review), `12ecb40` (merge onto the marketplace-source parent).

Review fixes in `62327ef`. Read these first.

1. Live `sync` plan used unpulled `cached_head`. Remote commits never reached apply. Pull the `path`-backed clone first. `--dry-run` does not clone or pull.
2. `--adopt` wrote raw `source:<git>:<path>` as git `source`. Split the tag. `agent_skill_from_inventory_tag` rsplit on the last `:`.
3. Sparse file copies followed `/etc/passwd` with no `allowed_root`. Bound the follow. `copy_sparse_root` now uses the same `copy_symlink` check.
4. A directory-symlink cycle must fail closed. `copy_dir_recursive_inner` tracks canonical paths in `visiting`. A repeat bails with `symlink cycle`. The dest is removed.
5. `././` must not leak into tags. `normalize_skill_path` drops `.` segments so `././packages/foo` and `packages/foo` share one inventory tag.

Copy bound. `allowed_root` is the clone for git Agent Skills. `allowed_root` is the plugin root for hub copies from a plugin. `is_within` uses a canonical prefix. That avoids the `/foo` vs `/foo-evil` string-prefix hole and the macOS `/tmp` vs `/private/tmp` alias.

Skip rule. A named `path` row is already present only when the inventory tag matches and clone HEAD matches `head_sha`. An unnamed `path` row uses the same tag and the same HEAD check.

Plan lines.

- named install: `+ install <name> ← source:<source> (<path>)`
- unnamed install: `+ install all ← source:<source> (<path>)`
- HEAD moved: `~ refresh <name> ← source:<source> (<path>)`

Duplicate check for `append_agent_skill` is now `(source, path, name)`.

Plumbing. `install` is a thin wrapper around `install_from` with `path = None`. `upgrade` passes `entry.path` into `install_from`. `docs/commands.md` documents the `path` field.

Out of scope. Do not expect `marketplace` on an Agent Skill row. Do not expect `OriginKind::Marketplace`. Do not expect a marketplace+path copy. Those land in the next PR.

Risk. The copier now follows in-clone symlinks. A symlink that points outside the clone is an error, not a skip. A cycle is an error. Both remove dest and fail `sync`. That is the closed behaviour.
