### PR TITLE
feat: copy Agent Skills from a marketplace clone via marketplace and path

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,7 +108,7 @@ zskills skill remove <name> [--force] [--file path]
 zskills skill upgrade [<name>...]
 ```
 
-`skill remove` deletes bytes. It is not `plugin remove`. `--force` is required when the name is also shipped by an enabled plugin, or when a source-only `[[agent_skills]]` row owns it.
+`skill remove` deletes bytes. It is not `plugin remove`. `--force` is required when inventory `source` starts with `plugin:`, or when a source-only `[[agent_skills]]` row owns the name. A `marketplace:` hub copy of the same name removes without `--force` and without disabling the plugin.
 
 ## `sync` (headline command)
 
@@ -128,7 +128,7 @@ zskills sync [--file <path>] [--dry-run] [--prune | --adopt]
 What sync does:
 1. For each `[[marketplaces]]` entry with `repo` or `url` that is not yet registered: clone the source and write `known_marketplaces.json` plus `extraKnownMarketplaces` (same as `marketplace add`). This runs **before** plugin resolve, so a fresh machine can recreate the clone. Unqualified `[[skills]]` names (`name` only) are resolved against the map **after** that clone, so they can match a marketplace that did not exist at plan time.
 2. For each `[[skills]]` entry: resolve `name@marketplace`. If `harnesses` (or `[defaults].harnesses`) contains `claude`, write to `enabledPlugins`. Entries currently enabled but not in the manifest get flipped off. Hub-backed harnesses (`pi`, `grok`, `codex`) copy nested `skills/<name>/` trees into `~/.agents/skills/` in the same pass. **`sync` refuses to write an `enabledPlugins` key whose marketplace is not registered.** It reports the unresolved plugins and exits non-zero instead of printing `✓ applied.` Hub copies for those plugins are skipped too.
-3. For each `[[agent_skills]]` entry: if `source` is present, clone/pull and copy `skills/<name>/` to `~/.agents/skills/`. If `path` is set, copy from that relative directory inside the clone instead of the default skill roots. If `npm` is present, run `npm install -g --no-fund --no-audit <pkg>` (or `install_cmd`), then claim all matching `claims` globs. If neither is present (just `name`), register the existing on-disk skill in inventory without fetching anything. A copy or resolve error increments a failure count: `sync` then skips `✓ applied.` and exits non-zero.
+3. For each `[[agent_skills]]` entry: classify the row by kind. `source` clones/pulls the Agent Skill cache. `marketplace` + `path` copies from the registered marketplace clone (hard error if the clone is missing — this is not a local-only row). If `path` is set, copy from that relative directory inside the clone instead of the default skill roots. If `npm` is present, run `npm install -g --no-fund --no-audit <pkg>` (or `install_cmd`), then claim all matching `claims` globs. If none of `source` / `marketplace` / `npm` is present (just `name`), register the existing on-disk skill in inventory without fetching anything. Nested plugin hub copies skip names claimed by `[[agent_skills]]`. Same-marketplace `plugin:` hub copies are taken over. A copy or resolve error increments a failure count: `sync` then skips `✓ applied.` and exits non-zero.
 4. Agent skills tracked in inventory but missing from the manifest are reported. With `--prune` they're deleted; with `--adopt` they're appended to the manifest; otherwise they're skipped.
 
 ### `--adopt` details
@@ -138,7 +138,7 @@ When you pass `--adopt`, sync writes new entries to `skills.toml` instead of rem
 - **Registered marketplace** not in manifest → new `[[marketplaces]]` row with `name` plus `repo` (`owner/repo`) or `url` (non-GitHub git source). Source comes from `known_marketplaces.json` / `extraKnownMarketplaces`. Remote-index entries are skipped. This is what makes a later `sync` on a fresh machine able to clone.
 - **Registered marketplace** already in the manifest with only `name` / `pin` → fill `repo` or `url`. Existing `pin` is left untouched. A row that already has a source is skipped.
 - **Enabled plugin** not in manifest → new `[[skills]]` row with `name` + `marketplace`.
-- **Agent skill** in inventory but not in manifest → new `[[agent_skills]]` row. The fields are reconstructed from the inventory tag: `local` becomes a name-only entry, `npm:pkg` becomes `npm = "pkg"`, `source:<git>:<path>` becomes `source` plus `path` (rsplit on the last `:`, so a git URL that contains `:` stays intact), and any other string becomes `source = "..."` only.
+- **Agent skill** in inventory but not in manifest → new `[[agent_skills]]` row. The fields are reconstructed from the inventory tag: `local` becomes a name-only entry, `npm:pkg` becomes `npm = "pkg"`, `marketplace:<name>:<path>` becomes `marketplace` plus `path` (rsplit on the last `:`), `source:<git>:<path>` becomes `source` plus `path` (rsplit on the last `:`, so a git URL that contains `:` stays intact), `plugin:…` is not adopted as `[[agent_skills]]`, and any other string becomes `source = "..."` only.
 - **MCP server** configured but not in manifest → new `[[mcps]]` row with full transport details (`command`/`args`/`env` for stdio, `url`/`headers` for http/sse), `scope` preserved. **Env and header values are copied verbatim** — if any contain literal secrets, eyeball the resulting manifest and replace them with `${VAR}` references before committing.
 
 Adoption is idempotent and de-duplicates against existing entries, so re-running `sync --adopt` after editing the manifest is safe.
@@ -159,9 +159,10 @@ zskills skill upgrade [<name>...]
 |---|---|
 | Plugins (marketplace-based) | For each registered marketplace tap, `git pull --ff-only` if it's a git working tree; otherwise fetch the GitHub archive tarball from the source recorded in `known_marketplaces.json` and atomically swap the tree. Claude Code picks up new plugin versions on next start. |
 | Git agent skills (`source = "owner/repo"`) | `git pull` the cached source clone + re-copy bytes. Honour `path` when set. |
+| Marketplace Agent Skills (`marketplace` + `path`) | Re-copy from the marketplace clone after marketplace refresh. Does not clone into the Agent Skill cache. Filter matches the marketplace name. Unnamed rows refresh names already tagged `marketplace:<name>:<path>`. |
 | npm agent skills (`npm = "pkg"`) | Run `npm install -g <pkg>` (or `install_cmd`), then re-apply the `claims` glob to retag inventory |
 
-Pass specific names to upgrade just those; empty = upgrade everything. The `name` filter matches against the manifest's `npm`, `source`, or `name` fields.
+Pass specific names to upgrade just those; empty = upgrade everything. The `name` filter matches against the manifest's `npm`, `source`, `name`, or `marketplace` fields.
 
 ## MCP servers manifest schema
 
@@ -246,6 +247,13 @@ source = "owner/odd-layout"
 path = "packages/foo/skills"
 name = "foo"
 
+# Reuse a registered marketplace clone (one clone, several packaging trees)
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
 # npm-distributed package
 [[agent_skills]]
 npm = "get-shit-done-cc"
@@ -263,8 +271,9 @@ name = "my-internal-tool"
 
 | Field | Purpose |
 |---|---|
-| `source` | Git source: `owner/repo` (GitHub) or full git URL. `sync`/`upgrade` clone/pull and copy. |
-| `path` | Relative directory inside the cloned `source`. Replaces the default walk of `.agents/skills` and `skills/`. If `path/SKILL.md` exists, that directory is the skill (name = last segment). Else every child with `SKILL.md` is a skill. Requires `source`. Must be relative: no `..`, no absolute form, no `\`, no `:`. Inventory tag is `source:<source>:<path>`. |
+| `source` | Git source: `owner/repo` (GitHub) or full git URL. `sync`/`upgrade` clone/pull and copy. Mutex with `npm` and `marketplace`. |
+| `marketplace` | Name of a registered marketplace. Reuse that clone instead of cloning `source` into the Agent Skill cache. Requires the clone to exist (hard error if missing). Mutex with `source` and `npm`. Inventory tag is `marketplace:<name>:<path>`. |
+| `path` | Relative directory inside the cloned `source` or `marketplace`. Replaces the default walk of `.agents/skills` and `skills/`. If `path/SKILL.md` exists, that directory is the skill (name = last segment). Else every child with `SKILL.md` is a skill. Requires `source` or `marketplace`. Must be relative: no `..`, no absolute form, no `\`, no `:`. Inventory tag is `source:<source>:<path>` or `marketplace:<name>:<path>`. |
 | `npm` | npm package name. `sync`/`upgrade` runs `npm install -g <pkg>`. |
 | `install_cmd` | Custom installer command — overrides the default `npm install -g`. Used for packages with their own setup CLI. |
 | `name` | Optional. For source entries, pick a single skill out of a multi-skill repo. For local-only entries, required — names the on-disk skill to track. |

--- a/src/agent_skill.rs
+++ b/src/agent_skill.rs
@@ -10,6 +10,7 @@
 //! Repo convention we recognize: `skills/<skill-name>/SKILL.md` under the source repo.
 
 use anyhow::{Context, Result};
+use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
@@ -43,6 +44,7 @@ pub struct SkillOrigin {
 #[derive(Debug, Clone)]
 pub enum OriginKind {
     Git { source: String },
+    Marketplace { name: String },
 }
 
 impl SkillOrigin {
@@ -53,6 +55,27 @@ impl SkillOrigin {
             },
             path,
         }
+    }
+
+    pub fn marketplace(name: impl Into<String>, path: Option<String>) -> Self {
+        Self {
+            kind: OriginKind::Marketplace { name: name.into() },
+            path,
+        }
+    }
+
+    /// Origin for a git or marketplace row. `npm` and local-only rows return `None`.
+    pub fn from_entry(entry: &crate::manifest::AgentSkillEntry) -> Option<Self> {
+        if entry.npm.is_some() {
+            return None;
+        }
+        if let Some(mp) = &entry.marketplace {
+            return Some(Self::marketplace(mp, entry.path.clone()));
+        }
+        if let Some(src) = &entry.source {
+            return Some(Self::git(src, entry.path.clone()));
+        }
+        None
     }
 }
 
@@ -536,6 +559,82 @@ pub fn cached_head(source: &str) -> Option<String> {
     crate::git::head_sha(&cache).ok()
 }
 
+/// Marketplace clone directory. Hard error if the clone is missing — this
+/// must not fall through to the local-only apply arm.
+pub fn resolve_marketplace_clone(name: &str) -> Result<PathBuf> {
+    let dir = crate::paths::marketplaces_dir()?.join(name);
+    if !dir.is_dir() {
+        anyhow::bail!(
+            "marketplace '{name}' is not registered — add repo = on [[marketplaces]] and run sync, or: zskills marketplace add <owner/repo>"
+        );
+    }
+    Ok(dir)
+}
+
+/// HEAD of a registered marketplace clone, or `"unknown"` for a tarball.
+/// `None` when the clone directory is missing.
+pub fn marketplace_head(name: &str) -> Option<String> {
+    let dir = crate::paths::marketplaces_dir().ok()?.join(name);
+    if !dir.is_dir() {
+        return None;
+    }
+    Some(crate::git::head_sha(&dir).unwrap_or_else(|_| "unknown".to_string()))
+}
+
+/// Live clone HEAD for plan/apply skip. `None` if the clone is not on disk.
+pub fn live_head(entry: &crate::manifest::AgentSkillEntry) -> Option<String> {
+    if let Some(mp) = entry.marketplace.as_deref() {
+        return marketplace_head(mp);
+    }
+    entry.source.as_deref().and_then(cached_head)
+}
+
+/// Names an `[[agent_skills]]` row claims on the hub. Explicit `name` wins;
+/// unnamed path rows walk the clone. A missing clone claims nothing so the
+/// later hard error can fire.
+pub fn names_claimed_by(entries: &[crate::manifest::AgentSkillEntry]) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for entry in entries {
+        if let Some(n) = &entry.name {
+            out.insert(n.clone());
+            continue;
+        }
+        let Some(origin) = SkillOrigin::from_entry(entry) else {
+            continue;
+        };
+        if let Some(names) = try_discover_names(&origin) {
+            out.extend(names);
+        }
+    }
+    out
+}
+
+fn try_discover_names(origin: &SkillOrigin) -> Option<Vec<String>> {
+    let clone = existing_clone(origin)?;
+    let found = match origin.path.as_deref() {
+        Some(rel) => {
+            let root = resolve_path_in_clone(&clone, rel).ok()?;
+            skills_at_path(&root).ok()?
+        }
+        None => skills_in_cache(&clone),
+    };
+    Some(found.into_iter().map(|(n, _)| n).collect())
+}
+
+fn existing_clone(origin: &SkillOrigin) -> Option<PathBuf> {
+    match &origin.kind {
+        OriginKind::Git { source } => {
+            let (_, name) = parse_source(source).ok()?;
+            let cache = crate::paths::agent_skills_cache_dir().ok()?.join(name);
+            cache.is_dir().then_some(cache)
+        }
+        OriginKind::Marketplace { name } => {
+            let dir = crate::paths::marketplaces_dir().ok()?.join(name);
+            dir.is_dir().then_some(dir)
+        }
+    }
+}
+
 /// Reject names that would make `user_skills_dir().join(name)` escape that
 /// directory. Empty, `.`, `..`, and any path separator are refused before
 /// `remove_dir_all`. `sync --prune` calls this through [`remove`].
@@ -828,34 +927,144 @@ pub fn install(source: &str, name: Option<&str>) -> Result<Vec<String>> {
     install_from(&SkillOrigin::git(source, None), name)
 }
 
+struct ResolvedOrigin {
+    clone: PathBuf,
+    head_sha: String,
+    source_tag: String,
+    available: Vec<(String, PathBuf)>,
+    label: String,
+}
+
+fn resolve_origin(origin: &SkillOrigin) -> Result<ResolvedOrigin> {
+    match &origin.kind {
+        OriginKind::Git { source } => {
+            let cache = ensure_cache(source)?;
+            let head_sha = crate::git::head_sha(&cache).unwrap_or_else(|_| "unknown".to_string());
+            if let Some(rel) = origin.path.as_deref() {
+                let rel = crate::manifest::normalize_skill_path(rel)?;
+                let root = resolve_path_in_clone(&cache, &rel)?;
+                let found = skills_at_path(&root)?;
+                Ok(ResolvedOrigin {
+                    clone: cache,
+                    head_sha,
+                    source_tag: format!("source:{source}:{rel}"),
+                    available: found,
+                    label: source.clone(),
+                })
+            } else {
+                let found = skills_in_cache(&cache);
+                if found.is_empty() {
+                    anyhow::bail!(
+                        "no skills found in {} (expected skills/<name>/SKILL.md)",
+                        source
+                    );
+                }
+                Ok(ResolvedOrigin {
+                    clone: cache,
+                    head_sha,
+                    source_tag: source.clone(),
+                    available: found,
+                    label: source.clone(),
+                })
+            }
+        }
+        OriginKind::Marketplace { name } => {
+            let clone = resolve_marketplace_clone(name)?;
+            let head_sha = crate::git::head_sha(&clone).unwrap_or_else(|_| "unknown".to_string());
+            if let Some(rel) = origin.path.as_deref() {
+                let rel = crate::manifest::normalize_skill_path(rel)?;
+                let root = resolve_path_in_clone(&clone, &rel)?;
+                let found = skills_at_path(&root)?;
+                Ok(ResolvedOrigin {
+                    clone,
+                    head_sha,
+                    source_tag: format!("marketplace:{name}:{rel}"),
+                    available: found,
+                    label: format!("marketplace:{name}"),
+                })
+            } else {
+                let found = skills_in_cache(&clone);
+                if found.is_empty() {
+                    anyhow::bail!(
+                        "no Agent Skills in marketplace '{name}' (expected skills/<name>/SKILL.md)"
+                    );
+                }
+                Ok(ResolvedOrigin {
+                    clone,
+                    head_sha,
+                    source_tag: format!("marketplace:{name}"),
+                    available: found,
+                    label: format!("marketplace:{name}"),
+                })
+            }
+        }
+    }
+}
+
+/// Disk ∩ inventory decision before `install_to_root` deletes dest.
+#[derive(Clone, Copy)]
+enum DestAction {
+    Copy,
+    Skip,
+    Takeover,
+}
+
+fn dest_action(
+    hub: &Path,
+    skill_name: &str,
+    origin: &SkillOrigin,
+    inv: &Inventory,
+    tag: &str,
+    head_sha: &str,
+) -> Result<DestAction> {
+    let dest = hub.join(skill_name);
+    if !dest.exists() {
+        return Ok(DestAction::Copy);
+    }
+    match inv.agent_skills.get(skill_name).map(|e| e.source.as_str()) {
+        None => anyhow::bail!(
+            "Agent Skill '{skill_name}' already exists on the hub with no inventory entry; \
+             run `zskills skill remove --force {skill_name}` or rename it"
+        ),
+        Some(src) if src == tag => {
+            if inv
+                .agent_skills
+                .get(skill_name)
+                .is_some_and(|e| e.head_sha == head_sha)
+            {
+                Ok(DestAction::Skip)
+            } else {
+                Ok(DestAction::Copy)
+            }
+        }
+        Some(src) if is_same_marketplace_plugin(origin, src) => Ok(DestAction::Takeover),
+        Some(src) => {
+            anyhow::bail!("refusing to overwrite Agent Skill '{skill_name}' (source {src})")
+        }
+    }
+}
+
+fn is_same_marketplace_plugin(origin: &SkillOrigin, inv_source: &str) -> bool {
+    let OriginKind::Marketplace { name } = &origin.kind else {
+        return false;
+    };
+    inv_source
+        .strip_prefix("plugin:")
+        .and_then(|q| q.rsplit_once('@'))
+        .is_some_and(|(_, mp)| mp == name)
+}
+
 /// Install (or refresh) an Agent Skill from `origin`. If `name` is given, only
 /// that skill is installed; otherwise every skill the origin yields.
 pub fn install_from(origin: &SkillOrigin, name: Option<&str>) -> Result<Vec<String>> {
-    let OriginKind::Git { source } = &origin.kind;
-    let cache = ensure_cache(source)?;
-    let head_sha = crate::git::head_sha(&cache).unwrap_or_else(|_| "unknown".to_string());
-    let installed_at = chrono_now_iso();
-    let (available, source_tag) = if let Some(rel) = origin.path.as_deref() {
-        let rel = crate::manifest::normalize_skill_path(rel)?;
-        let root = resolve_path_in_clone(&cache, &rel)?;
-        let found = skills_at_path(&root)?;
-        (found, format!("source:{source}:{rel}"))
-    } else {
-        let found = skills_in_cache(&cache);
-        if found.is_empty() {
-            anyhow::bail!(
-                "no skills found in {} (expected skills/<name>/SKILL.md)",
-                source
-            );
-        }
-        (found, source.clone())
-    };
+    let resolved = resolve_origin(origin)?;
     let chosen: Vec<_> = match name {
-        Some(n) => available
+        Some(n) => resolved
+            .available
             .into_iter()
             .filter(|(k, _)| k == n)
             .collect::<Vec<_>>(),
-        None => available,
+        None => resolved.available,
     };
     if chosen.is_empty() {
         if let Some(rel) = origin.path.as_deref() {
@@ -863,32 +1072,62 @@ pub fn install_from(origin: &SkillOrigin, name: Option<&str>) -> Result<Vec<Stri
                 "skill '{}' not found under path '{}' in {}",
                 name.unwrap_or("?"),
                 rel,
-                source
+                resolved.label
             );
         }
         anyhow::bail!(
             "skill '{}' not found in {} (skills/<name>/ not present)",
             name.unwrap_or("?"),
-            source
+            resolved.label
         );
     }
     let hub = crate::paths::user_skills_dir()?;
     let mut inv = load_inventory()?;
-    let mut installed_names = Vec::new();
+    let installed_at = chrono_now_iso();
+    // Decide every dest before any copy. An unnamed row that yields
+    // wiki-manager then wiki-query must not copy wiki-manager if wiki-query
+    // will refuse: dest_action? after a copy would leave that dest untagged.
+    let mut planned: Vec<(&String, &PathBuf, DestAction)> = Vec::new();
     for (skill_name, src_dir) in &chosen {
-        if src_dir == &cache {
+        let action = dest_action(
+            &hub,
+            skill_name,
+            origin,
+            &inv,
+            &resolved.source_tag,
+            &resolved.head_sha,
+        )?;
+        planned.push((skill_name, src_dir, action));
+    }
+    let mut installed_names = Vec::new();
+    for (skill_name, src_dir, action) in planned {
+        match action {
+            DestAction::Skip => {
+                installed_names.push(skill_name.clone());
+                continue;
+            }
+            DestAction::Takeover => {
+                println!(
+                    "  {} {}: hub taken over by [[agent_skills]] path",
+                    "·".dimmed(),
+                    skill_name
+                );
+            }
+            DestAction::Copy => {}
+        }
+        if src_dir == &resolved.clone {
             // Root-level SKILL.md in a larger project — materialize sparsely
             // instead of copying the whole source tree.
-            install_root_skill_sparse_to(&hub, skill_name, &cache)?;
+            install_root_skill_sparse_to(&hub, skill_name, &resolved.clone)?;
         } else {
-            install_to_root(&hub, skill_name, src_dir, &cache)?;
+            install_to_root(&hub, skill_name, src_dir, &resolved.clone)?;
         }
         inv.agent_skills.insert(
             skill_name.clone(),
             Entry {
-                source: source_tag.clone(),
+                source: resolved.source_tag.clone(),
                 installed_at: installed_at.clone(),
-                head_sha: head_sha.clone(),
+                head_sha: resolved.head_sha.clone(),
                 to: vec!["agents".into()],
             },
         );

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -42,8 +42,6 @@ pub fn remove(names: Vec<String>, force: bool, file: Option<PathBuf>) -> Result<
         None => None,
     };
     let inv = crate::agent_skill::load_inventory()?;
-    let report = crate::reconcile::run()?;
-    let from_plugins = crate::agent_skill::plugin_provided_skills(&report.active);
 
     let mut failed = 0usize;
     for name in &names {
@@ -53,7 +51,6 @@ pub fn remove(names: Vec<String>, force: bool, file: Option<PathBuf>) -> Result<
             manifest_path.as_deref(),
             manifest.as_ref(),
             &inv,
-            &from_plugins,
         ) {
             eprintln!("{} {name}: {e}", "✗".red());
             failed += 1;
@@ -69,19 +66,23 @@ fn remove_one(
     manifest_path: Option<&std::path::Path>,
     manifest: Option<&crate::manifest::Manifest>,
     inv: &crate::agent_skill::Inventory,
-    from_plugins: &std::collections::BTreeSet<String>,
 ) -> Result<()> {
     crate::agent_skill::validate_skill_name(name)?;
-    if from_plugins.contains(name) && !force {
+    // Nested plugin-cache names are not enough: after takeover the hub copy is
+    // a `marketplace:` artefact and must remove without --force.
+    let plugin_owned = inv
+        .agent_skills
+        .get(name)
+        .is_some_and(|e| e.source.starts_with("plugin:"));
+    if plugin_owned && !force {
         anyhow::bail!(
             "Agent Skill '{name}' is also shipped by an enabled plugin; removing the user copy will not remove it — use `zskills plugin remove`, or --force"
         );
     }
     if let (Some(entry), Some(m)) = (inv.agent_skills.get(name), manifest) {
-        let source_only = m
-            .agent_skills
-            .iter()
-            .any(|e| e.name.is_none() && e.source.as_deref() == Some(entry.source.as_str()));
+        let source_only = m.agent_skills.iter().any(|e| {
+            e.name.is_none() && e.inventory_tag().as_deref() == Some(entry.source.as_str())
+        });
         if source_only && !force {
             anyhow::bail!(
                 "Agent Skill '{name}' is owned by a source-only [[agent_skills]] row (source = {}); convert to a named row first, or pass --force",

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -346,8 +346,12 @@ fn install_plugin_specs(
         );
     }
     if want_hub || targets.iter().any(|h| h.skill_skip_reason().is_some()) {
+        let claimed = crate::manifest::discover()
+            .and_then(|p| crate::manifest::load(&p).ok())
+            .map(|m| crate::agent_skill::names_claimed_by(&m.agent_skills))
+            .unwrap_or_default();
         for q in &resolved {
-            match crate::harness::materialize_hub(q, &targets, category) {
+            match crate::harness::materialize_hub(q, &targets, category, &claimed) {
                 Ok(names) if !names.is_empty() => {
                     println!(
                         "  {} copied {} nested skill(s) from {} into the Agent Skill hub",

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -195,17 +195,13 @@ pub fn run(
     let mut desired_named: BTreeSet<String> = BTreeSet::new();
     let mut deferred_sources: Vec<&crate::manifest::AgentSkillEntry> = Vec::new();
     for entry in &manifest.agent_skills {
-        match (&entry.name, &entry.source) {
-            (Some(n), _) => {
-                desired_named.insert(n.clone());
-            }
-            (None, Some(_)) => {
-                // Source without an explicit name — every skill in `skills/` of that repo.
-                deferred_sources.push(entry);
-            }
-            (None, None) => {
-                // Invalid: report below at apply time
-            }
+        if let Some(n) = &entry.name {
+            desired_named.insert(n.clone());
+        } else if entry.source.is_some() || entry.marketplace.is_some() {
+            // Unnamed git-source, source+path, or marketplace+path — install
+            // every skill the origin yields. Marketplace+path is first-class
+            // deferred: prune must not delete it.
+            deferred_sources.push(entry);
         }
     }
 
@@ -270,46 +266,49 @@ pub fn run(
             {
                 return true;
             }
-            if e.path.is_some() {
-                if let Some(src) = &e.source {
-                    if let Some(head) = crate::agent_skill::cached_head(src) {
-                        return inventoried_from_source
-                            .iter()
-                            .any(|(_, ent)| ent.head_sha != head);
-                    }
+            // Missing clone must still apply so the hard error fires.
+            if e.marketplace.is_some() && crate::agent_skill::live_head(e).is_none() {
+                return true;
+            }
+            if e.path.is_some() || e.marketplace.is_some() {
+                if let Some(head) = crate::agent_skill::live_head(e) {
+                    return inventoried_from_source
+                        .iter()
+                        .any(|(_, ent)| ent.head_sha != head);
                 }
             }
             false
         })
         .copied()
         .collect();
-    // Named source+path rows whose bytes are on disk but the clone HEAD moved.
-    let mut path_refresh: Vec<(&str, &str, &str)> = Vec::new();
+    // Named origin rows whose bytes are on disk but the clone HEAD moved.
+    let mut path_refresh: Vec<(&str, String, &str)> = Vec::new();
+    // On disk, tag mismatch or no inventory — takeover / refuse / first tag.
+    let mut named_retag: Vec<(&str, String, Option<&str>)> = Vec::new();
     for entry in &manifest.agent_skills {
-        let (Some(n), Some(src), Some(p)) = (
-            entry.name.as_deref(),
-            entry.source.as_deref(),
-            entry.path.as_deref(),
-        ) else {
+        let Some(n) = entry.name.as_deref() else {
             continue;
         };
+        if crate::agent_skill::SkillOrigin::from_entry(entry).is_none() {
+            continue;
+        }
         if !on_disk.contains(n) {
             continue;
         }
-        let Some(tag) = entry.inventory_tag() else {
-            continue;
-        };
-        let Some(inv_e) = inv.agent_skills.get(n) else {
-            continue;
-        };
-        if inv_e.source != tag {
+        if already_present_named(entry, n, &on_disk, &inv) {
             continue;
         }
-        if let Some(head) = crate::agent_skill::cached_head(src) {
-            if inv_e.head_sha != head {
-                path_refresh.push((n, src, p));
+        let label = origin_plan_label(entry);
+        let path = entry.path.as_deref();
+        let tag = entry.inventory_tag();
+        let inv_e = inv.agent_skills.get(n);
+        if let (Some(tag), Some(inv_e), Some(p)) = (tag.as_deref(), inv_e, path) {
+            if inv_e.source == tag {
+                path_refresh.push((n, label, p));
+                continue;
             }
         }
+        named_retag.push((n, label, path));
     }
     // Don't propose removing a skill that's owned by any manifest entry — either:
     //   (a) it came from a source-only [[agent_skills]] entry (we'll re-resolve), or
@@ -383,6 +382,7 @@ pub fn run(
         && agent_to_remove.is_empty()
         && deferred_sources_to_install.is_empty()
         && path_refresh.is_empty()
+        && named_retag.is_empty()
         && mcps_to_install.is_empty()
         && mcps_to_update.is_empty()
         && mcps_to_remove.is_empty()
@@ -484,14 +484,22 @@ pub fn run(
             .iter()
             .find(|e| e.name.as_deref() == Some(n.as_str()))
         {
-            if let (Some(src), Some(p)) = (&entry.source, &entry.path) {
-                println!("  {} install {} ← source:{} ({})", "+".green(), n, src, p);
+            if let Some(line) = path_plan_line(entry, n) {
+                println!("  {} install {line}", "+".green());
                 continue;
             }
         }
         println!("  {} install agent   {}", "+".green(), n);
     }
     for entry in &deferred_sources_to_install {
+        if let Some(mp) = &entry.marketplace {
+            if let Some(p) = &entry.path {
+                println!("  {} install all ← marketplace:{} ({})", "+".green(), mp, p);
+                continue;
+            }
+            println!("  {} install all ← marketplace:{}", "+".green(), mp);
+            continue;
+        }
         if let (Some(s), Some(p)) = (&entry.source, &entry.path) {
             println!("  {} install all ← source:{} ({})", "+".green(), s, p);
             continue;
@@ -505,8 +513,14 @@ pub fn run(
             );
         }
     }
-    for (n, src, p) in &path_refresh {
-        println!("  {} refresh {} ← source:{} ({})", "~".cyan(), n, src, p);
+    for (n, label, p) in &path_refresh {
+        println!("  {} refresh {} ← {} ({})", "~".cyan(), n, label, p);
+    }
+    for (n, label, p) in &named_retag {
+        match p {
+            Some(p) => println!("  {} install {} ← {} ({})", "+".green(), n, label, p),
+            None => println!("  {} install {} ← {}", "+".green(), n, label),
+        }
     }
     for n in &agent_to_remove {
         if adopt {
@@ -625,6 +639,9 @@ pub fn run(
                 .get(n)
                 .map(|e| e.source.as_str())
                 .unwrap_or("local");
+            if tag.starts_with("plugin:") {
+                continue;
+            }
             let manifest_entry = crate::manifest::agent_skill_from_inventory_tag(n, tag);
             if crate::manifest::append_agent_skill(&path, &manifest_entry)? {
                 adopted += 1;
@@ -760,12 +777,18 @@ pub fn run(
     }
 
     let mut failures = 0usize;
+    let claimed = crate::agent_skill::names_claimed_by(&manifest.agent_skills);
 
     for (q, hs) in &plugin_copies {
         if unresolved.contains(q) {
             continue;
         }
-        match crate::harness::materialize_hub(q, hs, crate::harness::DEFAULT_HERMES_CATEGORY) {
+        match crate::harness::materialize_hub(
+            q,
+            hs,
+            crate::harness::DEFAULT_HERMES_CATEGORY,
+            &claimed,
+        ) {
             Ok(names) => {
                 if !names.is_empty() {
                     println!(
@@ -815,71 +838,56 @@ pub fn run(
             }
             continue;
         }
-        match (entry.source.as_deref(), entry.name.as_deref()) {
-            (Some(src), name) => {
-                // Skip the (re-)install if the skill is already on disk + tagged
-                // with this same source. Path-backed rows also skip only when
-                // head_sha still matches the clone HEAD; otherwise re-copy.
-                // `upgrade` is the deliberate refresh path for git-source without path.
-                let origin = crate::agent_skill::SkillOrigin::git(src, entry.path.clone());
-                let tag = entry.inventory_tag().unwrap_or_else(|| src.to_string());
-                let inv_now = crate::agent_skill::load_inventory()?;
-                let on_disk: std::collections::BTreeSet<String> =
-                    crate::agent_skill::installed_on_disk()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .collect();
-                let already_present = match name {
-                    Some(n) => {
-                        let tagged = on_disk.contains(n)
-                            && inv_now.agent_skills.get(n).is_some_and(|e| e.source == tag);
-                        if tagged && entry.path.is_some() {
-                            let cache_ok = crate::agent_skill::ensure_cache(src).ok();
-                            let head = cache_ok.as_ref().and_then(|c| crate::git::head_sha(c).ok());
-                            inv_now
-                                .agent_skills
-                                .get(n)
-                                .is_some_and(|e| head.as_deref().is_some_and(|h| e.head_sha == h))
-                        } else {
-                            tagged
-                        }
-                    }
-                    None => false,
-                };
-                if already_present {
-                    if let Some(n) = name {
-                        crate::harness::link_hub_to_harnesses(
-                            &[n.to_string()],
-                            &hs,
-                            crate::harness::DEFAULT_HERMES_CATEGORY,
-                        )?;
-                        println!(
-                            "  {} {}  {}",
-                            "·".dimmed(),
-                            n,
-                            format!("← {}  (already present)", src).dimmed()
-                        );
-                    }
-                    continue;
+        if let Some(origin) = crate::agent_skill::SkillOrigin::from_entry(entry) {
+            // Skip the (re-)install if the skill is already on disk + tagged
+            // with this same source. Path-backed and marketplace rows also skip
+            // only when head_sha still matches the clone HEAD; otherwise re-copy.
+            let inv_now = crate::agent_skill::load_inventory()?;
+            let on_disk_now: std::collections::BTreeSet<String> =
+                crate::agent_skill::installed_on_disk()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect();
+            let already = match entry.name.as_deref() {
+                Some(n) => already_present_named(entry, n, &on_disk_now, &inv_now),
+                None => false,
+            };
+            if already {
+                if let Some(n) = entry.name.as_deref() {
+                    crate::harness::link_hub_to_harnesses(
+                        &[n.to_string()],
+                        &hs,
+                        crate::harness::DEFAULT_HERMES_CATEGORY,
+                    )?;
+                    println!(
+                        "  {} {}  {}",
+                        "·".dimmed(),
+                        n,
+                        format!("← {}  (already present)", origin_plan_label(entry)).dimmed()
+                    );
                 }
-                match crate::agent_skill::install_from(&origin, name) {
-                    Ok(names) => {
-                        crate::harness::link_hub_to_harnesses(
-                            &names,
-                            &hs,
-                            crate::harness::DEFAULT_HERMES_CATEGORY,
-                        )?;
-                        for n in &names {
-                            println!("  installed agent skill {}", n.bold());
-                        }
+                continue;
+            }
+            match crate::agent_skill::install_from(&origin, entry.name.as_deref()) {
+                Ok(names) => {
+                    crate::harness::link_hub_to_harnesses(
+                        &names,
+                        &hs,
+                        crate::harness::DEFAULT_HERMES_CATEGORY,
+                    )?;
+                    for n in &names {
+                        println!("  installed agent skill {}", n.bold());
                     }
-                    Err(e) => {
-                        eprintln!("{} {}: {}", "✗".red(), src, e);
-                        failures += 1;
-                    }
+                }
+                Err(e) => {
+                    eprintln!("{} {}: {}", "✗".red(), origin_plan_label(entry), e);
+                    failures += 1;
                 }
             }
-            (None, Some(name)) if entry.npm.is_none() => {
+            continue;
+        }
+        match entry.name.as_deref() {
+            Some(name) if entry.npm.is_none() => {
                 // Local-only entry: register in inventory if present on disk; don't fetch.
                 //
                 // The disk check is the point. Tracking a name that is not there writes an
@@ -941,17 +949,15 @@ pub fn run(
                     crate::agent_skill::save_inventory(&inv)?;
                 }
             }
-            (None, None) => {
+            None => {
                 eprintln!(
-                    "{} agent_skill entry needs either `source` or `name`",
+                    "{} agent_skill entry needs `source`, `marketplace`, `npm`, or `name`",
                     "✗".red()
                 );
                 failures += 1;
             }
-            (None, Some(_)) => {
+            Some(_) => {
                 // npm path; already handled by the early `if let Some(pkg) = entry.npm` continue.
-                // Reachable only if npm = Some(_) AND name = Some(_) — name is informational
-                // for npm entries.
             }
         }
     }
@@ -1088,4 +1094,53 @@ fn mcp_entry_from_raw(
         }
     }
     e
+}
+
+fn origin_plan_label(entry: &crate::manifest::AgentSkillEntry) -> String {
+    if let Some(mp) = &entry.marketplace {
+        return format!("marketplace:{mp}");
+    }
+    if let Some(src) = &entry.source {
+        return format!("source:{src}");
+    }
+    String::new()
+}
+
+fn path_plan_line(entry: &crate::manifest::AgentSkillEntry, name: &str) -> Option<String> {
+    let p = entry.path.as_deref()?;
+    if let Some(mp) = &entry.marketplace {
+        return Some(format!("{name} ← marketplace:{mp} ({p})"));
+    }
+    if let Some(src) = &entry.source {
+        return Some(format!("{name} ← source:{src} ({p})"));
+    }
+    None
+}
+
+fn already_present_named(
+    entry: &crate::manifest::AgentSkillEntry,
+    name: &str,
+    on_disk: &BTreeSet<String>,
+    inv: &crate::agent_skill::Inventory,
+) -> bool {
+    if !on_disk.contains(name) {
+        return false;
+    }
+    let Some(tag) = entry.inventory_tag() else {
+        return false;
+    };
+    let Some(inv_e) = inv.agent_skills.get(name) else {
+        return false;
+    };
+    if inv_e.source != tag {
+        return false;
+    }
+    if entry.path.is_some() || entry.marketplace.is_some() {
+        return match crate::agent_skill::live_head(entry) {
+            Some(head) => inv_e.head_sha == head,
+            // Missing clone: do not skip — apply must hard-error.
+            None => false,
+        };
+    }
+    true
 }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -39,12 +39,13 @@ pub fn run(filter: Vec<String>) -> Result<()> {
     if !manifest.agent_skills.is_empty() {
         println!("\n{}", "Agent Skills".bold());
         for entry in &manifest.agent_skills {
-            // Apply --name filter against any of: npm, source, name
+            // Apply --name filter against any of: npm, source, name, marketplace
             if !filter.is_empty() {
                 let candidates: Vec<&str> = [
                     entry.npm.as_deref(),
                     entry.source.as_deref(),
                     entry.name.as_deref(),
+                    entry.marketplace.as_deref(),
                 ]
                 .into_iter()
                 .flatten()
@@ -73,18 +74,19 @@ pub fn run(filter: Vec<String>) -> Result<()> {
                 continue;
             }
 
-            if let Some(src) = entry.source.as_deref() {
-                let label = entry.name.as_deref().unwrap_or(src);
+            if let Some(origin) = crate::agent_skill::SkillOrigin::from_entry(entry) {
+                let label = entry
+                    .name
+                    .as_deref()
+                    .or(entry.marketplace.as_deref())
+                    .or(entry.source.as_deref())
+                    .unwrap_or("?");
                 print!("  {} {} ... ", "↻".cyan(), label);
 
-                // A source-only entry means "keep what I already own from this source",
-                // not "adopt whatever it ships today". `install(src, None)` installs
-                // every skill the survey finds, with no cap and no prompt — so widening
-                // the survey (a new skill root, or upstream simply adding skills) would
-                // otherwise make an unattended `upgrade` install things nobody asked for.
-                // Refresh the names already in the inventory instead.
-                let tag = entry.inventory_tag().unwrap_or_else(|| src.to_string());
-                let origin = crate::agent_skill::SkillOrigin::git(src, entry.path.clone());
+                // An unnamed entry means "keep what I already own from this source",
+                // not "adopt whatever it ships today". Refresh the names already
+                // tagged. Unnamed marketplace+path uses the same rule.
+                let tag = entry.inventory_tag().unwrap_or_default();
                 let owned: Vec<String> = match entry.name.as_deref() {
                     Some(n) => vec![n.to_string()],
                     None => {

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -584,10 +584,12 @@ fn symlink_hub_into(hub: &Path, dest: &Path) -> Result<()> {
 
 /// Copy nested plugin skill trees into the shared Agent Skill hub.
 /// Prints a skip line for harnesses that need a tree we will not invent.
+/// Names claimed by `[[agent_skills]]` are not copied and not retagged `plugin:`.
 pub fn materialize_hub(
     qualified: &str,
     harnesses: &[Harness],
     category: &str,
+    claimed: &BTreeSet<String>,
 ) -> Result<Vec<String>> {
     ensure_pi_hub_if_targeted(harnesses)?;
     let want_hub = harnesses.iter().any(|h| h.needs_hub_copy());
@@ -602,8 +604,31 @@ pub fn materialize_hub(
     let trees = plugin_skill_trees(qualified)?;
     let plugin = plugin_root(qualified)?;
     let root = crate::paths::user_skills_dir()?;
+    let inv = crate::agent_skill::load_inventory().ok();
     let mut copied = BTreeSet::new();
     for (name, src) in &trees {
+        if claimed.contains(name) {
+            println!(
+                "  {} {}: hub owned by [[agent_skills]] path, not plugin {qualified}",
+                "·".dimmed(),
+                name
+            );
+            continue;
+        }
+        // Check inventory before install_to_root deletes dest. A marketplace:
+        // (or git/local) hub copy must not be replaced with Claude-flavored
+        // bytes and then fail record_plugin_copies, leaving the dest clobbered.
+        if let Some(entry) = inv.as_ref().and_then(|i| i.agent_skills.get(name)) {
+            if !entry.source.starts_with("plugin:") {
+                println!(
+                    "  {} {}: hub owned by {}, not plugin {qualified}",
+                    "·".dimmed(),
+                    name,
+                    entry.source
+                );
+                continue;
+            }
+        }
         crate::agent_skill::install_to_root(&root, name, src, &plugin)?;
         copied.insert(name.clone());
         println!(
@@ -697,11 +722,20 @@ impl Visibility {
 }
 
 /// Harnesses that can see a marketplace plugin. `claude` is true when the
-/// plugin is enabled and inventoried. Hub-backed harnesses are true when any
-/// nested skill name has `SKILL.md` in `~/.agents/skills/`.
+/// plugin is enabled and inventoried. Hub-backed harnesses are true only when
+/// a nested skill's inventory tag is `plugin:<qualified>` — a `marketplace:`
+/// hub copy of the same name is not a plugin projection.
 pub fn visibility_for_plugin(qualified: &str, active: bool) -> Visibility {
     let names = plugin_skill_names(qualified);
-    let on_hub = names.iter().any(|n| hub_has(n));
+    let inv = crate::agent_skill::load_inventory().ok();
+    let tag = format!("plugin:{qualified}");
+    let on_hub = names.iter().any(|n| {
+        hub_has(n)
+            && inv
+                .as_ref()
+                .and_then(|i| i.agent_skills.get(n))
+                .is_some_and(|e| e.source == tag)
+    });
     visibility(active, on_hub, &names)
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -283,27 +283,34 @@ impl McpEntry {
 
 /// An Agent Skill declaration.
 ///
-/// Exactly one of `source`, `npm`, or (for local-only entries) `name` should be set.
+/// Exactly one of `source`, `npm`, or `marketplace` should be set. A local-only
+/// row has `name` and none of those three.
 ///
 /// - `source`: `owner/repo` (GitHub) or a git URL. `sync` clones/pulls and copies
 ///   skills under `skills/<name>/` into `~/.agents/skills/<name>/`.
-/// - `path`: relative directory inside the cloned `source`. Replaces the default
-///   walk of `.agents/skills` and `skills/`. If `path/SKILL.md` exists, that
-///   directory is the skill (name = last segment). Else every child with
-///   `SKILL.md` is a skill. Requires `source`. Ban `..`, absolute form, `\`, `:`.
+/// - `marketplace`: reuse a registered marketplace clone instead of cloning
+///   `source` into the Agent Skill cache.
+/// - `path`: relative directory inside the clone (`source` or `marketplace`).
+///   Replaces the default walk of `.agents/skills` and `skills/`. If
+///   `path/SKILL.md` exists, that directory is the skill (name = last segment).
+///   Else every child with `SKILL.md` is a skill. Requires `source` or
+///   `marketplace`. Ban `..`, absolute form, `\`, `:`.
 /// - `npm`: npm package name. `sync` runs `npm install -g <pkg>` and trusts the
 ///   package's post-install to place files under `~/.agents/skills/`. After install,
 ///   zskills diffs the directory and tags every new skill with `source: "npm:<pkg>"`.
 /// - `install_cmd`: optional override for npm packages with custom setup (e.g.,
 ///   `"npx some-tool install"`).
 /// - `name` (optional): pick a single skill out of a multi-skill repo. For
-///   local-only entries (no `source`/`npm`), `name` is required.
+///   local-only entries (no `source`/`npm`/`marketplace`), `name` is required.
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct AgentSkillEntry {
     #[serde(default)]
     pub source: Option<String>,
     #[serde(default)]
     pub npm: Option<String>,
+    /// Reuse a registered marketplace clone. Mutex with `source` and `npm`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub marketplace: Option<String>,
     #[serde(default)]
     pub install_cmd: Option<String>,
     #[serde(default)]
@@ -326,13 +333,24 @@ impl AgentSkillEntry {
     /// Strip a leading `./` from `path` and reject a selector that would escape
     /// the clone. `:` is banned so inventory tags can rsplit on it later.
     pub fn validate(&mut self) -> Result<()> {
+        let origins = [
+            self.source.is_some(),
+            self.npm.is_some(),
+            self.marketplace.is_some(),
+        ]
+        .into_iter()
+        .filter(|x| *x)
+        .count();
+        if origins > 1 {
+            anyhow::bail!("agent skill: pick one of source, npm, marketplace");
+        }
         if let Some(raw) = self.path.take() {
             let normalized = normalize_skill_path(&raw)?;
-            if self.source.is_none() {
-                anyhow::bail!("path requires source");
-            }
             if self.npm.is_some() {
                 anyhow::bail!("path is not valid on an npm entry");
+            }
+            if self.source.is_none() && self.marketplace.is_none() {
+                anyhow::bail!("path requires source or marketplace");
             }
             self.path = Some(normalized);
         }
@@ -341,9 +359,16 @@ impl AgentSkillEntry {
 
     /// Inventory `source` tag this row owns. `source` + `path` uses
     /// `source:<source>:<path>` so two paths from one repo do not collide.
+    /// Marketplace-backed rows use `marketplace:<name>:<path>`.
     pub fn inventory_tag(&self) -> Option<String> {
         if let Some(pkg) = &self.npm {
             return Some(format!("npm:{pkg}"));
+        }
+        if let Some(mp) = &self.marketplace {
+            return Some(match &self.path {
+                Some(p) => format!("marketplace:{mp}:{p}"),
+                None => format!("marketplace:{mp}"),
+            });
         }
         let src = self.source.as_deref()?;
         match &self.path {
@@ -384,8 +409,8 @@ pub fn normalize_skill_path(path: &str) -> Result<String> {
 
 /// Rebuild an `[[agent_skills]]` row from an inventory `source` tag.
 ///
-/// `source:<git>:<path>` rsplit on the last `:` so a git URL that contains `:`
-/// stays intact. Path cannot contain `:`.
+/// Prefix first, then rsplit on the last `:` so a git URL that contains `:`
+/// stays intact. Path cannot contain `:`. Marketplace names cannot contain `:`.
 pub fn agent_skill_from_inventory_tag(name: &str, tag: &str) -> AgentSkillEntry {
     if tag == "local" {
         return AgentSkillEntry {
@@ -399,6 +424,25 @@ pub fn agent_skill_from_inventory_tag(name: &str, tag: &str) -> AgentSkillEntry 
             name: Some(name.to_string()),
             ..Default::default()
         };
+    }
+    if let Some(rest) = tag.strip_prefix("marketplace:") {
+        if let Some((mp, path)) = rest.rsplit_once(':') {
+            if !mp.is_empty() && !path.is_empty() {
+                return AgentSkillEntry {
+                    marketplace: Some(mp.to_string()),
+                    path: Some(path.to_string()),
+                    name: Some(name.to_string()),
+                    ..Default::default()
+                };
+            }
+        }
+        if !rest.is_empty() {
+            return AgentSkillEntry {
+                marketplace: Some(rest.to_string()),
+                name: Some(name.to_string()),
+                ..Default::default()
+            };
+        }
     }
     if let Some(rest) = tag.strip_prefix("source:") {
         if let Some((src, path)) = rest.rsplit_once(':') {
@@ -477,13 +521,21 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
         .parse()
         .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
 
-    // Check for duplicates: (source, path, name)
+    // Check for duplicates: (source, marketplace, path, name)
     if let Some(Item::ArrayOfTables(existing)) = doc.get("agent_skills") {
         for t in existing.iter() {
             let src = t.get("source").and_then(|v| v.as_str()).map(str::to_string);
+            let mp = t
+                .get("marketplace")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
             let path = t.get("path").and_then(|v| v.as_str()).map(str::to_string);
             let name = t.get("name").and_then(|v| v.as_str()).map(str::to_string);
-            if src == entry.source && path == entry.path && name == entry.name {
+            if src == entry.source
+                && mp == entry.marketplace
+                && path == entry.path
+                && name == entry.name
+            {
                 return Ok(false);
             }
         }
@@ -507,13 +559,22 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
     if let Some(src) = &entry.source {
         t["source"] = value(src);
     }
+    if let Some(mp) = &entry.marketplace {
+        t["marketplace"] = value(mp);
+    }
     if let Some(p) = &entry.path {
         t["path"] = value(p);
     }
     if let Some(n) = &entry.name {
         t["name"] = value(n);
     }
-    let _ = Array::new(); // unused; placate compiler if toml_edit changes shape
+    if !entry.harnesses.is_empty() {
+        let mut arr = Array::new();
+        for h in &entry.harnesses {
+            arr.push(h.as_str());
+        }
+        t["harnesses"] = Item::Value(arr.into());
+    }
     aot.push(t);
 
     std::fs::write(path, doc.to_string())
@@ -1107,21 +1168,56 @@ mod agent_skill_path_tests {
     }
 
     #[test]
-    fn path_requires_source() {
+    fn path_requires_source_or_marketplace() {
         let err = validate_toml("[[agent_skills]]\nname = \"x\"\npath = \"skills\"\n")
             .unwrap_err()
             .to_string();
-        assert!(err.contains("path requires source"), "{err}");
+        assert!(err.contains("path requires source or marketplace"), "{err}");
     }
 
     #[test]
     fn path_is_not_valid_on_npm() {
+        let err = validate_toml("[[agent_skills]]\nnpm = \"pkg\"\npath = \"skills\"\n")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("path is not valid on an npm entry"), "{err}");
+    }
+
+    #[test]
+    fn source_npm_marketplace_are_mutex() {
         let err = validate_toml(
-            "[[agent_skills]]\nnpm = \"pkg\"\npath = \"skills\"\nsource = \"owner/repo\"\n",
+            "[[agent_skills]]\nsource = \"owner/repo\"\nmarketplace = \"llm-wiki\"\npath = \"skills\"\n",
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("path is not valid on an npm entry"), "{err}");
+        assert!(
+            err.contains("pick one of source, npm, marketplace"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn marketplace_plus_path_inventory_tag() {
+        let m = validate_toml(
+            "[[agent_skills]]\nmarketplace = \"llm-wiki\"\npath = \"plugins/llm-wiki-opencode/skills\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            m.agent_skills[0].inventory_tag().as_deref(),
+            Some("marketplace:llm-wiki:plugins/llm-wiki-opencode/skills")
+        );
+    }
+
+    #[test]
+    fn inventory_tag_rsplit_marketplace() {
+        let e = agent_skill_from_inventory_tag(
+            "wiki-manager",
+            "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills",
+        );
+        assert_eq!(e.marketplace.as_deref(), Some("llm-wiki"));
+        assert_eq!(e.path.as_deref(), Some("plugins/llm-wiki-opencode/skills"));
+        assert_eq!(e.name.as_deref(), Some("wiki-manager"));
+        assert!(e.source.is_none());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3998,3 +3998,594 @@ fn sync_adopt_source_path_tag_writes_source_and_path() {
         "adopt must not store the raw inventory tag as source: {raw}"
     );
 }
+
+const CLAUDE_WIKI_SKILL: &str = "---\nname: wiki-manager\ndescription: Activates for /wiki commands\ntools: Read, Write, Edit\n---\nClaude Code is both the compiler and the runtime.\n";
+const OPENCODE_WIKI_SKILL: &str = "---\nname: wiki-manager\ndescription: Manage a local wiki\n---\nOpenCode Integration Notes.\n\nTreat any /wiki:* references in this document as shorthand for the matching skill action.\n";
+
+/// `file://` git repo shaped like nvk/llm-wiki: Claude plugin + OpenCode Agent Skills.
+fn write_llm_wiki_repo(parent: &std::path::Path) -> std::path::PathBuf {
+    let repo = parent.join("llm-wiki");
+    fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": "llm-wiki",
+            "plugins": [{ "name": "wiki", "source": "./claude-plugin", "version": "0.24.4" }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let plugin_meta = repo.join("claude-plugin").join(".claude-plugin");
+    fs::create_dir_all(&plugin_meta).unwrap();
+    fs::write(plugin_meta.join("plugin.json"), r#"{"name":"wiki"}"#).unwrap();
+
+    let claude_skill = repo.join("claude-plugin/skills/wiki-manager");
+    fs::create_dir_all(claude_skill.join("references")).unwrap();
+    fs::write(claude_skill.join("SKILL.md"), CLAUDE_WIKI_SKILL).unwrap();
+    fs::write(
+        claude_skill.join("references/hub-resolution.md"),
+        "hub resolution notes\n",
+    )
+    .unwrap();
+
+    let oc = repo.join("plugins/llm-wiki-opencode/skills");
+    let wm = oc.join("wiki-manager");
+    fs::create_dir_all(&wm).unwrap();
+    fs::write(wm.join("SKILL.md"), OPENCODE_WIKI_SKILL).unwrap();
+    std::os::unix::fs::symlink(
+        "../../../../claude-plugin/skills/wiki-manager/references",
+        wm.join("references"),
+    )
+    .unwrap();
+    let wq = oc.join("wiki-query");
+    fs::create_dir_all(&wq).unwrap();
+    fs::write(
+        wq.join("SKILL.md"),
+        "---\nname: wiki-query\n---\nquery-lite\n",
+    )
+    .unwrap();
+
+    git_init_and_commit(&repo);
+    repo
+}
+
+fn mark_plugin_installed(home: &TempDir, qualified: &str) {
+    let path = home.path().join("plugins").join("installed_plugins.json");
+    let mut v: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    v["plugins"][qualified] = json!([{
+        "scope": "user",
+        "installPath": "/tmp/x",
+        "version": "1.0.0"
+    }]);
+    fs::write(&path, serde_json::to_string_pretty(&v).unwrap()).unwrap();
+}
+
+fn llm_wiki_recipe(url: &str, plugin_harnesses: &str) -> String {
+    format!(
+        r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = {plugin_harnesses}
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-query"
+harnesses = ["pi", "grok"]
+"#
+    )
+}
+
+fn read_inv(home: &TempDir) -> serde_json::Value {
+    serde_json::from_slice(&fs::read(home.path().join("skills/.zskills.json")).unwrap()).unwrap()
+}
+
+fn setup_llm_wiki_home() -> (TempDir, tempfile::TempDir, std::path::PathBuf) {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    fs::create_dir_all(home.path().join("grok")).unwrap();
+    register_clone(&home, "llm-wiki", &repo, "HEAD");
+    mark_plugin_installed(&home, "wiki@llm-wiki");
+    (home, up, repo)
+}
+
+#[test]
+fn sync_marketplace_path_copies_opencode_tree_not_local_only() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &llm_wiki_recipe(
+            &file_url(&home.path().join("plugins/marketplaces/llm-wiki")),
+            r#"["claude"]"#,
+        ),
+    );
+
+    zskills(&home)
+        .arg("sync")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("wiki-manager"))
+        .stdout(predicate::str::contains("applied."))
+        .stdout(predicate::str::contains("declared local, not on disk").not());
+
+    let wm = home.path().join("skills/wiki-manager");
+    assert_eq!(
+        fs::read_to_string(wm.join("SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL
+    );
+    let copied = wm.join("references/hub-resolution.md");
+    assert!(copied.is_file(), "in-clone symlink must be a regular file");
+    assert!(!copied.symlink_metadata().unwrap().file_type().is_symlink());
+    assert!(home.path().join("skills/wiki-query/SKILL.md").is_file());
+
+    let inv = read_inv(&home);
+    let tag = "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills";
+    assert_eq!(inv["agent_skills"]["wiki-manager"]["source"], tag);
+    assert_eq!(inv["agent_skills"]["wiki-query"]["source"], tag);
+
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(home.path().join("settings.json")).unwrap()).unwrap();
+    assert_eq!(settings["enabledPlugins"]["wiki@llm-wiki"], true);
+
+    let pi = home.path().join("pi/agent/settings.json");
+    let pi_s: serde_json::Value = serde_json::from_slice(&fs::read(&pi).unwrap()).unwrap();
+    let hub = home.path().join("skills").to_string_lossy().into_owned();
+    let count = pi_s["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|v| v.as_str() == Some(hub.as_str()))
+        .count();
+    assert_eq!(count, 1, "Pi settings must list the hub once: {pi_s}");
+
+    let grok_skills = home.path().join("grok/skills");
+    assert!(
+        !grok_skills.exists()
+            || fs::read_dir(&grok_skills)
+                .map(|rd| rd.count() == 0)
+                .unwrap_or(true),
+        "must not write GROK_HOME/skills"
+    );
+}
+
+#[test]
+fn sync_marketplace_path_takeover_and_list_and_remove() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = ["pi"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    zskills(&home).arg("sync").assert().success();
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        CLAUDE_WIKI_SKILL
+    );
+    assert_eq!(
+        read_inv(&home)["agent_skills"]["wiki-manager"]["source"],
+        "plugin:wiki@llm-wiki"
+    );
+
+    write_manifest(
+        &home,
+        &llm_wiki_recipe(
+            &file_url(&home.path().join("plugins/marketplaces/llm-wiki")),
+            r#"["claude"]"#,
+        ),
+    );
+    zskills(&home)
+        .arg("sync")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "hub taken over by [[agent_skills]] path",
+        ));
+
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL
+    );
+    let tag = "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills";
+    assert_eq!(
+        read_inv(&home)["agent_skills"]["wiki-manager"]["source"],
+        tag
+    );
+
+    let out = zskills(&home)
+        .args(["list", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert!(
+        v["plugins"]["active"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|x| x == "wiki@llm-wiki"),
+        "plugin must stay active: {v}"
+    );
+    let plugin_vis = v["plugins"]["harnesses"]["wiki@llm-wiki"]["visible"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(plugin_vis.iter().filter(|x| *x == "claude").count(), 1);
+    assert!(
+        !plugin_vis.iter().any(|x| x == "pi" || x == "grok"),
+        "plugin line must be claude-only after takeover: {v}"
+    );
+    let skill_vis = v["agent_skills"]["harnesses"]["wiki-manager"]["visible"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        skill_vis.iter().any(|x| x == "pi") && skill_vis.iter().any(|x| x == "grok"),
+        "Agent Skill line must include pi/grok: {v}"
+    );
+
+    zskills(&home)
+        .args(["skill", "remove", "wiki-manager"])
+        .assert()
+        .success();
+    assert!(!home.path().join("skills/wiki-manager").exists());
+    let settings: serde_json::Value =
+        serde_json::from_slice(&fs::read(home.path().join("settings.json")).unwrap()).unwrap();
+    assert_eq!(
+        settings["enabledPlugins"]["wiki@llm-wiki"], true,
+        "plugin stays enabled after Agent Skill remove"
+    );
+}
+
+#[test]
+fn sync_marketplace_path_skips_claimed_plugin_hub_copy() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &llm_wiki_recipe(
+            &file_url(&home.path().join("plugins/marketplaces/llm-wiki")),
+            r#"["pi"]"#,
+        ),
+    );
+    zskills(&home)
+        .arg("sync")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "hub owned by [[agent_skills]] path, not plugin wiki@llm-wiki",
+        ));
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL
+    );
+    assert_eq!(
+        read_inv(&home)["agent_skills"]["wiki-manager"]["source"],
+        "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills"
+    );
+}
+
+#[test]
+fn sync_refuses_untagged_hub_dir() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    let dest = home.path().join("skills/wiki-manager");
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(dest.join("SKILL.md"), "user content\n").unwrap();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    let out = zskills(&home)
+        .arg("sync")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("applied."),
+        "refuse must skip ✓ applied.: {stdout}"
+    );
+    assert!(
+        stderr.contains("no inventory entry") || stderr.contains("operation(s) failed"),
+        "stderr={stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+        "user content\n"
+    );
+}
+
+#[test]
+fn sync_unnamed_marketplace_path_is_not_pruned() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+harnesses = ["pi", "grok"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    zskills(&home).arg("sync").assert().success();
+    assert!(home.path().join("skills/wiki-manager/SKILL.md").is_file());
+    assert!(home.path().join("skills/wiki-query/SKILL.md").is_file());
+
+    zskills(&home).args(["sync", "--prune"]).assert().success();
+    assert!(
+        home.path().join("skills/wiki-manager/SKILL.md").is_file(),
+        "unnamed marketplace+path must not be pruned"
+    );
+    assert!(home.path().join("skills/wiki-query/SKILL.md").is_file());
+}
+
+#[test]
+fn sync_adopt_marketplace_tag_writes_marketplace_and_path() {
+    let home = fake_home();
+    let skill = home.path().join("skills/wiki-manager");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(skill.join("SKILL.md"), "x").unwrap();
+    fs::write(
+        home.path().join("skills/.zskills.json"),
+        json!({
+            "version": 1,
+            "agent_skills": {
+                "wiki-manager": {
+                    "source": "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills",
+                    "installed_at": "@0",
+                    "head_sha": "abc"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_manifest(&home, "");
+
+    zskills(&home).args(["sync", "--adopt"]).assert().success();
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    assert!(
+        raw.contains("marketplace = \"llm-wiki\""),
+        "adopt must write marketplace: {raw}"
+    );
+    assert!(
+        raw.contains("path = \"plugins/llm-wiki-opencode/skills\""),
+        "adopt must write path: {raw}"
+    );
+    assert!(
+        !raw.contains("source = \"marketplace:"),
+        "adopt must not store the raw inventory tag as source: {raw}"
+    );
+}
+
+#[test]
+fn sync_missing_marketplace_clone_is_hard_error() {
+    let home = fake_home();
+    write_manifest(
+        &home,
+        r#"[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+"#,
+    );
+    let out = zskills(&home)
+        .arg("sync")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("applied."),
+        "missing clone must skip ✓ applied.: {stdout}"
+    );
+    assert!(
+        !stdout.contains("declared local, not on disk"),
+        "must not fall through to local-only: {stdout}"
+    );
+    assert!(
+        stderr.contains("not registered") || stderr.contains("operation(s) failed"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn sync_missing_path_exits_nonzero_skips_applied() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "does-not-exist"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    let out = zskills(&home)
+        .arg("sync")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("applied."),
+        "missing path must skip ✓ applied.: {stdout}"
+    );
+}
+
+#[test]
+fn upgrade_marketplace_path_recopies_not_local_only() {
+    let (home, _up, repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &llm_wiki_recipe(
+            &file_url(&home.path().join("plugins/marketplaces/llm-wiki")),
+            r#"["claude"]"#,
+        ),
+    );
+    zskills(&home).arg("sync").assert().success();
+
+    fs::write(
+        repo.join("plugins/llm-wiki-opencode/skills/wiki-manager/SKILL.md"),
+        "---\nname: wiki-manager\n---\nOpenCode flavour v2\n",
+    )
+    .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["add", "-A"])
+        .status()
+        .unwrap();
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["commit", "--quiet", "-m", "second"])
+        .status()
+        .unwrap();
+
+    zskills(&home)
+        .args(["skill", "upgrade", "wiki-manager"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(local-only, skipped)").not());
+
+    // Upgrade of the skill name does not refresh the marketplace clone.
+    // Point the clone at the new commit, then upgrade again.
+    StdCommand::new("git")
+        .arg("-C")
+        .arg(home.path().join("plugins/marketplaces/llm-wiki"))
+        .args(["pull", "--ff-only", "--quiet"])
+        .status()
+        .unwrap();
+    zskills(&home)
+        .args(["skill", "upgrade", "llm-wiki"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(local-only, skipped)").not());
+
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        "---\nname: wiki-manager\n---\nOpenCode flavour v2\n"
+    );
+}
+
+#[test]
+fn sync_unnamed_marketplace_path_refuses_before_copying_siblings() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    let dest = home.path().join("skills/wiki-query");
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(dest.join("SKILL.md"), "user query\n").unwrap();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+harnesses = ["pi", "grok"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    zskills(&home).arg("sync").assert().failure();
+    assert!(
+        !home.path().join("skills/wiki-manager").exists(),
+        "a later refuse must not leave an earlier sibling copied and untagged"
+    );
+    assert_eq!(
+        fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+        "user query\n"
+    );
+}
+
+#[test]
+fn plugin_install_skips_hub_names_claimed_by_agent_skills() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &llm_wiki_recipe(
+            &file_url(&home.path().join("plugins/marketplaces/llm-wiki")),
+            r#"["claude"]"#,
+        ),
+    );
+    zskills(&home).arg("sync").assert().success();
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL
+    );
+
+    zskills(&home)
+        .args(["plugin", "install", "wiki@llm-wiki", "--harness", "pi"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "hub owned by [[agent_skills]] path, not plugin wiki@llm-wiki",
+        ));
+
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL,
+        "plugin install must not clobber a marketplace: hub copy"
+    );
+    assert_eq!(
+        read_inv(&home)["agent_skills"]["wiki-manager"]["source"],
+        "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills"
+    );
+}


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `enhancement`
- [x] Priority: `priority:high`
- [x] Size: `t-shirt:big`
- [x] Area: `area:cli`

## Summary

`[[agent_skills]]` can name a registered marketplace clone and a relative `path` inside it.

`sync` copies those Agent Skills onto the hub at `~/.agents/skills/`. The copy reads the marketplace clone. It does not clone the same repo into the Agent Skill cache.

Marketplace + `path` is a first-class kind. A missing clone is a hard error. `sync` does not treat the row as local-only. A missing path increments the failure count. `sync` skips `✓ applied.` and exits non-zero.

This is the llm-wiki split. One clone. Claude consumes plugin `wiki@llm-wiki` from the Claude plugin tree. Pi and Grok consume hub Agent Skills from `plugins/llm-wiki-opencode/skills`.

The same name can exist in both trees. The OpenCode `SKILL.md` is not the Claude `SKILL.md`. Nested plugin hub copies skip names claimed by `[[agent_skills]]`. A hub copy already tagged `plugin:<plugin>@<this marketplace>` is taken over: replace bytes, retag, print.

User content without an inventory entry is refused. A dest tagged anything else is refused.

This unique range is `12ecb40..7f6231e` (`bb057ae`, review `7f6231e`). It stacks on PR 1 (`path` inside a `source` clone).

## How It Works (diagram — REQUIRED)

### Manifest schema

`AgentSkillEntry` gains `marketplace`. Pick one of `source`, `npm`, `marketplace`. More than one fails validate: `agent skill: pick one of source, npm, marketplace`.

`path` requires `source` or `marketplace`. `path` on an npm row still fails. `path` still bans `..`, absolute form, `\`, and `:`.

The duplicate key for `append_agent_skill` is `(source, marketplace, path, name)`.

Inventory tag is `marketplace:<name>:<path>`. Example: `marketplace:llm-wiki:plugins/llm-wiki-opencode/skills`.

`--adopt` reconstructs the row from that tag. It rsplit on the last `:` for `marketplace:` and `source:` prefixes. It writes `marketplace` plus `path`. It does not store the raw tag as `source`. `plugin:` tags are not adopted as `[[agent_skills]]`.

### Origin and copy

`SkillOrigin` has `OriginKind::Marketplace { name }`. `SkillOrigin::from_entry` returns that origin for a marketplace row. npm and local-only rows still return `None`.

`resolve_marketplace_clone` reads `~/.claude/plugins/marketplaces/<name>`. A missing directory bails. The apply arm does not fall through to local-only.

`install_from` walks `path` the same way as git `source` + `path`. If `path/SKILL.md` exists, that directory is the skill. Else every child with `SKILL.md` is a skill. In-clone symlinks materialize as regular files on the hub.

### Dest decision (`dest_action`)

Decide every dest before any copy. Then copy.

| Hub dest | Inventory tag | Action |
|---|---|---|
| absent | — | copy, tag `marketplace:<name>:<path>` |
| present | none | refuse (user content). Run `zskills skill remove --force <name>` or rename |
| present | `plugin:<plugin>@<this marketplace>` | takeover: replace, retag, print `hub taken over by [[agent_skills]] path` |
| present | matching marketplace tag, HEAD unchanged | skip |
| present | matching marketplace tag, HEAD moved | copy |
| present | any other tag | refuse |

An unnamed row can yield several skills. A later dest that would refuse must not leave an earlier sibling copied and untagged. Plan all `dest_action` results first. Copy only after every dest is accepted.

### Claimed names vs plugin hub copies

`names_claimed_by` is the set of hub names `[[agent_skills]]` owns. An explicit `name` is claimed. An unnamed path row walks the clone. A missing clone claims nothing, so the later hard error can fire.

`sync` and `plugin install` pass that set into `materialize_hub`. `materialize_hub` skips a claimed name before copy and before `record_plugin_copies`. It prints `hub owned by [[agent_skills]] path, not plugin <qualified>`.

Same-pass order:

1. Compute claimed names from the manifest.
2. Copy nested plugin trees. Skip claimed names.
3. Copy `[[agent_skills]]` marketplace + `path` rows.

A previous plugin hub copy of the same name is the takeover case. Same-pass claim skip avoids that copy.

### Visibility and `skill remove`

`visibility_for_plugin` sets `on_hub` only when inventory is `plugin:<qualified>`. After takeover, the plugin line stays in `enabledPlugins`. Hub-backed harnesses (`pi`, `grok`) move to the Agent Skill line.

`skill remove --force` is required only when inventory starts with `plugin:`. A `marketplace:` hub copy of the same name removes without `--force`. The plugin stays enabled.

`--prune` does not delete unnamed marketplace + `path` names. Those rows are deferred origins. Their inventory tag matches, so they stay owned.

### `upgrade`

`skill upgrade` matches the filter against `npm`, `source`, `name`, or `marketplace`. A match re-copies from the marketplace clone. It does not clone into the Agent Skill cache.

Marketplace refresh still runs first, and only when the filter matches the marketplace name. `skill upgrade wiki-manager` re-copies current clone HEAD. It does not `git pull` marketplace `llm-wiki`. `skill upgrade llm-wiki` refreshes the clone, then re-copies.

An unnamed row refreshes names already tagged `marketplace:<name>:<path>`. It does not adopt new names. `sync` is the adopt path.

```mermaid
flowchart TD
    A["[[agent_skills]] marketplace plus path"] --> B{clone in known_marketplaces.json?}
    B -->|no| C[hard error, skip applied]
    B -->|yes| D[walk path in marketplace clone]
    D --> E{hub dest exists?}
    E -->|no| F[copy and tag marketplace:name:path]
    E -->|yes| G{inventory tag?}
    G -->|none| H[refuse user content]
    G -->|"plugin:plugin@this marketplace"| I[takeover: replace, retag, print]
    G -->|matching marketplace tag| J{clone HEAD moved?}
    J -->|yes| F
    J -->|no| K[skip]
    G -->|other tag| L[refuse]
    F --> M[materialize_hub skips claimed names]
```

## Linked Issues / ADRs
- Resolves: #59
- Part of: #51, #57

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

Ran on `7f6231e`. `ZSKILLS_NO_CLAUDE_CLI=1`. CLI tests point `CLAUDE_HOME` and `AGENTS_HOME` at `TempDir`. No test reached the real `~/.claude` or `~/.agents`.

```
cargo fmt --check
# exit 0

cargo clippy --all-targets -- -D warnings
# exit 0

cargo test
# 117 unit + 145 CLI, exit 0
```

New and extended coverage:

- `sync_marketplace_path_copies_opencode_tree_not_local_only` — copies OpenCode `wiki-manager` and `wiki-query`. Inventory tag is `marketplace:llm-wiki:plugins/llm-wiki-opencode/skills`. In-clone symlink becomes a regular file. Plugin `wiki@llm-wiki` stays in `enabledPlugins`. Pi lists the hub once. Grok does not get `GROK_HOME/skills`.
- `sync_marketplace_path_takeover_and_list_and_remove` — first sync writes Claude bytes tagged `plugin:wiki@llm-wiki`. Second sync takes over. Hub bytes become OpenCode. `list --json` keeps the plugin active and Claude-only. Agent Skill line lists pi and grok. `skill remove wiki-manager` deletes the hub copy. The plugin stays enabled.
- `sync_marketplace_path_skips_claimed_plugin_hub_copy` — same-pass claim skip. Plugin harness `pi` does not overwrite the marketplace copy.
- `sync_refuses_untagged_hub_dir` — user content, no inventory. Refuse. Skip `✓ applied.`. Bytes unchanged.
- `sync_unnamed_marketplace_path_is_not_pruned` — unnamed row survives `sync --prune`.
- `sync_unnamed_marketplace_path_refuses_before_copying_siblings` — `wiki-query` is user content. `wiki-manager` is not copied. Dest stays untagged.
- `sync_adopt_marketplace_tag_writes_marketplace_and_path` — `--adopt` writes `marketplace` and `path`. It does not write `source = "marketplace:…"`.
- `sync_missing_marketplace_clone_is_hard_error` — not registered. Skip `✓ applied.`. No `declared local, not on disk`.
- `sync_missing_path_exits_nonzero_skips_applied` — path `does-not-exist`. Non-zero. Skip `✓ applied.`
- `upgrade_marketplace_path_recopies_not_local_only` — re-copy is not local-only. Skill-name upgrade does not pull the marketplace clone. Marketplace-name upgrade does.
- `plugin_install_skips_hub_names_claimed_by_agent_skills` — `plugin install wiki@llm-wiki --harness pi` does not overwrite a `marketplace:` hub copy.

Unit tests in `src/manifest.rs`: `path` requires `source` or `marketplace`. `source` / `npm` / `marketplace` are mutex. Inventory tag rsplit round-trips `marketplace` plus `path`.

Fixture `write_llm_wiki_repo` is a `file://` git repo shaped like `nvk/llm-wiki`: Claude plugin tree plus OpenCode Agent Skills.

## Additional Notes for Reviewers

Review commit `7f6231e` fixed four holes in `bb057ae`:

1. Unnamed multi-skill `install_from` could copy a dest, then refuse a later sibling, and leave the first dest untagged. Refuse before any copy.
2. `plugin install` still copied claimed hub names. `sync` skipped them. `plugin install` now calls `names_claimed_by` too.
3. `--force` docs said "shipped by an enabled plugin". `--force` is only for inventory that starts with `plugin:`.
4. Unnamed marketplace + `path` was pruned. It is not.

Risk: takeover replaces hub bytes. The dest must already be tagged `plugin:<plugin>@<this marketplace>`. User content without inventory is refused. A tag from another origin is refused.

`skill remove` of a `marketplace:` copy does not disable the plugin. Reviewers should not expect `enabledPlugins["wiki@llm-wiki"]` to flip.

A later docs PR pastes this recipe. This PR does not add that guide. One clone. Claude consumes the plugin. Pi and Grok consume hub Agent Skills.

```
[[marketplaces]]
name = "llm-wiki"
repo = "nvk/llm-wiki"

[[skills]]
name = "wiki"
marketplace = "llm-wiki"
harnesses = ["claude"]

[[agent_skills]]
marketplace = "llm-wiki"
path = "plugins/llm-wiki-opencode/skills"
name = "wiki-manager"
harnesses = ["pi", "grok"]
```
