### PR TITLE
feat: hint Agent Skill trees under plugins/*/skills after marketplace add

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -395,12 +395,23 @@ zskills marketplace update [<name>]
 
 `add` clones the marketplace repo into `~/.claude/plugins/marketplaces/<name>/` and writes both `known_marketplaces.json` and `settings.json`'s `extraKnownMarketplaces`. Mirrors what `/plugin marketplace add` does inside Claude Code.
 
-Adding a marketplace does **not** install plugins and does **not** change the manifest. After a successful add, zskills reads `.claude-plugin/marketplace.json` and prints the plugins the marketplace offers, plus the next command:
+Adding a marketplace does **not** install plugins and does **not** change the manifest. After a successful add, zskills reads `.claude-plugin/marketplace.json` and prints the plugins the marketplace offers, plus the next command.
+
+If the clone also has Agent Skill trees at `plugins/*/skills/` that are not inside a plugin source from `marketplace.json`, add prints those Agent Skill names and a `[[agent_skills]]` stanza. It does not write the stanza to the manifest.
 
 ```
 ✓ added marketplace llm-wiki
   1 plugin: wiki
   Next: zskills plugin install wiki@llm-wiki
+  Agent Skills under plugins/llm-wiki-opencode/skills: wiki-manager, wiki-query
+    [[agent_skills]]
+    marketplace = "llm-wiki"
+    path = "plugins/llm-wiki-opencode/skills"
+    name = "wiki-manager"
+    [[agent_skills]]
+    marketplace = "llm-wiki"
+    path = "plugins/llm-wiki-opencode/skills"
+    name = "wiki-query"
 ```
 
 If `marketplace.json` is missing, add still registers the clone and warns. `list` also prints a dimmed hint when no plugins are active and a registered marketplace offers at least one.

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -3,6 +3,7 @@ use owo_colors::OwoColorize;
 use serde_json::Value;
 #[cfg(feature = "skills-sh")]
 use serde_json::{json, Map};
+use std::path::Path;
 
 use crate::cli::MarketplaceCmd;
 
@@ -34,48 +35,134 @@ fn add(source: String) -> Result<()> {
     Ok(())
 }
 
-/// After a marketplace is registered, say what it offers and how to install it.
-///
-/// `marketplace add` only writes `known_marketplaces.json` and
-/// `extraKnownMarketplaces`. It does not install plugins and it does not
-/// change the manifest. Users who then run `sync` / `list` see no plugins
-/// and no next command (zot24/zskills#55).
-fn print_add_followup(name: &str, install_location: &std::path::Path) {
+/// Print plugins from marketplace.json and extra Agent Skill trees under
+/// `plugins/*/skills/`. Do not write the manifest.
+fn print_add_followup(name: &str, install_location: &Path) {
     let manifest_path = install_location
         .join(".claude-plugin")
         .join("marketplace.json");
+    let mut plugin_sources: Vec<String> = Vec::new();
     if !manifest_path.exists() {
         println!(
             "  {} no .claude-plugin/marketplace.json — plugin install and search will not find anything here",
             "!".yellow()
         );
-        return;
+    } else {
+        match crate::marketplace::load_manifest(&manifest_path) {
+            Ok(m) if m.plugins.is_empty() => {
+                println!("  {} marketplace.json lists 0 plugins", "!".yellow());
+            }
+            Ok(m) => {
+                plugin_sources = m
+                    .plugins
+                    .iter()
+                    .filter_map(|p| local_plugin_source(&p.source))
+                    .collect();
+                let names: Vec<&str> = m.plugins.iter().map(|p| p.name.as_str()).collect();
+                if names.len() <= 8 {
+                    println!(
+                        "  {} plugin{}: {}",
+                        names.len(),
+                        if names.len() == 1 { "" } else { "s" },
+                        names.join(", ")
+                    );
+                } else {
+                    println!("  {} plugins", names.len());
+                }
+                if names.len() == 1 {
+                    println!("  Next: zskills plugin install {}@{}", names[0], name);
+                } else {
+                    println!("  Next: zskills plugin install <plugin>@{}", name);
+                    println!("        zskills plugin install -i");
+                }
+            }
+            Err(e) => {
+                println!("  {} could not read marketplace.json ({e})", "!".yellow());
+            }
+        }
     }
-    match crate::marketplace::load_manifest(&manifest_path) {
-        Ok(m) if m.plugins.is_empty() => {
-            println!("  {} marketplace.json lists 0 plugins", "!".yellow());
+    print_agent_skill_hint(name, install_location, &plugin_sources);
+}
+
+/// Local relative plugin source from marketplace.json (`"./claude-plugin"`).
+/// Remote object sources have no tree in this clone to exclude.
+fn local_plugin_source(source: &Option<Value>) -> Option<String> {
+    let Value::String(s) = source.as_ref()? else {
+        return None;
+    };
+    let s = s.trim().trim_start_matches("./").trim_end_matches('/');
+    if s.is_empty() || s == "." || s.starts_with('/') || s.contains("://") {
+        return None;
+    }
+    Some(s.to_string())
+}
+
+/// Walk `plugins/` only: nested skills of the Claude plugin live under its
+/// source tree (`claude-plugin/skills/`, `./p/skills/`, …), not this glob.
+fn extra_agent_skill_trees(
+    install_location: &Path,
+    plugin_sources: &[String],
+) -> Vec<(String, Vec<String>)> {
+    let plugins_dir = install_location.join("plugins");
+    let Ok(entries) = std::fs::read_dir(&plugins_dir) else {
+        return Vec::new();
+    };
+    let mut packs: Vec<_> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    packs.sort();
+
+    let mut out = Vec::new();
+    for pack in packs {
+        let Some(pack_name) = pack.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if pack_name.starts_with('.') {
+            continue;
         }
-        Ok(m) => {
-            let names: Vec<&str> = m.plugins.iter().map(|p| p.name.as_str()).collect();
-            if names.len() <= 8 {
-                println!(
-                    "  {} plugin{}: {}",
-                    names.len(),
-                    if names.len() == 1 { "" } else { "s" },
-                    names.join(", ")
-                );
-            } else {
-                println!("  {} plugins", names.len());
-            }
-            if names.len() == 1 {
-                println!("  Next: zskills plugin install {}@{}", names[0], name);
-            } else {
-                println!("  Next: zskills plugin install <plugin>@{}", name);
-                println!("        zskills plugin install -i");
-            }
+        let skills_dir = pack.join("skills");
+        if !skills_dir.is_dir() {
+            continue;
         }
-        Err(e) => {
-            println!("  {} could not read marketplace.json ({e})", "!".yellow());
+        let rel = format!("plugins/{pack_name}/skills");
+        if plugin_sources.iter().any(|src| path_is_inside(&rel, src)) {
+            continue;
+        }
+        let Ok(children) = std::fs::read_dir(&skills_dir) else {
+            continue;
+        };
+        let mut names: Vec<String> = children
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_dir() && p.join("SKILL.md").is_file())
+            .filter_map(|p| p.file_name()?.to_str().map(str::to_string))
+            .collect();
+        names.sort();
+        if !names.is_empty() {
+            out.push((rel, names));
+        }
+    }
+    out
+}
+
+fn path_is_inside(rel: &str, src: &str) -> bool {
+    let src = src.trim_end_matches('/');
+    rel == src
+        || rel
+            .strip_prefix(src)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+fn print_agent_skill_hint(marketplace: &str, install_location: &Path, plugin_sources: &[String]) {
+    for (path, names) in extra_agent_skill_trees(install_location, plugin_sources) {
+        println!("  Agent Skills under {path}: {}", names.join(", "));
+        for skill in &names {
+            println!("    [[agent_skills]]");
+            println!("    marketplace = \"{marketplace}\"");
+            println!("    path = \"{path}\"");
+            println!("    name = \"{skill}\"");
         }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1676,7 +1676,106 @@ fn marketplace_add_prints_plugins_and_the_next_install_command() {
         .stdout(predicate::str::contains("1 plugin: wiki"))
         .stdout(predicate::str::contains(
             "zskills plugin install wiki@llm-wiki",
-        ));
+        ))
+        .stdout(predicate::str::contains("Agent Skills").not());
+}
+
+/// llm-wiki shape: Claude plugin at `./claude-plugin`, Agent Skills at
+/// `plugins/llm-wiki-opencode/skills/<name>/SKILL.md`. Nested plugin skills
+/// under the Claude plugin source must not be hinted.
+fn write_llm_wiki_shaped_repo(parent: &std::path::Path) -> std::path::PathBuf {
+    let repo = parent.join("llm-wiki");
+    fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": "llm-wiki",
+            "plugins": [{ "name": "wiki", "source": "./claude-plugin" }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let claude_skill = repo
+        .join("claude-plugin")
+        .join("skills")
+        .join("wiki-manager");
+    fs::create_dir_all(&claude_skill).unwrap();
+    fs::write(claude_skill.join("SKILL.md"), "# wiki-manager (claude)\n").unwrap();
+    for name in ["wiki-manager", "wiki-query"] {
+        let dir = repo
+            .join("plugins")
+            .join("llm-wiki-opencode")
+            .join("skills")
+            .join(name);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), format!("# {name}\n")).unwrap();
+    }
+    git_init_and_commit(&repo);
+    repo
+}
+
+#[test]
+fn marketplace_add_hints_agent_skill_trees_outside_the_plugin_source() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_shaped_repo(upstream.path());
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&repo)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("added marketplace llm-wiki"))
+        .stdout(predicate::str::contains("1 plugin: wiki"))
+        .stdout(predicate::str::contains(
+            "zskills plugin install wiki@llm-wiki",
+        ))
+        .stdout(predicate::str::contains(
+            "Agent Skills under plugins/llm-wiki-opencode/skills: wiki-manager, wiki-query",
+        ))
+        .stdout(predicate::str::contains("[[agent_skills]]"))
+        .stdout(predicate::str::contains("marketplace = \"llm-wiki\""))
+        .stdout(predicate::str::contains(
+            "path = \"plugins/llm-wiki-opencode/skills\"",
+        ))
+        .stdout(predicate::str::contains("name = \"wiki-manager\""))
+        .stdout(predicate::str::contains("name = \"wiki-query\""))
+        .stdout(predicate::str::contains("Agent Skills under claude-plugin/skills").not());
+
+    // Hint only: add must not write the manifest.
+    assert!(!home
+        .path()
+        .join("config")
+        .join("zskills")
+        .join("skills.toml")
+        .exists());
+}
+
+#[test]
+fn marketplace_add_does_not_hint_skills_inside_the_plugin_source() {
+    let upstream = tempfile::tempdir().unwrap();
+    let repo = upstream.path().join("nested-src");
+    fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": "nested-src",
+            "plugins": [{ "name": "foo", "source": "./plugins/foo" }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let nested = repo.join("plugins").join("foo").join("skills").join("bar");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("SKILL.md"), "# bar\n").unwrap();
+    git_init_and_commit(&repo);
+
+    let home = fake_home();
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&repo)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 plugin: foo"))
+        .stdout(predicate::str::contains("Agent Skills").not());
 }
 
 #[test]


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `enhancement`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:small`
- [x] Area: `area:cli`, `area:dx`

## Summary
- `marketplace add` already prints plugins from `.claude-plugin/marketplace.json`. It already prints the next `plugin install` command.
- This change prints extra Agent Skill trees after that follow-up.
- The scan looks at `plugins/*/skills/<name>/SKILL.md` in the clone.
- It keeps a tree only when that path sits outside every local Claude plugin source listed in `marketplace.json`.
- For the llm-wiki shape (`./claude-plugin` plus `plugins/llm-wiki-opencode/skills/`), stdout also includes the Agent Skill names. It includes a sample `[[agent_skills]]` stanza. The stanza sets `marketplace` and `path`.
- Stdout only. `marketplace add` does not write the stanza to the manifest.
- Nested `SKILL.md` trees inside the plugin source are not hinted. That includes `claude-plugin/skills/…`. That includes `plugins/foo/skills/…` when `./plugins/foo` is the plugin source.

## How It Works (diagram — REQUIRED)

`print_add_followup` still loads `.claude-plugin/marketplace.json`. It still prints plugin names and the next `plugin install` command.

It now also collects local relative plugin sources. A string such as `"./claude-plugin"` becomes `claude-plugin`. Remote object sources have no tree in this clone. The collector skips those.

Then `extra_agent_skill_trees` walks `plugins/` only:

1. Read each `plugins/<pack>/` directory.
2. Skip hidden names.
3. Require a `skills/` directory.
4. Build the relative path `plugins/<pack>/skills`.
5. Skip that path when it sits inside a collected plugin source.
6. Keep a child directory when it contains `SKILL.md`.

`print_agent_skill_hint` prints one summary line per kept path. It then prints one `[[agent_skills]]` stanza per Agent Skill name. Each stanza repeats `marketplace`, `path`, and `name`.

The command does not write `skills.toml`.

The walk never enters `claude-plugin/skills/`. That tree is not under `plugins/`.

When the plugin source is `./plugins/foo`, `path_is_inside` skips `plugins/foo/skills`. The Claude plugin already ships those nested `SKILL.md` trees.

If `marketplace.json` is missing, add still registers the clone. Plugin sources stay empty. The scan still runs.

Review commit `285b2ff` adds a negative assertion. The llm-wiki test now also checks that stdout does not contain `Agent Skills under claude-plugin/skills`.

```mermaid
flowchart TD
    A["marketplace add"] --> B["clone marketplace"]
    B --> C["print plugins from marketplace.json"]
    C --> D["print next plugin install command"]
    D --> E["scan plugins/*/skills/*/SKILL.md"]
    E --> F{"tree inside Claude plugin source?"}
    F -->|yes| G["skip"]
    F -->|no| H["print Agent Skill names and agent_skills stanza"]
    H --> I["do not write skills.toml"]
```

Sample stdout for the llm-wiki shape:

```
✓ added marketplace llm-wiki
  1 plugin: wiki
  Next: zskills plugin install wiki@llm-wiki
  Agent Skills under plugins/llm-wiki-opencode/skills: wiki-manager, wiki-query
    [[agent_skills]]
    marketplace = "llm-wiki"
    path = "plugins/llm-wiki-opencode/skills"
    name = "wiki-manager"
    [[agent_skills]]
    marketplace = "llm-wiki"
    path = "plugins/llm-wiki-opencode/skills"
    name = "wiki-query"
```

The user copies the stanza into the manifest. Then `sync` copies from the marketplace clone. This branch already parses `marketplace` and `path` on `[[agent_skills]]`.

## Linked Issues / ADRs
- Resolves: #58
- Part of: #59

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

```
$ cargo fmt --check
(no output, exit 0)

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s

$ ZSKILLS_NO_CLAUDE_CLI=1 cargo test
    test result: ok. 117 passed  (unit)
    test result: ok. 145 passed  (CLI, tests/cli.rs)
```

Relevant CLI tests, also with `ZSKILLS_NO_CLAUDE_CLI=1`. Each test points `CLAUDE_HOME` and `AGENTS_HOME` at a temporary home.

```
$ ZSKILLS_NO_CLAUDE_CLI=1 cargo test --test cli marketplace_add_
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.29s
     Running tests/cli.rs (target/debug/deps/cli-6273665b27278a34)

running 5 tests
test marketplace_add_warns_when_marketplace_json_is_missing ... ok
test marketplace_add_writes_last_updated_as_a_string ... ok
test marketplace_add_prints_plugins_and_the_next_install_command ... ok
test marketplace_add_hints_agent_skill_trees_outside_the_plugin_source ... ok
test marketplace_add_does_not_hint_skills_inside_the_plugin_source ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 140 filtered out; finished in 1.06s
```

What those tests cover:

- `marketplace_add_hints_agent_skill_trees_outside_the_plugin_source` — llm-wiki fixture. Plugin source is `./claude-plugin`. Extra trees live at `plugins/llm-wiki-opencode/skills/{wiki-manager,wiki-query}/SKILL.md`. Stdout contains both names. Stdout contains `[[agent_skills]]`, `marketplace = "llm-wiki"`, and `path = "plugins/llm-wiki-opencode/skills"`. Stdout does not contain `Agent Skills under claude-plugin/skills`. `skills.toml` does not exist after add.
- `marketplace_add_does_not_hint_skills_inside_the_plugin_source` — plugin source is `./plugins/foo`. Nested `plugins/foo/skills/bar/SKILL.md` is not hinted.
- `marketplace_add_prints_plugins_and_the_next_install_command` — clone with plugins and no extra Agent Skill trees. Stdout still has the plugin follow-up. Stdout does not contain `Agent Skills`.

Sandbox contract for the llm-wiki fixture:

| Path | Before `marketplace add` | After |
|---|---|---|
| `known_marketplaces.json` | empty / fixture | entry for `llm-wiki` (existing add) |
| `extraKnownMarketplaces` | fixture | entry for `llm-wiki` (existing add) |
| `skills.toml` | absent | still absent |

`marketplace add` still writes `known_marketplaces.json` and `extraKnownMarketplaces`. This PR does not add a write to the manifest.

## Additional Notes for Reviewers
- Stack parent is PR 2 (`marketplace` + `path`, #59). Issue #58 listed this work as independent of that parser. The stack places the hint after PR 2. The printed fields are fields this branch already parses.
- The hint does not install Agent Skills. It does not append the stanza. The user pastes the stanza into `skills.toml` and runs `sync`.
- Do not treat a nested `SKILL.md` inside the Claude plugin source as an extra Agent Skill. `plugin install` covers that tree.
- The scan walks `plugins/` only. Agent Skills at `.agents/skills/` or at a repo-root `skills/` directory are not hinted here.
- `docs/commands.md` shows the new stdout for `marketplace add`.
