### PR TITLE
feat: doctor warns when hub wiki-manager is Claude-flavored for Pi or Grok

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -178,6 +178,46 @@ zskills sync
 zskills doctor --fix
 ```
 
+## `doctor` says hub Agent Skill is Claude-flavored
+
+Pi or Grok can see `~/.agents/skills/wiki-manager/SKILL.md`, and that file matches Claude flavour:
+
+- YAML frontmatter contains `Activates for /wiki commands`, or
+- a `tools:` list with Claude Code names (`Read`, `Write`, `Edit`), or
+- the body contains `Claude Code is both the compiler`
+
+That happens when a plugin nested skill was copied onto the hub. Pi and Grok do not load `/wiki:*` slash commands, so they need the OpenCode tree.
+
+OpenCode `wiki-manager` still contains `/wiki:*` as documented shorthand. That string alone is **not** this finding. `doctor` does not substring `/wiki:`.
+
+Fix: point `[[agent_skills]]` at the OpenCode tree and `sync`:
+
+```toml
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+```
+
+`--fix` does not rewrite SKILL.md. `sync` takes over a same-marketplace `plugin:` hub copy.
+
+## `doctor` says `[[agent_skills]]` path is not on disk
+
+The `path` in the manifest does not exist inside the clone. Check the relative path (`plugins/llm-wiki-opencode/skills` for llm-wiki). Then `zskills marketplace update` or fix the selector.
+
+`--fix` does not create the directory.
+
+## `doctor` says marketplace is not in known_marketplaces.json
+
+The `marketplace` name on an `[[agent_skills]]` row is not a key in `~/.claude/plugins/known_marketplaces.json`. Register it:
+
+```bash
+zskills marketplace add nvk/llm-wiki
+```
+
+Or add `repo = "nvk/llm-wiki"` on `[[marketplaces]]` and run `sync`. `--fix` does not register a marketplace.
+
 ## "unrecognized marketplace source: skills.sh"
 
 You ran `zskills marketplace add skills.sh` against a default build. The skills.sh driver is gated behind the `skills-sh` cargo feature and not compiled into vanilla binaries. Reinstall with the feature on:

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -166,6 +166,9 @@ pub fn run(fix: bool) -> Result<()> {
         );
     }
 
+    issues += check_claude_flavored_hub();
+    issues += check_agent_skill_path_and_marketplace(&known);
+
     if issues == 0 {
         println!(
             "{} All good — disk, inventory, and settings are in sync.",
@@ -443,6 +446,222 @@ fn check_stale_zskills_skill_md() -> usize {
     issues
 }
 
+/// Frontmatter phrase on Claude `wiki-manager`. OpenCode rewrites this.
+const CLAUDE_WIKI_ACTIVATION: &str = "Activates for /wiki commands";
+/// Body sentence on Claude `wiki-manager`. OpenCode does not keep it.
+const CLAUDE_COMPILER_SENTENCE: &str = "Claude Code is both the compiler";
+/// Claude Code tool names cited as a flavour signal. Matching the trio
+/// avoids treating a single "Read" token as Claude flavour.
+const CLAUDE_TOOL_TRIO: &[&str] = &["Read", "Write", "Edit"];
+
+/// Warn when Pi or Grok can see hub `wiki-manager` and SKILL.md is Claude-flavored.
+///
+/// Do **not** substring `/wiki:` — OpenCode SKILL.md documents `/wiki:*` as
+/// shorthand, so that match would false-positive after a successful path copy.
+fn check_claude_flavored_hub() -> usize {
+    let Ok(hub) = crate::paths::user_skills_dir() else {
+        return 0;
+    };
+    let path = hub.join("wiki-manager").join("SKILL.md");
+    if !path.is_file() {
+        return 0;
+    }
+    let vis = crate::harness::visibility_for_skill("wiki-manager");
+    let targets: Vec<&str> = vis
+        .visible
+        .iter()
+        .filter(|h| {
+            matches!(
+                h,
+                crate::harness::Harness::Pi | crate::harness::Harness::Grok
+            )
+        })
+        .map(|h| h.as_str())
+        .collect();
+    if targets.is_empty() {
+        return 0;
+    }
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return 0;
+    };
+    if !is_claude_flavored(&text) {
+        return 0;
+    }
+    println!(
+        "{} hub Agent Skill `wiki-manager` is Claude-flavored and visible to {}",
+        "!".yellow(),
+        targets.join(", ")
+    );
+    println!(
+        "  {}",
+        "Pi and Grok need the OpenCode tree. Add [[agent_skills]] marketplace + path, then sync."
+            .dimmed()
+    );
+    1
+}
+
+/// YAML frontmatter between leading `---` fences, if any.
+fn yaml_frontmatter(text: &str) -> Option<&str> {
+    let t = text.trim_start_matches('\u{feff}');
+    let t = t.strip_prefix("---")?;
+    let t = t.strip_prefix("\r\n").or_else(|| t.strip_prefix('\n'))?;
+    let idx = t.find("\n---")?;
+    Some(&t[..idx])
+}
+
+/// Body after the closing `---` fence. Whole text when there is no frontmatter.
+fn markdown_body(text: &str) -> &str {
+    let t = text.trim_start_matches('\u{feff}');
+    let Some(rest) = t.strip_prefix("---") else {
+        return text;
+    };
+    let rest = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'));
+    let Some(rest) = rest else {
+        return text;
+    };
+    match rest.find("\n---") {
+        Some(idx) => {
+            let after = &rest[idx + 4..];
+            after
+                .strip_prefix("\r\n")
+                .or_else(|| after.strip_prefix('\n'))
+                .unwrap_or(after)
+        }
+        None => text,
+    }
+}
+
+/// Claude flavour: activation phrase or `tools:` trio in frontmatter, or the
+/// compiler sentence in the body. `/wiki:` alone is not a signal.
+fn is_claude_flavored(text: &str) -> bool {
+    if let Some(fm) = yaml_frontmatter(text) {
+        if fm.contains(CLAUDE_WIKI_ACTIVATION) {
+            return true;
+        }
+        if frontmatter_has_claude_tools(fm) {
+            return true;
+        }
+    }
+    markdown_body(text).contains(CLAUDE_COMPILER_SENTENCE)
+}
+
+fn frontmatter_has_claude_tools(fm: &str) -> bool {
+    let lines: Vec<&str> = fm.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if let Some(rest) = trimmed.strip_prefix("tools:") {
+            let mut blob = rest.trim().to_string();
+            if blob.is_empty() {
+                i += 1;
+                while i < lines.len() {
+                    let t = lines[i].trim();
+                    if let Some(item) = t.strip_prefix('-') {
+                        blob.push(' ');
+                        blob.push_str(item.trim());
+                        i += 1;
+                    } else if t.is_empty() {
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            return claude_tool_trio(&blob);
+        }
+        i += 1;
+    }
+    false
+}
+
+fn claude_tool_trio(blob: &str) -> bool {
+    let tokens: std::collections::BTreeSet<&str> = blob
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect();
+    CLAUDE_TOOL_TRIO.iter().all(|t| tokens.contains(t))
+}
+
+/// Dangling `path` on disk, and a `marketplace` name missing from
+/// `known_marketplaces.json`. Neither is auto-fixable.
+fn check_agent_skill_path_and_marketplace(
+    known: &serde_json::Map<String, serde_json::Value>,
+) -> usize {
+    let Some(path) = crate::manifest::discover() else {
+        return 0;
+    };
+    let Ok(manifest) = crate::manifest::load(&path) else {
+        return 0;
+    };
+    let mut issues = 0;
+    let mut warned_mp = std::collections::BTreeSet::new();
+    let mut warned_path = std::collections::BTreeSet::new();
+    for entry in &manifest.agent_skills {
+        if let Some(mp) = &entry.marketplace {
+            if !known.contains_key(mp) {
+                if warned_mp.insert(mp.clone()) {
+                    issues += 1;
+                    println!(
+                        "{} [[agent_skills]] marketplace `{}` is not in known_marketplaces.json",
+                        "✗".red(),
+                        mp
+                    );
+                    println!(
+                        "  {}",
+                        "register it with `zskills marketplace add`, or set repo = on [[marketplaces]] and run sync"
+                            .dimmed()
+                    );
+                }
+                continue;
+            }
+        }
+        let Some(rel) = &entry.path else {
+            continue;
+        };
+        let Some(clone) = clone_dir_for(entry) else {
+            continue;
+        };
+        if crate::agent_skill::resolve_path_in_clone(&clone, rel).is_ok() {
+            continue;
+        }
+        let key = match &entry.marketplace {
+            Some(mp) => format!("marketplace:{mp}:{rel}"),
+            None => format!("source:{}:{rel}", entry.source.as_deref().unwrap_or("")),
+        };
+        if !warned_path.insert(key) {
+            continue;
+        }
+        issues += 1;
+        let origin = match &entry.marketplace {
+            Some(mp) => format!("marketplace `{mp}`"),
+            None => match &entry.source {
+                Some(src) => format!("source `{src}`"),
+                None => "the clone".to_string(),
+            },
+        };
+        println!(
+            "{} [[agent_skills]] path `{}` is not on disk in {}",
+            "✗".red(),
+            rel,
+            origin
+        );
+    }
+    issues
+}
+
+fn clone_dir_for(entry: &crate::manifest::AgentSkillEntry) -> Option<std::path::PathBuf> {
+    if let Some(mp) = entry.marketplace.as_deref() {
+        let dir = crate::paths::marketplaces_dir().ok()?.join(mp);
+        return dir.is_dir().then_some(dir);
+    }
+    let src = entry.source.as_deref()?;
+    let (_, name) = crate::agent_skill::parse_source(src).ok()?;
+    let cache = crate::paths::agent_skills_cache_dir().ok()?.join(name);
+    cache.is_dir().then_some(cache)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,5 +732,74 @@ mod tests {
                 "bare form of `{verb}` must be detected"
             );
         }
+    }
+
+    const CLAUDE_WIKI: &str = "---\nname: wiki-manager\ndescription: Activates for /wiki commands\ntools: Read, Write, Edit\n---\nClaude Code is both the compiler and the runtime.\n";
+    const OPENCODE_WIKI: &str = "---\nname: wiki-manager\ndescription: Manage a local wiki\n---\nOpenCode Integration Notes.\n\nTreat any /wiki:* references in this document as shorthand for the matching skill action.\n";
+
+    #[test]
+    fn claude_wiki_skill_is_flavored() {
+        assert!(is_claude_flavored(CLAUDE_WIKI));
+    }
+
+    #[test]
+    fn opencode_wiki_shorthand_is_not_flavored() {
+        assert!(
+            OPENCODE_WIKI.contains("/wiki:"),
+            "negative case must contain the shorthand that a `/wiki:` substring would trip"
+        );
+        assert!(!is_claude_flavored(OPENCODE_WIKI));
+    }
+
+    #[test]
+    fn activation_phrase_in_frontmatter_is_flavored() {
+        assert!(is_claude_flavored(
+            "---\ndescription: Activates for /wiki commands. Use when querying.\n---\nbody\n"
+        ));
+    }
+
+    #[test]
+    fn tools_trio_in_frontmatter_is_flavored() {
+        assert!(is_claude_flavored(
+            "---\nname: wiki-manager\ntools: Read, Write, Edit, Bash\n---\nbody\n"
+        ));
+        assert!(is_claude_flavored(
+            "---\ntools:\n  - Read\n  - Write\n  - Edit\n---\nbody\n"
+        ));
+    }
+
+    #[test]
+    fn compiler_sentence_in_body_is_flavored() {
+        assert!(is_claude_flavored(
+            "---\nname: wiki-manager\n---\nClaude Code is both the compiler and the runtime.\n"
+        ));
+    }
+
+    #[test]
+    fn wiki_slash_substring_alone_is_not_flavored() {
+        let text = "---\nname: wiki-manager\n---\nTreat any /wiki:* references as shorthand.\n";
+        assert!(text.contains("/wiki:"));
+        assert!(!is_claude_flavored(text));
+    }
+
+    #[test]
+    fn tools_in_body_are_not_flavored() {
+        assert!(!is_claude_flavored(
+            "---\nname: wiki-manager\n---\nUse tools: Read, Write, Edit\n"
+        ));
+    }
+
+    #[test]
+    fn activation_phrase_in_body_is_not_flavored() {
+        assert!(!is_claude_flavored(
+            "---\nname: wiki-manager\n---\nActivates for /wiki commands\n"
+        ));
+    }
+
+    #[test]
+    fn single_claude_tool_is_not_the_trio() {
+        assert!(!is_claude_flavored(
+            "---\nname: wiki-manager\ntools: Read\n---\nbody\n"
+        ));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4688,3 +4688,107 @@ fn plugin_install_skips_hub_names_claimed_by_agent_skills() {
         "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills"
     );
 }
+
+#[test]
+fn doctor_warns_when_hub_wiki_manager_is_claude_flavored_for_pi_or_grok() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = ["pi"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    zskills(&home).arg("sync").assert().success();
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        CLAUDE_WIKI_SKILL
+    );
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Claude-flavored"))
+        .stdout(predicate::str::contains("wiki-manager"));
+}
+
+#[test]
+fn doctor_does_not_warn_on_opencode_wiki_shorthand() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &llm_wiki_recipe(
+            &file_url(&home.path().join("plugins/marketplaces/llm-wiki")),
+            r#"["claude"]"#,
+        ),
+    );
+    zskills(&home).arg("sync").assert().success();
+    let skill = fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap();
+    assert!(
+        skill.contains("/wiki:"),
+        "fixture must contain /wiki: shorthand so this is a real negative"
+    );
+    assert_eq!(skill, OPENCODE_WIKI_SKILL);
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Claude-flavored").not());
+}
+
+#[test]
+fn doctor_warns_when_agent_skill_path_is_missing_on_disk() {
+    let (home, _up, _repo) = setup_llm_wiki_home();
+    write_manifest(
+        &home,
+        &format!(
+            r#"[[marketplaces]]
+name = "llm-wiki"
+url = "{url}"
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/does-not-exist/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+"#,
+            url = file_url(&home.path().join("plugins/marketplaces/llm-wiki"))
+        ),
+    );
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("does-not-exist"))
+        .stdout(predicate::str::contains("not on disk"));
+}
+
+#[test]
+fn doctor_warns_when_marketplace_is_not_in_known_marketplaces() {
+    let home = fake_home();
+    write_manifest(
+        &home,
+        r#"[[agent_skills]]
+marketplace = "ghost-mp"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+"#,
+    );
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ghost-mp"))
+        .stdout(predicate::str::contains("known_marketplaces.json"));
+}


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `enhancement`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:small`
- [x] Area: `area:cli`

## Summary
- `zskills doctor` reports three findings for llm-wiki path selectors.
- None of the three findings are auto-fixable.
- `--fix` does not rewrite `SKILL.md`.
- `--fix` does not create a missing directory.
- `--fix` does not register a marketplace.

llm-wiki ships two trees. The Claude plugin nested skill for `wiki-manager` is Claude-flavored. Pi and Grok load Agent Skills from `~/.agents/skills/`. Those harnesses need the OpenCode tree at `plugins/llm-wiki-opencode/skills`.

A `sync` that copies the Claude plugin nested skill onto the hub leaves `~/.agents/skills/wiki-manager/SKILL.md` Claude-flavored. Pi and Grok then see a `SKILL.md` they cannot use. This PR makes `doctor` report that state.

### Finding 1. Hub `wiki-manager` is Claude-flavored

`check_claude_flavored_hub` runs on every `doctor` call.

It reads `~/.agents/skills/wiki-manager/SKILL.md`. The name is fixed. Other Agent Skills are not checked.

It then calls `visibility_for_skill("wiki-manager")`. It keeps only `pi` and `grok` from the visible set. If that set is empty, it returns `0`. Claude-only visibility does not warn.

If Pi or Grok can see the file, it classifies the text. Claude-flavored means any of these:

1. YAML frontmatter contains `Activates for /wiki commands`.
2. Frontmatter `tools:` contains the trio `Read`, `Write`, `Edit`.
3. The markdown body contains `Claude Code is both the compiler`.

The `tools:` match accepts an inline list (`tools: Read, Write, Edit`) and a YAML list. Extra names such as `Bash` still match when the trio is present. A single `Read` token is not the trio.

The activation phrase and the `tools:` trio count only in frontmatter. The same strings in the body do not warn. The compiler sentence counts only in the body.

`doctor` does not substring `/wiki:`. OpenCode `SKILL.md` documents `/wiki:*` as shorthand. That string remains after a correct OpenCode copy. A `/wiki:` substring would warn on a healthy hub.

On a match it prints a yellow `!` line:

```
hub Agent Skill `wiki-manager` is Claude-flavored and visible to pi, grok
```

The note tells the user to add `[[agent_skills]]` `marketplace` plus `path`, then `sync`. That is the OpenCode selector from `#59`.

The finding increments `issues`. It does not increment `fixable`.

### Finding 2. `[[agent_skills]]` `path` is not on disk

`check_agent_skill_path_and_marketplace` walks every `[[agent_skills]]` row in the manifest.

A row with `path` must resolve inside the marketplace clone or the source cache. The helper is `resolve_path_in_clone`. A missing relative path prints a red `✗` line:

```
[[agent_skills]] path `plugins/does-not-exist/skills` is not on disk in marketplace `llm-wiki`
```

Each `marketplace:{name}:{path}` or `source:{source}:{path}` key warns once.

The finding increments `issues`. It does not increment `fixable`. `--fix` does not create the directory. The user fixes the selector or runs `zskills marketplace update`.

### Finding 3. `marketplace` is not in `known_marketplaces.json`

The `marketplace` name on an `[[agent_skills]]` row must be a key in `known_marketplaces.json`.

A name that is absent prints a red `✗` line:

```
[[agent_skills]] marketplace `ghost-mp` is not in known_marketplaces.json
```

Each marketplace name warns once. The row then skips the path check. An unknown marketplace has no clone to resolve against.

The finding increments `issues`. It does not increment `fixable`. `--fix` does not register a marketplace. The user runs `zskills marketplace add` or sets `repo =` on `[[marketplaces]]` and runs `sync`.

### Docs

`docs/troubleshooting.md` adds one section per finding. Each section states the signal, the user fix, and that `--fix` does not apply.

This change stacks on `#59` (PR 3a). Unique range: `285b2ff..f5d9c27`.

## How It Works (diagram — REQUIRED)

`run` already splits `issues` from `fixable`. These three checks add to `issues` only. `--fix` has no repair branch for them.

Claude-flavored classification is a gate, then three positive signals, then a hard negative for `/wiki:` alone.

```mermaid
flowchart TD
    A[zskills doctor] --> B{hub wiki-manager visible to Pi or Grok?}
    B -->|no| C[skip flavored check]
    B -->|yes| D{Claude-flavored?}
    D -->|frontmatter Activates for wiki commands| E[warn]
    D -->|frontmatter tools Read Write Edit| E
    D -->|body Claude Code is both the compiler| E
    D -->|substring wiki colon only| F[do not warn]
    A --> G{"agent_skills path on disk?"}
    G -->|no| H[warn missing path]
    A --> I{"marketplace in known_marketplaces.json?"}
    I -->|no| J[warn unknown marketplace]
```

Call order inside `run`:

1. Existing marketplace, plugin, and MCP checks run first.
2. `check_claude_flavored_hub` runs next.
3. `check_agent_skill_path_and_marketplace(&known)` runs after that. It reuses the `known_marketplaces.json` map already loaded.
4. If `issues` is still `0`, `doctor` prints `All good`.
5. If `issues` is greater than `0` and `fixable` is `0`, `doctor` prints `Nothing here is auto-fixable`.

## Linked Issues / ADRs
- Resolves: #60
- Part of: #59

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

`doctor` does not write for these findings. `--fix` does not touch them. CLI tests still set `CLAUDE_HOME` and `AGENTS_HOME` on a `TempDir`. The suite sets `ZSKILLS_NO_CLAUDE_CLI=1`. Tests do not reach a real `claude` binary or the developer home.

```
$ cargo fmt --check
exit: 0

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
exit: 0

$ cargo test --bin zskills flavored
running 8 tests
test commands::doctor::tests::claude_wiki_skill_is_flavored ... ok
test commands::doctor::tests::activation_phrase_in_frontmatter_is_flavored ... ok
test commands::doctor::tests::tools_in_body_are_not_flavored ... ok
test commands::doctor::tests::opencode_wiki_shorthand_is_not_flavored ... ok
test commands::doctor::tests::wiki_slash_substring_alone_is_not_flavored ... ok
test commands::doctor::tests::compiler_sentence_in_body_is_flavored ... ok
test commands::doctor::tests::activation_phrase_in_body_is_not_flavored ... ok
test commands::doctor::tests::tools_trio_in_frontmatter_is_flavored ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 109 filtered out

$ cargo test --bin zskills single_claude_tool_is_not_the_trio
test commands::doctor::tests::single_claude_tool_is_not_the_trio ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 116 filtered out

$ cargo test --test cli doctor_warns_when_hub_wiki_manager_is_claude_flavored_for_pi_or_grok
test doctor_warns_when_hub_wiki_manager_is_claude_flavored_for_pi_or_grok ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 144 filtered out

$ cargo test --test cli doctor_does_not_warn_on_opencode_wiki_shorthand
test doctor_does_not_warn_on_opencode_wiki_shorthand ... ok

$ cargo test --test cli doctor_warns_when_agent_skill_path_is_missing_on_disk
test doctor_warns_when_agent_skill_path_is_missing_on_disk ... ok

$ cargo test --test cli doctor_warns_when_marketplace_is_not_in_known_marketplaces
test doctor_warns_when_marketplace_is_not_in_known_marketplaces ... ok
```

Full suite on this range: 117 unit tests in `src/main.rs`, 145 CLI tests in `tests/cli.rs`. Both counts include the new tests above.

CLI cases:

| Test | Setup | Expect |
|---|---|---|
| `doctor_warns_when_hub_wiki_manager_is_claude_flavored_for_pi_or_grok` | `[[skills]]` `wiki` for `pi`. No OpenCode `[[agent_skills]]` row. `sync` copies Claude `SKILL.md` onto the hub. | stdout contains `Claude-flavored` and `wiki-manager`. |
| `doctor_does_not_warn_on_opencode_wiki_shorthand` | Recipe copies OpenCode `wiki-manager` for Pi and Grok. Hub `SKILL.md` contains `/wiki:`. | stdout does not contain `Claude-flavored`. |
| `doctor_warns_when_agent_skill_path_is_missing_on_disk` | `path = "plugins/does-not-exist/skills"` on a registered `llm-wiki` marketplace. | stdout contains `does-not-exist` and `not on disk`. |
| `doctor_warns_when_marketplace_is_not_in_known_marketplaces` | `marketplace = "ghost-mp"` with no `known_marketplaces.json` key. | stdout contains `ghost-mp` and `known_marketplaces.json`. |

Unit cases cover the three positive signals, the `/wiki:` negative, tools in the body, the activation phrase in the body, and a single `Read` token.

## Additional Notes for Reviewers
- The flavored check is hardcoded to hub `wiki-manager`. It does not scan other Agent Skills.
- Pi and Grok names in the warning come from `Harness::as_str()`. The printed line uses `pi` and `grok`.
- If `marketplace` is a key in `known_marketplaces.json` but the clone directory is missing, `clone_dir_for` returns `None`. The path check is then skipped. That gap is pre-existing clone layout, not a new repair.
- `--fix` with only these findings prints `Fixed 0 issue(s)` and `N further finding(s) need a human`. MCP checks already use that counter split.
- Parent branch: `execute-plan/7a55703f-pr-3a-feat-hint-agent-skill-trees-under-pluginsskills-af`.
- Files: `src/commands/doctor.rs`, `docs/troubleshooting.md`, `tests/cli.rs`.
