### PR TITLE
feat: skill install --path for non-conventional Agent Skill roots

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,14 +45,16 @@ zskills plugin install <name>@<marketplace>         # qualified plugin
 zskills plugin install <name> --harness pi,grok     # copy nested skills/<name>/ into the shared Agent Skill hub
 zskills skill install <owner>/<repo>                # Agent Skill(s) from a git repo
 zskills skill install <git-url>                     # same, for https://, git@, file://
+zskills skill install <owner>/<repo> --path REL     # Agent Skills under a non-conventional root
 zskills plugin install -i                           # interactive picker over marketplace plugins
 ```
 
 **Plugin path (`<name>` / `<name>@<marketplace>`).** Resolves against registered marketplaces. `--harness` is a one-shot override of `[defaults].harnesses` (comma-separated: `claude`, `pi`, `hermes`, `kimi`, `grok`, `codex`). Missing `[defaults]` and missing `--harness` keep 1.0 behaviour: Claude only. `claude` in the set flips `enabledPlugins` in `~/.claude/settings.json` and materializes the marketplace plugin. `pi` / `grok` / `codex` / `hermes` copy each nested `skills/<name>/` tree into the shared hub `~/.agents/skills/<name>/` so `SKILL.md` sits at the scan root. Pi and Grok scan the hub itself; Codex and Hermes are symlinked from it into `~/.codex/skills/<name>` and `~/.hermes/skills/<category>/<name>`. Copies into the hub are real directories — a plugin cache path is version-stamped, so a link there would break on upgrade. `kimi` prints `unsupported` and does not invent a folder.
 
 **Repo path (`<owner>/<repo>` or git URL).** Clones the repo via `git clone --depth 1` into `~/.cache/zskills/agent-skills/<owner>-<repo>/`, surveys the tree, and:
-- **Agent Skills** (any directory under `skills/<name>/SKILL.md`) — installed to `~/.agents/skills/<name>/` (the cross-client convention; visible to Claude Code, Grok CLI, and any other compliant client). Inventory tagged with the source.
-- **Marketplace** (`.claude-plugin/marketplace.json` at repo root) — prints a redirect: `use zskills marketplace add <owner/repo>` and installs nothing from this repo.
+- **Agent Skills** (any directory under `skills/<name>/SKILL.md` or `.agents/skills/<name>/SKILL.md`) — installed to `~/.agents/skills/<name>/` (the cross-client convention; visible to Claude Code, Grok CLI, and any other compliant client). Inventory tagged with the source.
+- **`--path REL`** — walk `REL` inside the clone instead of those default roots. If `REL/SKILL.md` exists, that directory is the skill. Else every child with `SKILL.md` is a skill. `--path` is sparse-intent: a repo with `.claude-plugin/marketplace.json` still installs from that path instead of redirecting to `marketplace add`. After a successful install, zskills appends an `[[agent_skills]]` row: `marketplace` when the spec matches a registered marketplace (and the copy reuses that clone), else `source`.
+- **Marketplace** (`.claude-plugin/marketplace.json` at repo root) — without `--path` / `--skill` / `-i`, prints a redirect: `use zskills marketplace add <owner/repo>` and installs nothing from this repo.
 - **MCP servers** (`.mcp.json` or `mcpServers` in `plugin.json`) — surfaced as a hint; not auto-installed (use `[[mcps]]` in `skills.toml` + `zskills sync`).
 
 | Flag | Default | Description |
@@ -60,6 +62,7 @@ zskills plugin install -i                           # interactive picker over ma
 | `-i`, `--interactive` | off | For plugin specs: without any `<name>`, browse all marketplace plugins with a fuzzy picker. For repo specs: always opens a multi-select picker over the Agent Skills found in the repo. |
 | `--all` | off | For repo specs only: when the repo contains more than 5 Agent Skills, confirm "yes, install every one." Without `--all`, large collections abort with a sample summary so they don't silently flood `~/.agents/skills/`. Ignored for repos with ≤5 skills (those install everything by default). |
 | `--skill <name>` | none | For repo specs only: install exactly one skill by name (the manifest `name` field) — the non-interactive counterpart to `-i` for multi-skill repos. Bypasses the >5-skill size policy (the selection is explicit) and conflicts with `--all`. |
+| `--path <rel>` | none | For repo specs only: relative path inside the clone to a directory of Agent Skills. Replaces the default walk of `.agents/skills` and `skills/`. Sparse-intent like `--skill` / `-i`: do not redirect a marketplace root. Writes `[[agent_skills]]` with `marketplace` or `source`. Ban `..`, absolute form, `\`, `:`. |
 | `--harness <list>` | `[defaults].harnesses`, or Claude only | Comma-separated harness names. One-shot override. Not `--to`. |
 
 **Repo-path count behavior**:
@@ -103,10 +106,12 @@ zskills plugin disable <name>...
 Agent Skills live in `~/.agents/skills/`. The group writes `[[agent_skills]]`, not `[[skills]]`.
 
 ```
-zskills skill install <owner/repo> [--skill NAME | --all | -i]
+zskills skill install <owner/repo> [--path REL] [--skill NAME | --all | -i]
 zskills skill remove <name> [--force] [--file path]
 zskills skill upgrade [<name>...]
 ```
+
+`--path REL` installs Agent Skills that do not live at `.agents/skills` or `skills/`. Example: `zskills skill install nvk/llm-wiki --path plugins/llm-wiki-opencode/skills --skill wiki-manager`. That command does not redirect to `marketplace add`. After install, the manifest row uses `marketplace` when the spec matches a registered marketplace, else `source`.
 
 `skill remove` deletes bytes. It is not `plugin remove`. `--force` is required when inventory `source` starts with `plugin:`, or when a source-only `[[agent_skills]]` row owns the name. A `marketplace:` hub copy of the same name removes without `--force` and without disabling the plugin.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -270,6 +270,12 @@ pub enum AgentSkillCmd {
             help = "Install only this one skill out of the source"
         )]
         skill: Option<String>,
+        #[arg(
+            long,
+            value_name = "REL",
+            help = "Relative path inside the clone to a directory of Agent Skills (skips the marketplace redirect)"
+        )]
+        path: Option<String>,
         /// One-shot harness override (comma-separated). Omitted: `[defaults].harnesses`.
         #[arg(
             long = "harness",
@@ -400,6 +406,7 @@ impl Cli {
                         interactive,
                         false,
                         None,
+                        None,
                         harness,
                         category,
                     )
@@ -418,6 +425,7 @@ impl Cli {
                     interactive,
                     all,
                     skill,
+                    path,
                     harness,
                     category,
                 } => crate::commands::agent_skills::install(
@@ -425,6 +433,7 @@ impl Cli {
                     interactive,
                     all,
                     skill,
+                    path,
                     harness,
                     category,
                 ),

--- a/src/commands/agent_skills.rs
+++ b/src/commands/agent_skills.rs
@@ -9,6 +9,7 @@ pub fn install(
     interactive: bool,
     all: bool,
     skill: Option<String>,
+    path: Option<String>,
     harness: Vec<crate::harness::Harness>,
     category: String,
 ) -> Result<()> {
@@ -20,7 +21,7 @@ pub fn install(
             "skill install takes owner/repo or a git URL; use `zskills plugin install` for name@marketplace"
         );
     }
-    crate::commands::install::run(specs, interactive, all, skill, harness, category)
+    crate::commands::install::run(specs, interactive, all, skill, path, harness, category)
 }
 
 pub fn upgrade(names: Vec<String>) -> Result<()> {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -7,8 +7,9 @@
 //!    as installed.
 //! 2. `<owner>/<repo>` or `git@…` / `https://…/<repo>.git` URL — **repo path** (v0.8+).
 //!    Clones the repo, surveys it via `repo_scanner`, and installs Agent Skills found
-//!    under `skills/<name>/SKILL.md`. Marketplaces are detected and redirected; MCPs
-//!    are mentioned but not auto-installed in this mode.
+//!    under `skills/<name>/SKILL.md`. `--path REL` walks that directory instead.
+//!    Marketplaces are detected and redirected unless `--skill` / `-i` / `--path`
+//!    (sparse intent); MCPs are mentioned but not auto-installed in this mode.
 //! 3. `skills.sh` remote index (cargo feature `skills-sh`): when local resolution fails
 //!    AND the index is registered AND `ZSKILLS_SKILLS_SH_API_KEY` is set, falls through
 //!    to clone the source repo and drop SKILL.md into `~/.agents/skills/<name>/`.
@@ -22,6 +23,7 @@ pub fn run(
     interactive: bool,
     all: bool,
     skill: Option<String>,
+    path: Option<String>,
     harness: Vec<crate::harness::Harness>,
     category: String,
 ) -> Result<()> {
@@ -41,6 +43,9 @@ pub fn run(
     if skill.is_some() && repo_specs.is_empty() {
         anyhow::bail!("--skill only applies to repo installs (owner/repo or git URL)");
     }
+    if path.is_some() && repo_specs.is_empty() {
+        anyhow::bail!("--path only applies to repo installs (owner/repo or git URL)");
+    }
 
     let mut failures = 0usize;
     for spec in &repo_specs {
@@ -49,6 +54,7 @@ pub fn run(
             interactive,
             all,
             skill.as_deref(),
+            path.as_deref(),
             &harness,
             &category,
         ) {
@@ -87,6 +93,7 @@ fn install_from_repo(
     interactive: bool,
     all: bool,
     skill: Option<&str>,
+    path: Option<&str>,
     harness: &[crate::harness::Harness],
     category: &str,
 ) -> Result<()> {
@@ -99,14 +106,26 @@ fn install_from_repo(
         }
     }
     println!("{} {}", "Surveying".dimmed(), spec.to_string().bold());
-    let cache = crate::agent_skill::ensure_cache(spec)?;
-    let survey = crate::repo_scanner::survey(&cache)?;
+
+    let path = match path {
+        Some(p) => Some(crate::manifest::normalize_skill_path(p)?),
+        None => None,
+    };
+    let (cache, origin) = resolve_repo_origin(spec, path.as_deref())?;
+    if let Some(rel) = path.as_deref() {
+        crate::agent_skill::resolve_path_in_clone(&cache, rel)?;
+    }
+    let survey = match path.as_deref() {
+        Some(rel) => crate::repo_scanner::survey_with_path(&cache, Some(rel))?,
+        None => crate::repo_scanner::survey(&cache)?,
+    };
 
     // A repo can be *both* a plugin marketplace and a collection of Agent Skills.
     // Redirecting to the marketplace is the right default for a bare
-    // `zskills install owner/repo`, but `--skill NAME` / `-i` are explicit sparse
-    // Agent Skill requests: the user already said what they want, so honour it.
-    let sparse_intent = skill.is_some() || interactive;
+    // `zskills install owner/repo`, but `--skill NAME` / `-i` / `--path` are
+    // explicit sparse Agent Skill requests: the user already said what they
+    // want, so honour it.
+    let sparse_intent = skill.is_some() || interactive || path.is_some();
     if survey.marketplace && !sparse_intent {
         println!(
             "{}",
@@ -168,16 +187,23 @@ fn install_from_repo(
                 .collect::<Vec<_>>()
                 .join(", ")
         );
-        return install_chosen(spec, &[name.to_string()], &hs, category);
+        let installed = install_chosen(spec, &origin, &[name.to_string()], &hs, category)?;
+        append_path_manifest(&origin, &installed, true, harness)?;
+        return Ok(());
     }
 
     const AUTO_INSTALL_MAX: usize = 5;
     let n = survey.agent_skills.len();
     let chosen: Vec<String> = match (n, interactive, all) {
-        (0, _, _) => anyhow::bail!(
-            "no Agent Skills found in {} (expected skills/<name>/SKILL.md)",
-            spec
-        ),
+        (0, _, _) => {
+            if let Some(rel) = path.as_deref() {
+                anyhow::bail!("no Agent Skills under path '{rel}' in {spec}");
+            }
+            anyhow::bail!(
+                "no Agent Skills found in {} (expected skills/<name>/SKILL.md)",
+                spec
+            )
+        }
         (1, _, _) => vec![survey.agent_skills[0].name.clone()],
         (_, true, _) => pick_skills(spec, &survey.agent_skills)?,
         (_, false, true) => survey.agent_skills.iter().map(|s| s.name.clone()).collect(),
@@ -185,7 +211,7 @@ fn install_from_repo(
             survey.agent_skills.iter().map(|s| s.name.clone()).collect()
         }
         (count, false, false) => {
-            print_large_collection_summary(spec, count, &survey.agent_skills);
+            print_large_collection_summary(spec, count, &survey.agent_skills, path.as_deref());
             return Ok(());
         }
     };
@@ -195,23 +221,49 @@ fn install_from_repo(
         return Ok(());
     }
 
-    install_chosen(spec, &chosen, &hs, category)
+    let installed = install_chosen(spec, &origin, &chosen, &hs, category)?;
+    // `--skill` / `-i` name the rows they picked. `--path` without those is
+    // "every Agent Skill under this path" — one unnamed row, not `skills = []`.
+    append_path_manifest(&origin, &installed, interactive, harness)?;
+    Ok(())
+}
+
+/// Clone (or reuse a registered marketplace clone) and the origin `install_from` uses.
+fn resolve_repo_origin(
+    spec: &str,
+    path: Option<&str>,
+) -> Result<(std::path::PathBuf, crate::agent_skill::SkillOrigin)> {
+    if let Some(rel) = path {
+        if let Some(mp) = crate::marketplace::name_for_source_spec(spec) {
+            let clone = crate::agent_skill::resolve_marketplace_clone(&mp)?;
+            return Ok((
+                clone,
+                crate::agent_skill::SkillOrigin::marketplace(mp, Some(rel.to_string())),
+            ));
+        }
+        let cache = crate::agent_skill::ensure_cache(spec)?;
+        return Ok((
+            cache,
+            crate::agent_skill::SkillOrigin::git(spec, Some(rel.to_string())),
+        ));
+    }
+    let cache = crate::agent_skill::ensure_cache(spec)?;
+    Ok((cache, crate::agent_skill::SkillOrigin::git(spec, None)))
 }
 
 fn install_chosen(
     spec: &str,
+    origin: &crate::agent_skill::SkillOrigin,
     chosen: &[String],
     hs: &[crate::harness::Harness],
     category: &str,
-) -> Result<()> {
+) -> Result<Vec<String>> {
+    let mut installed_names = Vec::new();
     for name in chosen {
-        match crate::agent_skill::install_from(
-            &crate::agent_skill::SkillOrigin::git(spec, None),
-            Some(name),
-        ) {
+        match crate::agent_skill::install_from(origin, Some(name)) {
             Ok(installed) => {
                 crate::harness::link_hub_to_harnesses(&installed, hs, category)?;
-                for n in installed {
+                for n in &installed {
                     println!(
                         "{} {} {}",
                         "+".green(),
@@ -219,11 +271,73 @@ fn install_chosen(
                         format!("[from {}]", spec).dimmed()
                     );
                 }
+                installed_names.extend(installed);
             }
             Err(e) => eprintln!("{} {}: {}", "✗".red(), name, e),
         }
     }
+    Ok(installed_names)
+}
+
+/// Durable `[[agent_skills]]` row for a `--path` install. `marketplace` when
+/// the spec matches a registered marketplace, else `source`.
+fn append_path_manifest(
+    origin: &crate::agent_skill::SkillOrigin,
+    installed: &[String],
+    named: bool,
+    harness: &[crate::harness::Harness],
+) -> Result<()> {
+    let Some(rel) = origin.path.as_deref() else {
+        return Ok(());
+    };
+    if installed.is_empty() {
+        return Ok(());
+    }
+    let manifest_path = default_manifest_path();
+    let harnesses: Vec<String> = harness.iter().map(|h| h.as_str().to_string()).collect();
+    let (marketplace, source) = match &origin.kind {
+        crate::agent_skill::OriginKind::Marketplace { name } => (Some(name.clone()), None),
+        crate::agent_skill::OriginKind::Git { source } => (None, Some(source.clone())),
+    };
+    let rows: Vec<Option<String>> = if named {
+        installed.iter().map(|n| Some(n.clone())).collect()
+    } else {
+        vec![None]
+    };
+    let mut wrote = false;
+    for name in rows {
+        let entry = crate::manifest::AgentSkillEntry {
+            source: source.clone(),
+            marketplace: marketplace.clone(),
+            path: Some(rel.to_string()),
+            name,
+            harnesses: harnesses.clone(),
+            ..Default::default()
+        };
+        if crate::manifest::append_agent_skill(&manifest_path, &entry)? {
+            wrote = true;
+        }
+    }
+    if wrote {
+        println!(
+            "  {} wrote [[agent_skills]] to {}",
+            "·".dimmed(),
+            manifest_path.display()
+        );
+    }
     Ok(())
+}
+
+fn default_manifest_path() -> std::path::PathBuf {
+    if let Some(p) = crate::manifest::discover() {
+        return p;
+    }
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
+        .unwrap_or_else(|| std::path::PathBuf::from(".config"))
+        .join("zskills")
+        .join("skills.toml")
 }
 
 fn pick_skills(spec: &str, skills: &[crate::repo_scanner::SkillSummary]) -> Result<Vec<String>> {
@@ -242,6 +356,7 @@ fn print_large_collection_summary(
     spec: &str,
     count: usize,
     skills: &[crate::repo_scanner::SkillSummary],
+    path: Option<&str>,
 ) {
     println!(
         "{} contains {} {} — zskills won't install all of them by default.",
@@ -250,14 +365,17 @@ fn print_large_collection_summary(
         "Agent Skills".dimmed()
     );
     println!("\n{}", "Options:".bold());
+    // Repeat `--path` so the next step stays sparse-intent and surveys the
+    // same tree. Without it, a marketplace repo redirects or walks SKILL_ROOTS.
+    let path_flag = path.map(|p| format!(" --path {p}")).unwrap_or_default();
     println!(
         "  {}   {}",
-        format!("zskills skill install {} -i", spec).bold(),
+        format!("zskills skill install {spec}{path_flag} -i").bold(),
         "interactive picker".dimmed()
     );
     println!(
         "  {}   {}",
-        format!("zskills skill install {} --all", spec).bold(),
+        format!("zskills skill install {spec}{path_flag} --all").bold(),
         format!("install all {} skills", count).dimmed()
     );
     let preview: Vec<&str> = skills.iter().take(5).map(|s| s.name.as_str()).collect();
@@ -484,6 +602,7 @@ fn run_interactive_browse_marketplaces(
             vec![qualified_names[idx].clone()],
             false,
             false,
+            None,
             None,
             harness,
             category,

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -134,6 +134,7 @@ fn install_from_hits(hits: &[Hit]) -> Result<()> {
                 false,
                 false,
                 None,
+                None,
                 Vec::new(),
                 crate::harness::DEFAULT_HERMES_CATEGORY.to_string(),
             )?;

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -215,6 +215,43 @@ pub fn register(name: &str, source: &str) -> Result<PathBuf> {
     Ok(install_location)
 }
 
+/// Registered marketplace whose clone source is `spec` (`owner/repo` or a git URL).
+///
+/// `skill install --path` uses this to reuse the marketplace clone and write
+/// `marketplace` rather than `source`. Checks `known_marketplaces.json` first,
+/// then `extraKnownMarketplaces`.
+pub fn name_for_source_spec(spec: &str) -> Option<String> {
+    let path = crate::paths::known_marketplaces_json().ok()?;
+    let known = load_known(&path).ok()?;
+    let extra = extra_known();
+    name_in_map(&known, spec).or_else(|| name_in_map(&extra, spec))
+}
+
+fn name_in_map(map: &Map<String, Value>, spec: &str) -> Option<String> {
+    let spec_github = if is_github_owner_repo(spec) {
+        Some(spec.to_string())
+    } else {
+        github_from_url(spec)
+    };
+    for (name, entry) in map {
+        if is_remote_index(entry) {
+            continue;
+        }
+        let Some((repo, url)) = source_for_manifest(entry) else {
+            continue;
+        };
+        if repo.as_deref() == Some(spec) || url.as_deref() == Some(spec) {
+            return Some(name.clone());
+        }
+        if let (Some(r), Some(g)) = (repo.as_deref(), spec_github.as_deref()) {
+            if r == g {
+                return Some(name.clone());
+            }
+        }
+    }
+    None
+}
+
 /// Shareable `repo` / `url` from a `known_marketplaces.json` or
 /// `extraKnownMarketplaces` entry. `None` for remote indexes and unreadable shapes —
 /// `--adopt` must not write a `[[marketplaces]]` row a fresh machine cannot clone.

--- a/src/repo_scanner.rs
+++ b/src/repo_scanner.rs
@@ -36,10 +36,31 @@ pub struct RepoSurvey {
 }
 
 pub fn survey(cache: &Path) -> Result<RepoSurvey> {
+    survey_with_path(cache, None)
+}
+
+/// Survey a clone. When `path` is set, walk that relative directory instead of
+/// `.agents/skills` and `skills/`. Marketplace / plugin / MCP detection still
+/// uses the clone root.
+pub fn survey_with_path(cache: &Path, path: Option<&str>) -> Result<RepoSurvey> {
     let mut out = RepoSurvey::default();
 
-    // Agent Skills — reuse the existing skills_in_cache logic and enrich.
-    for (name, dir) in crate::agent_skill::skills_in_cache(cache) {
+    let found = match path {
+        Some(rel) => {
+            let rel = crate::manifest::normalize_skill_path(rel)?;
+            let root = cache.join(&rel);
+            if root.join("SKILL.md").is_file() {
+                match root.file_name().and_then(|n| n.to_str()) {
+                    Some(name) => vec![(name.to_string(), root)],
+                    None => Vec::new(),
+                }
+            } else {
+                crate::agent_skill::skills_in_dir(&root)
+            }
+        }
+        None => crate::agent_skill::skills_in_cache(cache),
+    };
+    for (name, dir) in found {
         let description = extract_description(&dir.join("SKILL.md"));
         out.agent_skills.push(SkillSummary {
             name,
@@ -367,5 +388,72 @@ mod tests {
         let s = survey(tmp.path()).unwrap();
         let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
         assert_eq!(names, vec!["real"]);
+    }
+
+    #[test]
+    fn survey_with_path_walks_non_conventional_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let oc = tmp
+            .path()
+            .join("plugins")
+            .join("llm-wiki-opencode")
+            .join("skills");
+        for name in ["wiki-manager", "wiki-query"] {
+            let d = oc.join(name);
+            fs::create_dir_all(&d).unwrap();
+            fs::write(d.join("SKILL.md"), skill_md(None)).unwrap();
+        }
+        let mp = tmp.path().join(".claude-plugin");
+        fs::create_dir_all(&mp).unwrap();
+        fs::write(mp.join("marketplace.json"), "{}").unwrap();
+
+        let default = survey(tmp.path()).unwrap();
+        assert!(default.marketplace);
+        assert!(
+            default.agent_skills.is_empty(),
+            "SKILL_ROOTS must not see plugins/*/skills"
+        );
+
+        let s = survey_with_path(tmp.path(), Some("plugins/llm-wiki-opencode/skills")).unwrap();
+        assert!(s.marketplace);
+        let names: Vec<&str> = s.agent_skills.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["wiki-manager", "wiki-query"]);
+    }
+
+    #[test]
+    fn survey_with_path_skill_dir_is_the_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = tmp
+            .path()
+            .join("plugins")
+            .join("llm-wiki-opencode")
+            .join("skills")
+            .join("wiki-manager");
+        fs::create_dir_all(&d).unwrap();
+        fs::write(d.join("SKILL.md"), skill_md(Some("OpenCode"))).unwrap();
+        let sibling = tmp
+            .path()
+            .join("plugins")
+            .join("llm-wiki-opencode")
+            .join("skills")
+            .join("wiki-query");
+        fs::create_dir_all(&sibling).unwrap();
+        fs::write(sibling.join("SKILL.md"), skill_md(None)).unwrap();
+
+        let s = survey_with_path(
+            tmp.path(),
+            Some("plugins/llm-wiki-opencode/skills/wiki-manager"),
+        )
+        .unwrap();
+        assert_eq!(s.agent_skills.len(), 1);
+        assert_eq!(s.agent_skills[0].name, "wiki-manager");
+        assert_eq!(s.agent_skills[0].description.as_deref(), Some("OpenCode"));
+    }
+
+    #[test]
+    fn survey_with_path_rejects_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = survey_with_path(tmp.path(), Some("../escape")).unwrap_err();
+        assert!(err.to_string().contains("invalid path"), "err={err}");
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4792,3 +4792,288 @@ harnesses = ["pi", "grok"]
         .stdout(predicate::str::contains("ghost-mp"))
         .stdout(predicate::str::contains("known_marketplaces.json"));
 }
+
+#[test]
+fn skill_install_llm_wiki_without_path_redirects() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    zskills(&home)
+        .args(["skill", "install", &file_url(&repo)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("marketplace add"));
+    assert!(
+        !home.path().join("skills/wiki-manager").exists(),
+        "bare install of a marketplace repo must not copy OpenCode Agent Skills"
+    );
+}
+
+#[test]
+fn skill_install_path_does_not_redirect_on_marketplace_repo() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "plugins/llm-wiki-opencode/skills",
+            "--skill",
+            "wiki-manager",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("wiki-manager"))
+        .stdout(predicate::str::contains("marketplace add").not());
+
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL
+    );
+    assert!(
+        !home.path().join("skills/wiki-query").exists(),
+        "--skill must install exactly one skill"
+    );
+    let copied = home
+        .path()
+        .join("skills/wiki-manager/references/hub-resolution.md");
+    assert!(copied.is_file(), "in-clone symlink must be a regular file");
+    assert!(!copied.symlink_metadata().unwrap().file_type().is_symlink());
+
+    let tag = format!(
+        "source:{}:plugins/llm-wiki-opencode/skills",
+        file_url(&repo)
+    );
+    assert_eq!(
+        read_inv(&home)["agent_skills"]["wiki-manager"]["source"],
+        tag
+    );
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    assert!(
+        raw.contains(&format!("source = \"{}\"", file_url(&repo))),
+        "unregistered spec must write source: {raw}"
+    );
+    assert!(raw.contains("path = \"plugins/llm-wiki-opencode/skills\""));
+    assert!(raw.contains("name = \"wiki-manager\""));
+    assert!(
+        !raw.contains("marketplace ="),
+        "unregistered spec must not write marketplace: {raw}"
+    );
+}
+
+#[test]
+fn skill_install_path_uses_registered_marketplace_not_source() {
+    let (home, _up, repo) = setup_llm_wiki_home();
+    zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "plugins/llm-wiki-opencode/skills",
+            "--skill",
+            "wiki-manager",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("marketplace add").not());
+
+    assert_eq!(
+        fs::read_to_string(home.path().join("skills/wiki-manager/SKILL.md")).unwrap(),
+        OPENCODE_WIKI_SKILL
+    );
+    assert_eq!(
+        read_inv(&home)["agent_skills"]["wiki-manager"]["source"],
+        "marketplace:llm-wiki:plugins/llm-wiki-opencode/skills"
+    );
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    assert!(
+        raw.contains("marketplace = \"llm-wiki\""),
+        "registered spec must write marketplace: {raw}"
+    );
+    assert!(raw.contains("path = \"plugins/llm-wiki-opencode/skills\""));
+    assert!(raw.contains("name = \"wiki-manager\""));
+    assert!(
+        !raw.contains("source ="),
+        "registered spec must not write source: {raw}"
+    );
+
+    let cache = home.path().join("cache/zskills/agent-skills");
+    assert!(
+        !cache.exists()
+            || fs::read_dir(&cache)
+                .map(|rd| rd.count() == 0)
+                .unwrap_or(true),
+        "must reuse the marketplace clone, not clone into the Agent Skill cache"
+    );
+}
+
+#[test]
+fn skill_install_path_parent_installs_every_skill_under_path() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "plugins/llm-wiki-opencode/skills",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("marketplace add").not());
+
+    assert!(home.path().join("skills/wiki-manager/SKILL.md").is_file());
+    assert!(home.path().join("skills/wiki-query/SKILL.md").is_file());
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    assert!(raw.contains("path = \"plugins/llm-wiki-opencode/skills\""));
+    assert!(
+        !raw.contains("name ="),
+        "all-under-path must write one unnamed row, not skills = []: {raw}"
+    );
+}
+
+#[test]
+fn skill_install_path_skill_dir_installs_one() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "plugins/llm-wiki-opencode/skills/wiki-manager",
+        ])
+        .assert()
+        .success();
+
+    assert!(home.path().join("skills/wiki-manager/SKILL.md").is_file());
+    assert!(
+        !home.path().join("skills/wiki-query").exists(),
+        "a skill-dir path must not also install sibling skills"
+    );
+}
+
+#[test]
+fn skill_install_path_unknown_skill_lists_available() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    let out = zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "plugins/llm-wiki-opencode/skills",
+            "--skill",
+            "nope",
+        ])
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8_lossy(&out);
+    assert!(stderr.contains("'nope' not found"), "{stderr}");
+    assert!(
+        stderr.contains("wiki-manager") && stderr.contains("wiki-query"),
+        "survey must walk --path: {stderr}"
+    );
+}
+
+#[test]
+fn skill_install_path_rejects_escape() {
+    let home = fake_home();
+    zskills(&home)
+        .args(["skill", "install", "owner/repo", "--path", "../escape"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid path"));
+}
+
+#[test]
+fn skill_install_path_missing_in_clone() {
+    let up = tempfile::tempdir().unwrap();
+    let repo = write_llm_wiki_repo(up.path());
+    let home = fake_home();
+    zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "does-not-exist",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn skill_install_path_large_collection_next_steps_repeat_path() {
+    // >5 under --path still aborts. Next-step commands must keep --path, or a
+    // marketplace repo redirects / surveys SKILL_ROOTS and finds nothing.
+    let up = tempfile::tempdir().unwrap();
+    let repo = up.path().join("odd-layout");
+    fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
+    fs::write(
+        repo.join(".claude-plugin").join("marketplace.json"),
+        r#"{"name":"odd","plugins":[]}"#,
+    )
+    .unwrap();
+    for i in 0..7 {
+        let d = repo
+            .join("packages")
+            .join("foo")
+            .join("skills")
+            .join(format!("skill-{i}"));
+        fs::create_dir_all(&d).unwrap();
+        fs::write(d.join("SKILL.md"), format!("---\nname: skill-{i}\n---\n")).unwrap();
+    }
+    git_init_and_commit(&repo);
+
+    let home = fake_home();
+    let out = zskills(&home)
+        .args([
+            "skill",
+            "install",
+            &file_url(&repo),
+            "--path",
+            "packages/foo/skills",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("won't install all"))
+        .stdout(predicate::str::contains("marketplace add").not())
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8_lossy(&out);
+    let path_flag = "--path packages/foo/skills";
+    assert!(
+        stdout.contains(&format!("skill install {} {path_flag} -i", file_url(&repo))),
+        "-i next step must repeat --path: {stdout}"
+    );
+    assert!(
+        stdout.contains(&format!(
+            "skill install {} {path_flag} --all",
+            file_url(&repo)
+        )),
+        "--all next step must repeat --path: {stdout}"
+    );
+    assert!(
+        !home.path().join("skills/skill-0").exists(),
+        "a large --path collection must install nothing"
+    );
+}


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `enhancement`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:medium`
- [x] Area: `area:cli`, `area:dx`

## Summary
- `nvk/llm-wiki` is a plugin marketplace. It also carries OpenCode Agent Skills under `plugins/llm-wiki-opencode/skills`. Those Agent Skills do not live at `.agents/skills` or `skills/`.
- `zskills skill install nvk/llm-wiki` used to redirect. It saw `.claude-plugin/marketplace.json`. It printed `zskills marketplace add`. It copied nothing into `~/.agents/skills/`.
- `--skill wiki-manager` did not fix this. `install_from_repo` surveyed only the default roots. The survey found zero Agent Skills. The OpenCode tree stayed invisible.
- This PR adds `--path REL` to `zskills skill install`. `--path` is sparse-intent. It is the same class as `--skill` and `-i`. A repo with `marketplace.json` still installs from `REL`. It does not redirect.
- `install_from_repo` validates `REL` before clone. It rejects `..`, an absolute path, `\`, and `:`. Then it resolves the clone. A spec that matches a registered marketplace reuses that clone. An unregistered spec clones into the Agent Skill cache.
- The survey walks `REL`. If `REL/SKILL.md` exists, that directory is the Agent Skill. Else every child with `SKILL.md` is an Agent Skill.
- A successful install appends an `[[agent_skills]]` row to the manifest.
  - `marketplace` plus `path` when the spec matches a registered marketplace. Inventory tag is `marketplace:<name>:<path>`.
  - `source` plus `path` otherwise. Inventory tag is `source:<spec>:<path>`.
  - `name` is set when `--skill` or `-i` picked names.
- An unnamed `--path` install writes one unnamed row. This is not `skills = []` from issue #54. This PR does not implement that field.
- When a collection under `REL` has more than 5 Agent Skills, the command still aborts. The next-step hints repeat `--path REL`. A hint without `--path` would redirect, or walk the default roots and find nothing.
- Example: `zskills skill install nvk/llm-wiki --path plugins/llm-wiki-opencode/skills --skill wiki-manager`.

## How It Works (diagram — REQUIRED)

`zskills skill install` takes `--path REL` on a repo spec only. A plugin spec with `--path` fails: `--path only applies to repo installs (owner/repo or git URL)`. `plugin install` and `search` pass `path: None`.

`install_from_repo` runs this sequence:

1. Call `normalize_skill_path` on `REL`. Fail before clone when the value is empty, `.`, `..`, absolute, contains `\`, or contains `:`.
2. Call `marketplace::name_for_source_spec(spec)`. That function reads `known_marketplaces.json` first, then `extraKnownMarketplaces`. It matches `owner/repo` or a git URL.
3. On a marketplace match, call `resolve_marketplace_clone`. Reuse that clone. Build `SkillOrigin::marketplace(name, Some(REL))`.
4. On no match, call `ensure_cache`. Clone into the Agent Skill cache. Build `SkillOrigin::git(spec, Some(REL))`.
5. Call `resolve_path_in_clone`. Fail when `REL` is missing inside the clone.
6. Call `survey_with_path`. Marketplace, plugin, and MCP server detection still uses the clone root. Agent Skill discovery uses `REL` instead of `.agents/skills` and `skills/`.
7. Set `sparse_intent` when `--path`, `--skill`, or `-i` is present. Skip the `marketplace.json` redirect when sparse-intent is true.
8. Select names with the existing size policy. `--skill` installs one. `-i` opens the picker. `--all` installs every name under `REL`. More than 5 names without those flags abort.
9. Call `install_from` with the origin. Copy into `~/.agents/skills/<name>/`. Follow in-clone symlinks into regular hub files.
10. Call `append_path_manifest`. Write `[[agent_skills]]` only when the origin carries `path`.

A large-collection abort prints:

```
zskills skill install <spec> --path REL -i
zskills skill install <spec> --path REL --all
```

Commit `083593d` added that repeat. The first commit omitted `--path` from those hints.

```mermaid
flowchart TD
    A["skill install SPEC --path REL"] --> B{REL valid?}
    B -->|no| C[invalid path before clone]
    B -->|yes| D{spec matches registered marketplace?}
    D -->|yes| E[reuse marketplace clone]
    D -->|no| F[clone into Agent Skill cache]
    E --> G[survey_with_path REL]
    F --> G
    G --> H{marketplace.json present and no --path?}
    H -->|yes redirect only| I[plugin install hint]
    H -->|no --path skips redirect| J[install_from]
    J --> K{marketplace match?}
    K -->|yes| L["append [[agent_skills]] marketplace plus path"]
    K -->|no| M["append [[agent_skills]] source plus path"]
```

`docs/commands.md` documents `--path REL`. The `skill` group synopsis is `zskills skill install <owner/repo> [--path REL] [--skill NAME | --all | -i]`.

## Linked Issues / ADRs
- Resolves: #62
- Part of: #57, #59
- Not #54. An unnamed `--path` row is one stanza without `name`. It is not `skills = []`.

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

```
$ cargo fmt --check
(exit 0, no diff)

$ cargo clippy --all-targets -- -D warnings
(exit 0)

$ cargo test
running 117 tests
test result: ok. 117 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 145 tests
test result: ok. 145 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

CLI tests set `CLAUDE_HOME` and `AGENTS_HOME` through `fake_home()`. `ZSKILLS_NO_CLAUDE_CLI=1` is set. The developer `~/.claude` and `~/.agents` are not used.

Fixture `write_llm_wiki_repo` is a `file://` clone shaped like `nvk/llm-wiki`. It has `.claude-plugin/marketplace.json`, a Claude plugin tree, and OpenCode Agent Skills at `plugins/llm-wiki-opencode/skills/{wiki-manager,wiki-query}`. `wiki-manager/references` is an in-clone symlink.

| Test | Result |
|---|---|
| `skill_install_llm_wiki_without_path_redirects` | Bare install prints `marketplace add`. `~/.agents/skills/wiki-manager` is absent. |
| `skill_install_path_does_not_redirect_on_marketplace_repo` | `--path` plus `--skill wiki-manager` copies the OpenCode `SKILL.md`. `wiki-query` is absent. `references/hub-resolution.md` is a regular file. Manifest has `source` plus `path` plus `name`. Inventory tag is `source:<url>:plugins/llm-wiki-opencode/skills`. No `marketplace =`. |
| `skill_install_path_uses_registered_marketplace_not_source` | Same command against a registered marketplace. Manifest has `marketplace = "llm-wiki"` plus `path` plus `name`. No `source =`. Inventory tag is `marketplace:llm-wiki:plugins/llm-wiki-opencode/skills`. Agent Skill cache stays empty. |
| `skill_install_path_parent_installs_every_skill_under_path` | `--path` without `--skill` copies `wiki-manager` and `wiki-query`. Manifest has one unnamed row. No `name =`. No `skills = []`. |
| `skill_install_path_skill_dir_installs_one` | `--path` at the `wiki-manager` directory copies that Agent Skill only. |
| `skill_install_path_unknown_skill_lists_available` | `--skill nope` fails. Stderr lists `wiki-manager` and `wiki-query` from the `--path` survey. |
| `skill_install_path_rejects_escape` | `--path ../escape` fails with `invalid path` before clone. |
| `skill_install_path_missing_in_clone` | `--path does-not-exist` fails with `not found`. |
| `skill_install_path_large_collection_next_steps_repeat_path` | 7 Agent Skills under `packages/foo/skills` abort. Stdout keeps `--path packages/foo/skills` on `-i` and `--all`. No `marketplace add`. `~/.agents/skills/` stays empty. |
| `survey_with_path_walks_non_conventional_root` | Default survey does not see `plugins/*/skills`. `--path` finds `wiki-manager` and `wiki-query`. `marketplace` stays true. |
| `survey_with_path_skill_dir_is_the_skill` | A path to one Agent Skill directory returns that name only. |
| `survey_with_path_rejects_escape` | `../escape` fails with `invalid path`. |

## Additional Notes for Reviewers
- Head: `execute-plan/7a55703f-pr-4-feat-skill-install-path-for-non-conventional-agent` at `083593d`.
- Stack parent: `execute-plan/7a55703f-pr-3b-feat-doctor-warns-when-hub-wiki-manager-is-claude` (`f5d9c27`). Unique range is `f5d9c27..083593d`.
- Commits: `d23ce20` (feat), `083593d` (review: next-step hints repeat `--path REL`).
- Depends on #57 (`path` on a source row) and #59 (`marketplace` plus `path` copy from the marketplace clone). Merge those first, or keep this PR stacked.
- `--path` does not change `plugin install`. A plugin still comes from a marketplace and lives in `~/.claude/plugins/`.
- An unnamed `--path` row means every Agent Skill under that path. Later `sync` will copy all of them. That is the intended shape until #54 adds `skills = []`.
- `--path` plus `--skill` or `-i` writes one named row per picked Agent Skill.
- Size policy is unchanged. The command installs two to five Agent Skills under `REL`. More than five names abort unless `--all`, `--skill`, or `-i` is set.
- Open the PR page and confirm the mermaid renders as a diagram, not as a plain code block.
