### PR TITLE
docs: declare llm-wiki plugin and OpenCode Agent Skills for Claude, Pi, and Grok

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,30 @@ marketplace = "claude-plugins-official"
 name = "cloudflare"
 marketplace = "cloudflare"
 
+# One source repo, two primitives. Requires zskills 1.3.0 or later.
+# Plugin for Claude. OpenCode Agent Skills for Pi and Grok.
+# Set harnesses on both rows — omit inherits [defaults].harnesses.
+[[marketplaces]]
+name = "llm-wiki"
+repo = "nvk/llm-wiki"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = ["claude"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-query"
+harnesses = ["pi", "grok"]
+
 # Agent Skills (older raw-SKILL.md format, installed to ~/.claude/skills/)
 [[agent_skills]]
 source = "jakubkrehel/make-interfaces-feel-better"
@@ -153,6 +177,8 @@ zskills sync --dry-run     # preview
 ```
 
 `zskills sync` is idempotent. Run it anywhere — same machine, new machine — and the result matches the manifest. Plugins flip via `enabledPlugins`. Agent Skills get `git clone`d and copied into `~/.claude/skills/<name>/`. Run it on every fresh checkout.
+
+The llm-wiki rows require zskills 1.3.0 or later. Set `harnesses` on both the plugin and the Agent Skill rows. Claude Code consumes plugin `wiki@llm-wiki` (`/wiki:*`). Pi and Grok consume hub Agent Skills `wiki-manager` and `wiki-query`. zskills does not install `scripts/pi-wiki-query`. zskills does not provide Grok slash `/wiki:*`. A 1.2 binary ignores `marketplace` and `path` on `[[agent_skills]]` and treats those rows as local-only. Full recipe: [Use cases](docs/use-cases.md#18-declare-llm-wiki-for-claude-code-pi-and-grok).
 
 ## Scanning project-scope skills
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -252,11 +252,18 @@ source = "owner/odd-layout"
 path = "packages/foo/skills"
 name = "foo"
 
-# Reuse a registered marketplace clone (one clone, several packaging trees)
+# Reuse a registered marketplace clone (one clone, several packaging trees).
+# Pair with [[skills]] harnesses = ["claude"] — see llm-wiki example below.
 [[agent_skills]]
 marketplace = "llm-wiki"
 path = "plugins/llm-wiki-opencode/skills"
 name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-query"
 harnesses = ["pi", "grok"]
 
 # npm-distributed package
@@ -282,7 +289,58 @@ name = "my-internal-tool"
 | `npm` | npm package name. `sync`/`upgrade` runs `npm install -g <pkg>`. |
 | `install_cmd` | Custom installer command — overrides the default `npm install -g`. Used for packages with their own setup CLI. |
 | `name` | Optional. For source entries, pick a single skill out of a multi-skill repo. For local-only entries, required — names the on-disk skill to track. |
+| `harnesses` | Optional list. Names which harnesses can see this Agent Skill. Empty inherits `[defaults].harnesses`, then every harness whose home exists. Set it on marketplace+path rows. The llm-wiki recipe uses `["pi", "grok"]` so Claude does not also get the OpenCode tree. |
 | `claims` | Glob patterns (e.g., `["gsd-*"]`) matched against `~/.agents/skills/`. After install, every match is tagged with this entry's source. Used for npm packages whose installer touches pre-existing directories — so the diff-after-install discovers nothing, but `claims` retroactively claims ownership. |
+
+### llm-wiki for Claude, Pi, and Grok
+
+`nvk/llm-wiki` is one source repo. It ships a Claude plugin and OpenCode Agent Skills. A plugin and an Agent Skill are different things. Declare both.
+
+Requires zskills 1.3.0 or later. 1.3.0 is the series after 1.2.0 that copies Agent Skills from a marketplace clone via `marketplace` and `path`. A 1.2 binary ignores unknown keys. It treats `marketplace` and `path` as absent. The `[[agent_skills]]` rows then become local-only. `sync` prints `✓ applied.` and copies nothing from the OpenCode tree.
+
+```toml
+[[marketplaces]]
+name = "llm-wiki"
+repo = "nvk/llm-wiki"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = ["claude"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-query"
+harnesses = ["pi", "grok"]
+```
+
+Set `harnesses` on both rows. Do not omit them. A plugin row that omits `harnesses` inherits `[defaults].harnesses`. If that default includes `pi` or `grok`, `sync` copies the Claude nested skill onto the hub. An Agent Skill row that omits `harnesses` inherits every harness whose home exists. That can symlink the OpenCode tree into `~/.claude/skills/`.
+
+`repo` lets `sync` clone the marketplace on a fresh machine. The Agent Skill rows reuse that clone. They do not clone `nvk/llm-wiki` a second time.
+
+Do not run `zskills skill install nvk/llm-wiki`. That command sees `.claude-plugin/marketplace.json` and redirects to `marketplace add`. Write the `[[agent_skills]]` rows.
+
+What each harness consumes:
+
+| Harness | What it consumes |
+|---|---|
+| Claude Code | Plugin `wiki@llm-wiki`. Slash commands `/wiki:*`. Nested Claude `wiki-manager`. `bin/llm-wiki` in the plugin cache. |
+| Pi | Hub Agent Skills `wiki-manager` and `wiki-query` at `~/.agents/skills/`. Invoke with `/skill:wiki-manager`. |
+| Grok | The same hub Agent Skills. Grok scans `~/.agents/skills/`. Slash `/wiki-manager` and `/wiki-query`. |
+
+What this recipe does not provide:
+
+- zskills does not install `scripts/pi-wiki-query`. That is a launcher. It is not an Agent Skill.
+- zskills does not provide Grok slash `/wiki:*`. zskills does not write `~/.grok/config.toml`. It does not install a Grok plugin.
+
+Apply with `zskills sync`. Workflow: [Use cases → Declare llm-wiki](use-cases.md#18-declare-llm-wiki-for-claude-code-pi-and-grok).
 
 ## `update`
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -327,3 +327,58 @@ zskills search next-js                # now federates to skills.sh
 ```
 
 Once you've found the name, `zskills plugin install <name>` flips it on (or appends `[[skills]]` to `skills.toml` for the declarative path).
+
+## 18. Declare llm-wiki for Claude Code, Pi, and Grok
+
+`nvk/llm-wiki` is one source repo. It ships a Claude plugin and OpenCode Agent Skills. A plugin and an Agent Skill are different things. Declare both.
+
+Requires zskills 1.3.0 or later. 1.3.0 is the series after 1.2.0 that copies Agent Skills from a marketplace clone via `marketplace` and `path`. A 1.2 binary ignores unknown keys. It treats `marketplace` and `path` as absent. The `[[agent_skills]]` rows then become local-only. `sync` prints `✓ applied.` and copies nothing from the OpenCode tree.
+
+```toml
+# ~/.config/zskills/skills.toml
+[[marketplaces]]
+name = "llm-wiki"
+repo = "nvk/llm-wiki"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = ["claude"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-query"
+harnesses = ["pi", "grok"]
+```
+
+Set `harnesses` on both rows. Do not omit them. A plugin row that omits `harnesses` inherits `[defaults].harnesses`. If that default includes `pi` or `grok`, `sync` copies the Claude nested skill onto the hub. An Agent Skill row that omits `harnesses` inherits every harness whose home exists. That can symlink the OpenCode tree into `~/.claude/skills/`.
+
+```bash
+zskills sync
+```
+
+`repo` lets `sync` clone the marketplace on a fresh machine. The Agent Skill rows reuse that clone. They do not clone `nvk/llm-wiki` a second time.
+
+Do not run `zskills skill install nvk/llm-wiki`. That command sees `.claude-plugin/marketplace.json` and redirects to `marketplace add`. Write the `[[agent_skills]]` rows.
+
+What each harness consumes:
+
+| Harness | What it consumes |
+|---|---|
+| Claude Code | Plugin `wiki@llm-wiki`. Slash commands `/wiki:*`. Nested Claude `wiki-manager`. `bin/llm-wiki` in the plugin cache. |
+| Pi | Hub Agent Skills `wiki-manager` and `wiki-query` at `~/.agents/skills/`. Invoke with `/skill:wiki-manager`. |
+| Grok | The same hub Agent Skills. Grok scans `~/.agents/skills/`. Slash `/wiki-manager` and `/wiki-query`. |
+
+What this recipe does not provide:
+
+- zskills does not install `scripts/pi-wiki-query`. That is a launcher. It is not an Agent Skill.
+- zskills does not provide Grok slash `/wiki:*`. zskills does not write `~/.grok/config.toml`. It does not install a Grok plugin.
+
+Schema: [Commands → llm-wiki for Claude, Pi, and Grok](commands.md#llm-wiki-for-claude-pi-and-grok).

--- a/skills/zskills/SKILL.md
+++ b/skills/zskills/SKILL.md
@@ -115,6 +115,13 @@ source = "jakubkrehel/make-interfaces-feel-better"
 source = "owner/multi-skill-repo"
 name = "specific-skill"
 
+# Agent Skills from a path inside a marketplace clone (zskills 1.3.0+)
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
 # npm package with glob ownership over installed directories
 [[agent_skills]]
 npm = "get-shit-done-cc"
@@ -189,6 +196,45 @@ unsupported** (no cited skills directory under `~/.kimi-code/` — zskills refus
 MCP servers are Claude-only. Pi reads the hub only once its absolute path is in
 `~/.pi/agent/settings.json` `skills: []` — `zskills skill register-pi-hub` puts it there. Hermes
 files skills by category, defaulting to `software-development` (`--category` overrides).
+
+Some source repos ship both a plugin and Agent Skills. `nvk/llm-wiki` is one. Do not fan plugin `wiki` to Pi or Grok. That copies the Claude nested skill. Claude talks about `/wiki:*`. Pi does not have `/wiki:*`. Declare the plugin with `harnesses = ["claude"]`. Declare the OpenCode Agent Skills from `plugins/llm-wiki-opencode/skills` with `harnesses = ["pi", "grok"]`. Do not rely on `[defaults].harnesses` for those rows.
+
+Requires zskills 1.3.0 or later. 1.3.0 is the series after 1.2.0 that copies Agent Skills from a marketplace clone via `marketplace` and `path`. A 1.2 binary ignores unknown keys. It treats `marketplace` and `path` as absent. The `[[agent_skills]]` rows then become local-only. `sync` prints `✓ applied.` and copies nothing from the OpenCode tree.
+
+```toml
+[[marketplaces]]
+name = "llm-wiki"
+repo = "nvk/llm-wiki"
+
+[[skills]]
+name = "wiki"
+marketplace = "llm-wiki"
+harnesses = ["claude"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-manager"
+harnesses = ["pi", "grok"]
+
+[[agent_skills]]
+marketplace = "llm-wiki"
+path = "plugins/llm-wiki-opencode/skills"
+name = "wiki-query"
+harnesses = ["pi", "grok"]
+```
+
+Set `harnesses` on both rows. Do not omit them. A plugin row that omits `harnesses` inherits `[defaults].harnesses`. An Agent Skill row that omits `harnesses` inherits every harness whose home exists.
+
+| Harness | What it consumes |
+|---|---|
+| Claude Code | Plugin `wiki@llm-wiki`. Slash commands `/wiki:*`. Nested Claude `wiki-manager`. `bin/llm-wiki` in the plugin cache. |
+| Pi | Hub Agent Skills `wiki-manager` and `wiki-query` at `~/.agents/skills/`. Invoke with `/skill:wiki-manager`. |
+| Grok | The same hub Agent Skills. Grok scans `~/.agents/skills/`. Slash `/wiki-manager` and `/wiki-query`. |
+
+zskills does not install `scripts/pi-wiki-query`. That is a launcher. It is not an Agent Skill. zskills does not provide Grok slash `/wiki:*`. zskills does not write `~/.grok/config.toml`. It does not install a Grok plugin.
+
+Do not run `zskills skill install nvk/llm-wiki`. That command sees `.claude-plugin/marketplace.json` and redirects to `marketplace add`. Write the `[[agent_skills]]` rows. Apply with `zskills sync`.
 
 ### Secret handling
 


### PR DESCRIPTION
## Labels (REQUIRED)
- [x] Type: `documentation`
- [x] Priority: `priority:medium`
- [x] Size: `t-shirt:small`
- [x] Area: `area:docs`

## Summary
- This PR documents the llm-wiki recipe in the manifest `skills.toml`.
- `nvk/llm-wiki` is one source repo. It ships a Claude plugin and OpenCode Agent Skills. A plugin and an Agent Skill are different things. Declare both.
- Parser code is not in this PR. Issue #59 implements `marketplace` and `path` on `[[agent_skills]]`. This PR teaches that recipe.
- The docs require zskills 1.3.0 or later. 1.3.0 is the series after 1.2.0. A 1.2 binary ignores `marketplace` and `path` on Agent Skill rows. It treats those rows as local-only. `sync` then prints `✓ applied.` and copies nothing from the OpenCode tree.
- Set `harnesses` on the plugin row and on the Agent Skill rows. Do not omit them. Do not fan plugin `wiki` to Pi or Grok.
- Four files change. `README.md` adds the example and a short version warning. `docs/commands.md` adds `harnesses` to the Agent Skill field table. It also adds the full recipe. `docs/use-cases.md` adds use case 18. `skills/zskills/SKILL.md` repeats the same recipe for the shipped Agent Skill.

## How It Works (diagram — REQUIRED)

The user writes four kinds of row in the manifest `skills.toml`.

1. `[[marketplaces]]` registers marketplace `llm-wiki` from repo `nvk/llm-wiki`.
2. `[[skills]]` names plugin `wiki` from that marketplace. `harnesses = ["claude"]` limits it to Claude.
3. Two `[[agent_skills]]` rows name `wiki-manager` and `wiki-query`. Each row sets `marketplace = "llm-wiki"` and `path = "plugins/llm-wiki-opencode/skills"`. Each row sets `harnesses = ["pi", "grok"]`.

`sync` clones the marketplace once. The plugin row writes `wiki@llm-wiki` into `enabledPlugins`. The Agent Skill rows copy from that same clone onto the hub at `~/.agents/skills/`. They do not clone `nvk/llm-wiki` a second time.

Do not run `zskills skill install nvk/llm-wiki`. That command sees `.claude-plugin/marketplace.json` and redirects to `marketplace add`. Write the `[[agent_skills]]` rows.

If a plugin row omits `harnesses`, it inherits `[defaults].harnesses`. If that default includes `pi` or `grok`, `sync` copies the Claude nested skill onto the hub. Claude talks about `/wiki:*`. Pi does not have `/wiki:*`.

If an Agent Skill row omits `harnesses`, it inherits every harness whose home exists. That can symlink the OpenCode tree into `~/.claude/skills/`.

What each harness consumes:

- Claude consumes plugin `wiki@llm-wiki`. Slash commands are `/wiki:*`. Nested Claude `wiki-manager` and `bin/llm-wiki` live in the plugin cache.
- Pi consumes hub Agent Skills `wiki-manager` and `wiki-query` at `~/.agents/skills/`. Invoke with `/skill:wiki-manager`.
- Grok consumes the same hub Agent Skills. Grok scans `~/.agents/skills/`. Slash names are `/wiki-manager` and `/wiki-query`.

What this recipe does not provide:

- zskills does not install `scripts/pi-wiki-query`. That path is a launcher. It is not an Agent Skill.
- zskills does not provide Grok slash `/wiki:*`. zskills does not write `~/.grok/config.toml`. It does not install a Grok plugin.

The four files carry the same recipe. A user who reads only one file still sees the version gate. That user also sees the `harnesses` rule.

- `README.md` is the short copy. It links to use case 18.
- `docs/commands.md` is the schema home.
- `docs/use-cases.md` is the workflow. It shows `zskills sync` after the recipe.
- `skills/zskills/SKILL.md` is the in-product copy. Agents that load the shipped Agent Skill must see the same keys.

```mermaid
flowchart LR
    Manifest["skills.toml recipe"] --> Plugin["plugin wiki@llm-wiki"]
    Manifest --> Hub["hub wiki-manager and wiki-query"]
    Plugin --> Claude["Claude /wiki:*"]
    Hub --> Pi["Pi via ~/.pi/agent/settings.json skills"]
    Hub --> Grok["Grok scans ~/.agents/skills"]
```

## Linked Issues / ADRs
- Resolves: #61
- Part of: #59

## Testing Evidence
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Ran the built binary against a sandboxed `CLAUDE_HOME` (state-changing commands only)

This PR is docs only. Parser code did not change. No state-changing command ran. The sandbox checkbox stays unchecked because no command writes `~/.claude/` or `~/.agents/`.

On the stack tip:

```
$ cargo fmt --check
(exit 0)

$ cargo clippy --all-targets -- -D warnings
(exit 0)

$ cargo test
117 unit tests passed
145 CLI tests passed
including shipped_skill_md_teaches_no_removed_verb
```

`shipped_skill_md_teaches_no_removed_verb` reads `skills/zskills/SKILL.md`. That file is in this diff. The test still passes.

## Additional Notes for Reviewers
- Depends on #59. Land the parser before a release that ships this recipe. A 1.2 binary that reads this recipe ignores `marketplace` and `path` on the Agent Skill rows.
- This commit is `c336ed0`, cherry-picked from `885e9c8`. Stack parent is PR 4 (`execute-plan/7a55703f-pr-4-feat-skill-install-path-for-non-conventional-agent`).
- Open the GitHub PR page and confirm the mermaid renders as a diagram.
