### PR TITLE
fix: plugin remove and purge clear manifest intent, not just state

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,7 +78,7 @@ zskills plugin install -i                           # interactive picker over ma
 
 ## `remove` / `purge`
 
-`remove` is apt-style: disable in `enabledPlugins` and drop the inventory entry, but leave bytes on disk so re-enabling is instant. `purge` does the same plus deletes the bytes from `~/.claude/plugins/cache/`.
+`remove` is apt-style: disable in `enabledPlugins`, drop the inventory entry, and drop the matching `[[skills]]` row from the manifest so `sync` does not re-enable the plugin. Bytes stay on disk so re-enabling is instant. `purge` does the same plus deletes the bytes from `~/.claude/plugins/cache/`.
 
 ```
 zskills plugin remove <name>...

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -1,4 +1,4 @@
-//! `remove` (apt-style: disable + drop inventory entry, keep bytes)
+//! `remove` (apt-style: disable + drop inventory + drop `[[skills]]` intent, keep bytes)
 //! `purge` (also delete bytes from ~/.claude/plugins/cache/.../<plugin>)
 
 use anyhow::Result;
@@ -56,7 +56,7 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
 
     let mut settings = crate::settings::load(&settings_path)?;
     let mut inventory = crate::inventory::load(&inventory_path)?;
-    let mut any = false;
+    let mut removed: Vec<String> = Vec::new();
     let mut failed = 0usize;
 
     for spec in &specs {
@@ -100,7 +100,7 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
             failed += 1;
             continue;
         }
-        any = true;
+        removed.push(qualified.clone());
 
         if purge_bytes {
             for p in &install_paths {
@@ -118,7 +118,18 @@ pub fn run(specs: Vec<String>, interactive: bool, purge_bytes: bool) -> Result<(
         }
     }
 
-    if any {
+    if !removed.is_empty() {
+        // Intent first: a later state-save failure must not leave a [[skills]]
+        // row that `sync` would re-enable.
+        if let Some(path) = crate::manifest::discover() {
+            for q in &removed {
+                let (name, mp) = match q.rsplit_once('@') {
+                    Some((n, m)) => (n, Some(m)),
+                    None => (q.as_str(), None),
+                };
+                crate::manifest::drop_skill(&path, name, mp)?;
+            }
+        }
         crate::settings::save(&settings_path, &settings)?;
         crate::inventory::save(&inventory_path, &inventory)?;
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1040,6 +1040,43 @@ pub fn drop_named_agent_skill(path: &Path, name: &str) -> Result<bool> {
     Ok(true)
 }
 
+/// Drop a `[[skills]]` row whose `name` and `marketplace` match.
+///
+/// A missing `marketplace` on the row matches only when `marketplace` is `None`.
+/// Unrelated tables, comments, and formatting survive via `toml_edit`.
+pub fn drop_skill(path: &Path, name: &str, marketplace: Option<&str>) -> Result<bool> {
+    use toml_edit::{DocumentMut, Item};
+
+    if !path.exists() {
+        return Ok(false);
+    }
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading manifest {}", path.display()))?;
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
+
+    let Some(Item::ArrayOfTables(aot)) = doc.get_mut("skills") else {
+        return Ok(false);
+    };
+    let mut idx = None;
+    for (i, t) in aot.iter().enumerate() {
+        let n = t.get("name").and_then(|v| v.as_str());
+        let mp = t.get("marketplace").and_then(|v| v.as_str());
+        if n == Some(name) && mp == marketplace {
+            idx = Some(i);
+            break;
+        }
+    }
+    let Some(i) = idx else {
+        return Ok(false);
+    };
+    aot.remove(i);
+    std::fs::write(path, doc.to_string())
+        .with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(true)
+}
+
 #[cfg(test)]
 mod marketplace_pin_tests {
     use super::*;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3313,6 +3313,55 @@ fn plugin_remove_unknown_name_does_not_print_success() {
 }
 
 #[test]
+fn plugin_remove_clears_manifest_intent() {
+    let home = fake_home();
+    let dir = home.path().join("config").join("zskills");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("skills.toml"),
+        "# keep this comment\n\
+         \n\
+         [[marketplaces]]\n\
+         name = \"test-mp\"\n\
+         repo = \"owner/test-mp\"\n\
+         \n\
+         [[skills]]\n\
+         name = \"foo\"\n\
+         marketplace = \"test-mp\"\n\
+         harnesses = [\"claude\"]\n\
+         \n\
+         [[skills]]\n\
+         name = \"keepme\"\n\
+         marketplace = \"test-mp\"\n\
+         harnesses = [\"claude\"]\n",
+    )
+    .unwrap();
+
+    zskills(&home)
+        .args(["plugin", "remove", "foo"])
+        .assert()
+        .success();
+
+    let toml = fs::read_to_string(dir.join("skills.toml")).unwrap();
+    assert!(
+        !toml.contains("name = \"foo\""),
+        "plugin remove must drop the [[skills]] row so sync cannot resurrect it:\n{toml}"
+    );
+    assert!(
+        toml.contains("name = \"keepme\""),
+        "plugin remove must leave neighbouring [[skills]] rows:\n{toml}"
+    );
+    assert!(
+        toml.contains("name = \"test-mp\""),
+        "plugin remove must leave [[marketplaces]]:\n{toml}"
+    );
+    assert!(
+        toml.contains("# keep this comment"),
+        "plugin remove must preserve comments via toml_edit:\n{toml}"
+    );
+}
+
+#[test]
 fn mcp_add_and_remove_write_intent_then_runtime() {
     let (parent, claude_home) = fake_home_nested();
     let manifest_dir = parent.path().join("config").join("zskills");


### PR DESCRIPTION
Closes #41

`skills.toml` is intent. `settings.json` and `installed_plugins.json` are state. `sync` makes state match intent. So a remove that edits only state gets undone by the next reconcile.

## Before

```console
$ zskills plugin remove pxpipe
- removed plugin pxpipe@acme

$ grep -c 'name = "pxpipe"' skills.toml
1

$ zskills sync --dry-run
Plan
  + enable  plugin  pxpipe@acme
```

`plugin purge` had the same problem.

## The change

`manifest.rs` already had `drop_mcp` and `drop_named_agent_skill`, but nothing for a `[[skills]]` row, so `remove.rs` had nothing to call. This adds that helper, written with `toml_edit` so unrelated rows, comments and formatting survive. `plugin remove` and `plugin purge` both call it in the same operation as the state edit.

The source-only refusal in `agent_skills.rs` is deliberately unchanged. One source row can own several skills, so dropping it because a single skill was removed would silently unmanage its siblings. There is a test for that, so it cannot be quietly relaxed later.

## Checked

Each of these ran against a throwaway `HOME`, so no real `~/.config/zskills/skills.toml` was touched.

- remove of an installed plugin drops its row and exits 0
- `sync --dry-run` afterwards no longer plans `+ enable`
- neighbouring rows and the marketplace entry survive
- an `[[agent_skills]]` row is untouched
- `skill remove` still refuses a source-only row
- `plugin purge` clears the row too
- `cargo test`: 147 passed, 0 failed

New test: `plugin_remove_clears_manifest_intent`.