### PR TITLE
fix(list): tag the source kind for single-skill sources too

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -250,6 +250,45 @@ fn print_empty_plugin_hint() {
     );
 }
 
+/// Kind for the human `list` source column.
+///
+/// Prefix checks run before the `contains('/')` github heuristic so a
+/// self-tagged source such as `source:owner/repo:skills/x` is not restamped.
+fn source_kind(source: &str) -> Option<&'static str> {
+    if source.starts_with("npm:") {
+        return Some("npm");
+    }
+    if source.starts_with("source:")
+        || source.starts_with("marketplace:")
+        || source.starts_with("plugin:")
+    {
+        return None;
+    }
+    if source == "local" {
+        return Some("local");
+    }
+    if source.starts_with("https://")
+        || source.starts_with("http://")
+        || source.starts_with("git://")
+        || source.starts_with("ssh://")
+        || source.starts_with("git@")
+    {
+        return Some("git");
+    }
+    if source.contains('/') {
+        return Some("github");
+    }
+    None
+}
+
+/// Prefix `github:` or `git:` when the source does not already name its kind.
+fn source_display(source: &str) -> String {
+    match source_kind(source) {
+        Some(kind @ ("github" | "git")) => format!("{kind}:{source}"),
+        _ => source.to_string(),
+    }
+}
+
 fn print_group(
     source: &str,
     names: &[String],
@@ -259,7 +298,7 @@ fn print_group(
 ) {
     let count = names.len();
     if count == 1 {
-        // Single skill from a source: "✓ <skill>  ← <source>  (<path>)"
+        // Single skill from a source: "✓ <skill>  ← <kind:source>"
         let path_suffix = if paths {
             agent_skill_path_suffix(&names[0], user_skills)
         } else {
@@ -269,16 +308,19 @@ fn print_group(
         println!(
             "  ✓ {}  {}{}{}",
             names[0],
-            format!("← {}", source).dimmed(),
+            format!("← {}", source_display(source)).dimmed(),
             loc.dimmed(),
             path_suffix
         );
         return;
     }
-    let (label, kind) = match source.split_once(':') {
-        Some(("npm", pkg)) => (pkg.to_string(), "npm"),
-        _ if source.contains('/') => (source.to_string(), "github"),
-        _ => (source.to_string(), source),
+    let (label, kind) = match source_kind(source) {
+        Some("npm") => (
+            source.strip_prefix("npm:").unwrap_or(source).to_string(),
+            "npm",
+        ),
+        Some(kind) => (source.to_string(), kind),
+        None => (source.to_string(), source),
     };
     println!(
         "  ✓ {} {}  {}",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -501,6 +501,32 @@ fn list_groups_agent_skills_by_source() {
 }
 
 #[test]
+fn list_single_skill_source_shows_kind() {
+    let home = fake_home();
+    let user_skills = home.path().join("skills");
+    fs::create_dir_all(user_skills.join("solo")).unwrap();
+    fs::write(user_skills.join("solo").join("SKILL.md"), "# solo\n").unwrap();
+
+    let inv = json!({
+        "version": 1,
+        "agent_skills": {
+            "solo": {"source": "owner/solo-repo", "installed_at": "@0", "head_sha": "abc"}
+        }
+    });
+    fs::write(
+        user_skills.join(".zskills.json"),
+        serde_json::to_string_pretty(&inv).unwrap(),
+    )
+    .unwrap();
+
+    zskills(&home)
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("← github:owner/solo-repo"));
+}
+
+#[test]
 fn upgrade_runs_without_marketplaces_or_manifest() {
     // Smoke test: upgrade against an empty fake home should succeed and print the
     // "Upgrade complete" line.


### PR DESCRIPTION
Closes #19

`zskills list` classified a source's kind only on the multi-skill path. A source providing exactly one Agent Skill hit an early return at `src/commands/list.rs:261` that printed the raw inventory string and returned at `:276`, before any classification ran. So a bare `owner/repo` never showed that it was a git source.

The classification it skipped was also wrong for non-GitHub git URLs: it stamped `github` on anything.

## Before

```
✓ solo  ← owner/solo-repo                    single skill, no kind
✓ owner/pair-repo (2 skills)  ← github       grouped, classified
✓ https://gitlab.com/o/r (2 skills)  ← github   wrong, not github
```

## The change

Both paths now classify, and the classifier distinguishes GitHub from other git hosts, including `ssh` and bare `https` remotes. A local path source is not relabelled.

## Checked

- a single-skill `owner/repo` source shows a git kind
- a GitLab URL shows git, not github, on both the single and grouped paths
- an `scp`-style remote is recognised
- a self-tagged `source:` string is not stamped twice
- multi-skill output is otherwise unchanged
- `cargo test`: all passing

New test covers the single-skill path.