### PR TITLE
fix(doctor): inspect the harness skill roots it installs into

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -169,6 +169,13 @@ pub fn run(fix: bool) -> Result<()> {
     issues += check_claude_flavored_hub();
     issues += check_agent_skill_path_and_marketplace(&known);
 
+    let harness_findings = scan_harness_skill_roots();
+    issues += harness_findings.len();
+    fixable += harness_findings.iter().filter(|f| f.fixable()).count();
+    for f in &harness_findings {
+        f.print();
+    }
+
     if issues == 0 {
         println!(
             "{} All good — disk, inventory, and settings are in sync.",
@@ -235,6 +242,12 @@ pub fn run(fix: bool) -> Result<()> {
                     fixed += 1;
                 }
                 Err(e) => println!("  {} could not re-install {}: {}", "✗".red(), name, e),
+            }
+        }
+
+        for f in &harness_findings {
+            if f.repair() {
+                fixed += 1;
             }
         }
 
@@ -660,6 +673,225 @@ fn clone_dir_for(entry: &crate::manifest::AgentSkillEntry) -> Option<std::path::
     let (_, name) = crate::agent_skill::parse_source(src).ok()?;
     let cache = crate::paths::agent_skills_cache_dir().ok()?.join(name);
     cache.is_dir().then_some(cache)
+}
+
+enum HarnessRootKind {
+    Dangling { target: std::path::PathBuf },
+    Malformed,
+    Shadow { newer: std::path::PathBuf },
+    Fossil,
+}
+
+struct HarnessRootFinding {
+    path: std::path::PathBuf,
+    kind: HarnessRootKind,
+}
+
+impl HarnessRootFinding {
+    fn fixable(&self) -> bool {
+        matches!(
+            self.kind,
+            HarnessRootKind::Dangling { .. } | HarnessRootKind::Fossil
+        )
+    }
+
+    fn print(&self) {
+        match &self.kind {
+            HarnessRootKind::Dangling { target } => {
+                println!(
+                    "{} dangling symlink {} → {}",
+                    "✗".red(),
+                    self.path.display(),
+                    target.display()
+                );
+            }
+            HarnessRootKind::Malformed => {
+                println!(
+                    "{} malformed Agent Skill {}",
+                    "✗".red(),
+                    self.path.display()
+                );
+            }
+            HarnessRootKind::Shadow { newer } => {
+                println!(
+                    "{} {} shadows the hub copy (newer: {})",
+                    "✗".red(),
+                    self.path.display(),
+                    newer.display()
+                );
+            }
+            HarnessRootKind::Fossil => {
+                println!("{} fossil inventory {}", "✗".red(), self.path.display());
+            }
+        }
+    }
+
+    fn repair(&self) -> bool {
+        match self.kind {
+            HarnessRootKind::Dangling { .. } => {
+                let Ok(meta) = std::fs::symlink_metadata(&self.path) else {
+                    return false;
+                };
+                if !meta.file_type().is_symlink() {
+                    return false;
+                }
+                if std::fs::remove_file(&self.path).is_err() {
+                    return false;
+                }
+                println!("  unlinked dangling symlink {}", self.path.display());
+                true
+            }
+            HarnessRootKind::Fossil => {
+                if self.path.file_name() != Some(std::ffi::OsStr::new(".zskills.json")) {
+                    return false;
+                }
+                let Ok(meta) = std::fs::symlink_metadata(&self.path) else {
+                    return false;
+                };
+                if meta.file_type().is_dir() {
+                    return false;
+                }
+                if std::fs::remove_file(&self.path).is_err() {
+                    return false;
+                }
+                println!("  removed fossil inventory {}", self.path.display());
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+fn scan_harness_skill_roots() -> Vec<HarnessRootFinding> {
+    let Ok(hub) = crate::paths::user_skills_dir() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for h in [
+        crate::harness::Harness::Claude,
+        crate::harness::Harness::Pi,
+        crate::harness::Harness::Hermes,
+        crate::harness::Harness::Kimi,
+        crate::harness::Harness::Grok,
+        crate::harness::Harness::Codex,
+    ] {
+        let roots = match h.skill_roots() {
+            Ok(Some(r)) => r,
+            _ => continue,
+        };
+        for root in roots {
+            if !root.is_dir() {
+                continue;
+            }
+            if root == hub {
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(&root) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                if let Some(finding) = classify_harness_entry(&entry.path(), &hub) {
+                    out.push(finding);
+                }
+            }
+        }
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    out
+}
+
+fn classify_harness_entry(
+    path: &std::path::Path,
+    hub: &std::path::Path,
+) -> Option<HarnessRootFinding> {
+    let name = path.file_name()?;
+    if name == ".zskills.json" {
+        let meta = std::fs::symlink_metadata(path).ok()?;
+        if meta.file_type().is_dir() {
+            return None;
+        }
+        return Some(HarnessRootFinding {
+            path: path.to_path_buf(),
+            kind: HarnessRootKind::Fossil,
+        });
+    }
+    if name.to_str()?.starts_with('.') {
+        return None;
+    }
+
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if meta.file_type().is_symlink() {
+        let target = std::fs::read_link(path).ok()?;
+        if std::fs::metadata(path).is_err() {
+            return Some(HarnessRootFinding {
+                path: path.to_path_buf(),
+                kind: HarnessRootKind::Dangling { target },
+            });
+        }
+        return None;
+    }
+    if !meta.file_type().is_dir() {
+        return None;
+    }
+
+    let skill_md = path.join("SKILL.md");
+    let text = match std::fs::read_to_string(&skill_md) {
+        Ok(t) => t,
+        Err(_) => {
+            return Some(HarnessRootFinding {
+                path: path.to_path_buf(),
+                kind: HarnessRootKind::Malformed,
+            });
+        }
+    };
+    if !skill_md_has_name(&text) {
+        return Some(HarnessRootFinding {
+            path: path.to_path_buf(),
+            kind: HarnessRootKind::Malformed,
+        });
+    }
+
+    let hub_copy = hub.join(name);
+    if hub_copy == *path {
+        return None;
+    }
+    let hub_md = hub_copy.join("SKILL.md");
+    let Ok(hub_bytes) = std::fs::read(&hub_md) else {
+        return None;
+    };
+    if hub_bytes == text.as_bytes() {
+        return None;
+    }
+    let newer = if copy_mtime(path) >= copy_mtime(&hub_copy) {
+        path.to_path_buf()
+    } else {
+        hub_copy
+    };
+    Some(HarnessRootFinding {
+        path: path.to_path_buf(),
+        kind: HarnessRootKind::Shadow { newer },
+    })
+}
+
+fn skill_md_has_name(text: &str) -> bool {
+    let Some(fm) = yaml_frontmatter(text) else {
+        return false;
+    };
+    fm.lines().any(|line| {
+        line.trim_start()
+            .strip_prefix("name:")
+            .is_some_and(|v| !v.trim().trim_matches(['"', '\'']).is_empty())
+    })
+}
+
+fn copy_mtime(dir: &std::path::Path) -> std::time::SystemTime {
+    let dir_t = std::fs::metadata(dir)
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+    let md_t = std::fs::metadata(dir.join("SKILL.md"))
+        .and_then(|m| m.modified())
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+    dir_t.max(md_t)
 }
 
 #[cfg(test)]

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -161,6 +161,20 @@ impl Harness {
         }
     }
 
+    /// Skill directories this harness loads from, independent of any skill name.
+    ///
+    /// `None` when the hub is enough (Pi, Grok) or the harness is unsupported
+    /// (Kimi). Hermes returns one path per category directory that currently
+    /// exists; a missing `skills/` directory is an empty list, not an error.
+    pub fn skill_roots(self) -> Result<Option<Vec<PathBuf>>> {
+        match self {
+            Self::Pi | Self::Grok | Self::Kimi => Ok(None),
+            Self::Claude => Ok(Some(vec![crate::paths::claude_home()?.join("skills")])),
+            Self::Codex => Ok(Some(vec![crate::paths::codex_home()?.join("skills")])),
+            Self::Hermes => Ok(Some(hermes_category_roots()?)),
+        }
+    }
+
     /// True when a hub copy is required as the symlink source or as the scan root.
     pub fn needs_hub_copy(self) -> bool {
         self.uses_hub() || matches!(self, Self::Codex | Self::Hermes)
@@ -169,6 +183,32 @@ impl Harness {
 
 /// Default Hermes category. `--category` overrides this. Do not invent others.
 pub const DEFAULT_HERMES_CATEGORY: &str = "software-development";
+
+fn hermes_category_roots() -> Result<Vec<PathBuf>> {
+    let skills = crate::paths::hermes_home()?.join("skills");
+    let mut roots = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&skills) else {
+        return Ok(roots);
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if !ft.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        roots.push(path);
+    }
+    roots.sort();
+    Ok(roots)
+}
 
 pub fn validate_hermes_category(category: &str) -> Result<()> {
     anyhow::ensure!(!category.is_empty(), "category must not be empty");
@@ -1027,6 +1067,62 @@ mod tests {
                 .join("devops")
                 .join("demo")
         );
+    }
+
+    #[test]
+    fn skill_roots_lists_existing_hermes_categories() {
+        let _guard = crate::paths::HOME_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(
+            root.join("hermes")
+                .join("skills")
+                .join("software-development"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("hermes").join("skills").join("devops")).unwrap();
+        let keys = [
+            ("CLAUDE_HOME", root.join("claude")),
+            ("CODEX_HOME", root.join("codex")),
+            ("HERMES_HOME", root.join("hermes")),
+        ];
+        // SAFETY: held under HOME_ENV_LOCK; restored before the guard drops.
+        let prev: Vec<_> = keys
+            .iter()
+            .map(|(k, v)| {
+                let old = std::env::var_os(k);
+                std::env::set_var(k, v);
+                (*k, old)
+            })
+            .collect();
+        let claude = Harness::Claude.skill_roots().unwrap().unwrap();
+        let codex = Harness::Codex.skill_roots().unwrap().unwrap();
+        let hermes = Harness::Hermes.skill_roots().unwrap().unwrap();
+        let pi = Harness::Pi.skill_roots().unwrap();
+        let grok = Harness::Grok.skill_roots().unwrap();
+        let kimi = Harness::Kimi.skill_roots().unwrap();
+        for (k, old) in prev {
+            match old {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+        assert_eq!(claude, vec![root.join("claude").join("skills")]);
+        assert_eq!(codex, vec![root.join("codex").join("skills")]);
+        assert_eq!(
+            hermes,
+            vec![
+                root.join("hermes").join("skills").join("devops"),
+                root.join("hermes")
+                    .join("skills")
+                    .join("software-development"),
+            ]
+        );
+        assert!(pi.is_none());
+        assert!(grok.is_none());
+        assert!(kimi.is_none());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2567,6 +2567,174 @@ fn doctor_fix_converges_and_does_not_count_unfixable_findings_as_failures() {
         .stdout(predicate::str::contains("still open").not());
 }
 
+fn write_named_skill(dir: &std::path::Path, name: &str, body: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {name}\n---\n{body}\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn doctor_reports_dangling_harness_symlink_with_its_target() {
+    let (parent, claude_home) = fake_home_nested();
+    let claude_skills = claude_home.join("skills");
+    fs::create_dir_all(&claude_skills).unwrap();
+    let ghost = claude_skills.join("ghostpack");
+    let target = "/nonexistent/zskills-test-dangle";
+    std::os::unix::fs::symlink(target, &ghost).unwrap();
+
+    let out = zskills_nested(&parent, &claude_home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(
+        s.contains(&ghost.display().to_string()),
+        "dangling entry path missing from:\n{s}"
+    );
+    assert!(s.contains(target), "stored link target missing from:\n{s}");
+}
+
+#[test]
+fn doctor_reports_hub_shadow_and_names_the_newer_side() {
+    let (parent, claude_home) = fake_home_nested();
+    let hub = parent.path().join(".agents").join("skills").join("dupe");
+    let harness = claude_home.join("skills").join("dupe");
+    write_named_skill(&hub, "dupe", "hub copy");
+    write_named_skill(&harness, "dupe", "harness copy, diverged");
+
+    let older = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_767_225_600);
+    let newer = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_785_484_800);
+    fs::File::open(hub.join("SKILL.md"))
+        .unwrap()
+        .set_modified(older)
+        .unwrap();
+    fs::File::open(&hub).unwrap().set_modified(older).unwrap();
+    fs::File::open(harness.join("SKILL.md"))
+        .unwrap()
+        .set_modified(newer)
+        .unwrap();
+    fs::File::open(&harness)
+        .unwrap()
+        .set_modified(newer)
+        .unwrap();
+
+    let out = zskills_nested(&parent, &claude_home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8_lossy(&out);
+    let token = format!("newer: {}", harness.display());
+    assert!(s.contains(&token), "expected `{token}` in:\n{s}");
+}
+
+#[test]
+fn doctor_fix_clears_dangling_links_and_fossil_inventory() {
+    let (parent, claude_home) = fake_home_nested();
+    let hub_root = parent.path().join(".agents").join("skills");
+    let claude_skills = claude_home.join("skills");
+    fs::create_dir_all(&hub_root).unwrap();
+    fs::create_dir_all(&claude_skills).unwrap();
+
+    write_named_skill(&hub_root.join("goodskill"), "goodskill", "hub body");
+    write_named_skill(&claude_skills.join("mystuff"), "mystuff", "hand written");
+    write_named_skill(&hub_root.join("dupe"), "dupe", "hub copy");
+    write_named_skill(
+        &claude_skills.join("dupe"),
+        "dupe",
+        "harness copy, diverged",
+    );
+    fs::write(
+        hub_root.join(".zskills.json"),
+        r#"{"version":1,"agent_skills":{}}"#,
+    )
+    .unwrap();
+    fs::write(
+        claude_skills.join(".zskills.json"),
+        r#"{"version":1,"agent_skills":{"gsd-fossil":{"source":"source:acme/skills:skills/gsd-fossil","installed_at":"@1788143572","head_sha":"deadbeef","to":["claude"]}}}"#,
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(hub_root.join("goodskill"), claude_skills.join("goodskill"))
+        .unwrap();
+    std::os::unix::fs::symlink(
+        "/nonexistent/zskills-test-fix",
+        claude_skills.join("ghostpack"),
+    )
+    .unwrap();
+
+    zskills_nested(&parent, &claude_home)
+        .args(["doctor", "--fix"])
+        .assert()
+        .success();
+
+    assert!(
+        !claude_skills.join("ghostpack").symlink_metadata().is_ok(),
+        "dangling symlink must be unlinked"
+    );
+    assert!(
+        !claude_skills.join(".zskills.json").exists(),
+        "fossil inventory must be deleted"
+    );
+    assert!(
+        claude_skills
+            .join("goodskill")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "resolving hub link must stay"
+    );
+    assert!(
+        claude_skills.join("mystuff").join("SKILL.md").is_file(),
+        "unmanaged harness dir must stay"
+    );
+    assert!(
+        claude_skills.join("dupe").join("SKILL.md").is_file(),
+        "shadow dir must stay"
+    );
+    assert!(
+        hub_root.join(".zskills.json").is_file(),
+        "live hub inventory must stay"
+    );
+}
+
+#[test]
+fn doctor_is_silent_on_collapsed_home_and_absent_harness_roots() {
+    let home = fake_home();
+    let known_path = home.path().join("plugins").join("known_marketplaces.json");
+    let mut known: serde_json::Value =
+        serde_json::from_slice(&fs::read(&known_path).unwrap()).unwrap();
+    known["test-mp"]["lastUpdated"] = json!("2026-08-20T00:00:00.000Z");
+    fs::write(&known_path, serde_json::to_string_pretty(&known).unwrap()).unwrap();
+
+    write_named_skill(
+        &home.path().join("skills").join("goodskill"),
+        "goodskill",
+        "body",
+    );
+    fs::write(
+        home.path().join("skills").join(".zskills.json"),
+        r#"{"version":1,"agent_skills":{"goodskill":{"source":"source:acme/skills:skills/goodskill","installed_at":"@1788143572","head_sha":"deadbeef","to":["agents"]}}}"#,
+    )
+    .unwrap();
+
+    zskills(&home)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("All good"))
+        .stdout(predicate::str::contains("newer:").not())
+        .stdout(predicate::str::contains(".zskills.json").not());
+}
+
 // ---------------------------------------------------------------------------
 // Marketplace pins.
 //


### PR DESCRIPTION
Closes #39

`zskills doctor` audited the manifest, the plugin tables and the hub at `~/.agents/skills`, but never walked the per-harness skill roots it installs into. A missing or broken harness link was invisible to the one command whose job is to find exactly that.

## The change

`doctor` now walks the harness roots and distinguishes the states that need different responses:

- a link that dangles because its target was removed
- a link that resolves but points somewhere unexpected
- an entry with no `SKILL.md`, or one whose `SKILL.md` has no `name`
- a harness copy that has diverged from the hub, reported with the direction of the drift
- a stale `.zskills.json` left under a harness root

It stays silent for a harness that is not configured, so an unused harness is never reported as broken. Hermes' extra category nesting is handled.

`doctor --fix` removes the dangling link and the stale inventory. A divergent copy is reported but not auto-resolved, because picking a winner there is a judgement call, so `--fix` reports success without silently overwriting anyone's edits.

## Checked

Against a throwaway `HOME`, one case per state above, plus:

- a healthy nested home produces no findings
- `doctor` still exits 0 when it has findings, so existing exit-code behaviour is unchanged
- `cargo test`: 149 passed, 0 failed

Four new named tests.