### PR TITLE
fix(sync): plan npm agent-skill rows instead of silently re-running them

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -194,7 +194,15 @@ pub fn run(
     // remember the source for each so we can install.
     let mut desired_named: BTreeSet<String> = BTreeSet::new();
     let mut deferred_sources: Vec<&crate::manifest::AgentSkillEntry> = Vec::new();
+    let mut npm_rows: Vec<&crate::manifest::AgentSkillEntry> = Vec::new();
     for entry in &manifest.agent_skills {
+        if entry.npm.is_some() {
+            // Apply runs npm rows unconditionally. Plan them even when
+            // claims already match inventory, or the dry-run is silent
+            // about work apply will do.
+            npm_rows.push(entry);
+            continue;
+        }
         if let Some(n) = &entry.name {
             desired_named.insert(n.clone());
         } else if entry.source.is_some() || entry.marketplace.is_some() {
@@ -390,6 +398,7 @@ pub fn run(
         && to_register.is_empty()
         && unresolved.is_empty()
         && pending_unqualified.is_empty()
+        && npm_rows.is_empty()
         && !(adopt && (!marketplaces_to_adopt.is_empty() || !marketplaces_to_fill.is_empty()));
     if nothing {
         println!("  (no changes — manifest matches current state)");
@@ -521,6 +530,33 @@ pub fn run(
             Some(p) => println!("  {} install {} ← {} ({})", "+".green(), n, label, p),
             None => println!("  {} install {} ← {}", "+".green(), n, label),
         }
+    }
+    for entry in &npm_rows {
+        let Some(pkg) = entry.npm.as_deref() else {
+            continue;
+        };
+        let tag = format!("npm:{pkg}");
+        let n = inv
+            .agent_skills
+            .iter()
+            .filter(|(name, e)| {
+                e.source == tag
+                    || entry
+                        .claims
+                        .iter()
+                        .any(|pat| crate::agent_skill::glob_match(pat, name))
+            })
+            .count();
+        println!(
+            "  {} npm:{} {}",
+            "~".cyan(),
+            pkg,
+            format!(
+                "(will run install; {n} claimed skill{} currently inventoried)",
+                if n == 1 { "" } else { "s" }
+            )
+            .dimmed()
+        );
     }
     for n in &agent_to_remove {
         if adopt {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3955,6 +3955,28 @@ fn sync_source_path_dry_run_prints_plan_line() {
 }
 
 #[test]
+fn sync_dry_run_plans_npm_agent_skill_entry() {
+    let home = fake_home();
+    wipe_plugins(&home);
+    write_manifest(
+        &home,
+        "[[agent_skills]]\nnpm = \"get-shit-done-cc\"\nclaims = [\"gsd-*\"]\n",
+    );
+
+    zskills(&home)
+        .args(["sync", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("npm:get-shit-done-cc"))
+        .stdout(predicate::str::contains("no changes — manifest matches current state").not());
+
+    assert!(
+        !home.path().join("skills/.zskills.json").exists(),
+        "dry-run must not write inventory"
+    );
+}
+
+#[test]
 fn sync_rejects_path_escape() {
     let home = fake_home();
     write_manifest(


### PR DESCRIPTION
Closes #43

The plan stage of `sync` never classified `[[agent_skills]]` rows whose only origin is npm. A dry run printed no changes while apply went on to run the npm install. A dry run that under-reports is worse than none, because it gets trusted.

## Before

```console
$ zskills sync --dry-run
Plan
  (no changes — manifest matches current state)

$ zskills sync          # installs anyway
```

## The change

npm rows are classified in the plan stage, so plan and apply agree.

Both directions are covered, because the obvious over-correction is as bad as the bug: an npm row that is already satisfied must still plan nothing. Otherwise `--dry-run` becomes permanently noisy and people stop reading it.

## Checked

Against a throwaway `HOME`:

- an npm row that is not yet installed is named in the plan, and apply performs it
- an npm row already satisfied plans nothing and does nothing
- a dry run installs nothing and rewrites no inventory
- a manifest with no npm rows that genuinely matches state still reports no changes
- `cargo test`: all passing

New test: `sync_dry_run_plans_npm_agent_skill_entry`.