### PR TITLE
feat(mcp): surface MCP servers in scan and migrate

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -379,7 +379,7 @@ Doctor never spawns or talks to an MCP server. Running-state diagnosis (whether 
 Walk a directory tree looking for project-scope skills.
 
 ```
-zskills scan [<path>] [--depth N] [--json]
+zskills scan [<path>] [--depth N] [--json] [--mcp]
 ```
 
 | Flag | Default | Description |
@@ -387,16 +387,18 @@ zskills scan [<path>] [--depth N] [--json]
 | `<path>` | `.` | Tree to walk |
 | `--depth N` | 6 | Maximum directory recursion depth |
 | `--json` | off | Machine-readable output |
+| `--mcp` | off | Also report each project's MCP servers (name and kind only; never env or header values). Without this flag, MCP-only projects are not listed and the JSON has no `mcps` key. |
 
-Detects two patterns:
+Detects:
 - `.claude/settings.json` or `.claude/settings.local.json` with `enabledPlugins` / `extraKnownMarketplaces` (project-scope plugin enables)
 - `.claude/skills/<name>/SKILL.md` (project-scope Agent Skills)
+- with `--mcp`: `<project>/.mcp.json` (wrapped `{"mcpServers": {…}}` or a flat top-level map) and `mcpServers` in `.claude/settings.json` / `settings.local.json`
 
 The default depth of 6 catches both patterns from a `~/Desktop/code`-style parent directory (Agent Skills are at depth 5 from the project root).
 
 ## `migrate`
 
-Promote ONE project's enabled plugins and project-scope Agent Skills to user scope.
+Promote ONE project's enabled plugins, project-scope Agent Skills, and MCP servers to user scope.
 
 ```
 zskills migrate <project> [--remove-from-project] [--dry-run]
@@ -404,7 +406,9 @@ zskills migrate <project> [--remove-from-project] [--dry-run]
 
 Reads `<project>/.claude/settings.json` (or `settings.local.json`) and `<project>/.claude/skills/<name>/`. Writes promoted plugin enables into `~/.claude/settings.json`'s `enabledPlugins` and copies Agent Skill directories into `~/.agents/skills/`.
 
-`--remove-from-project` clears `enabledPlugins`, `extraKnownMarketplaces`, and `.claude/skills/` from the project after a successful promote.
+MCP servers are promoted too. Sources are `<project>/.mcp.json` (both schemas), `<project>/.claude.local/settings.json`, and the `.claude/settings*.json` files above. Each raw JSON entry is copied verbatim into `~/.claude.json`, env and header values included. Plugin-provided servers are skipped. A name already present at user scope is left alone.
+
+`--remove-from-project` clears `enabledPlugins`, `extraKnownMarketplaces`, `.claude/skills/`, and promoted MCP keys from the project after a successful promote.
 
 ## `migrate-skill`
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -278,7 +278,13 @@ You've added MCP servers ad-hoc with `claude mcp add` from different projects; n
    zskills list --paths
    ```
 
-2. **Manually transcribe each into `~/.config/zskills/skills.toml`** as `[[mcps]]` entries. Use `${VAR}` refs for any credentials — never paste literal tokens.
+2. **Adopt every configured-but-unlisted MCP into the manifest:**
+
+   ```bash
+   zskills sync --adopt
+   ```
+
+   Each server becomes a `[[mcps]]` row with its transport details intact. Env and header values are copied verbatim — eyeball `skills.toml` and replace any literal secrets with `${VAR}` references before you commit it.
 
 3. **Sync with prune** to write at user scope AND delete the duplicates from other scopes:
 
@@ -287,8 +293,6 @@ You've added MCP servers ad-hoc with `claude mcp add` from different projects; n
    ```
 
 `--prune` removes MCP entries currently in settings files but absent from the manifest. **Plugin-injected MCPs are never pruned** — zskills detects them by name match against every enabled plugin's `plugin.json` / sibling `.mcp.json` and leaves them alone. **Managed scope is never written** — IT-deployed entries are read-only.
-
-A `dump-mcps` helper to skip the manual transcription step is on the roadmap (see [issue #14](https://github.com/zot24/zskills/issues/14)).
 
 ## 16. Validate MCPs before launching Claude Code
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,6 +135,10 @@ pub enum Command {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+
+        /// Also report each project's MCP servers (name + kind only; never values)
+        #[arg(long)]
+        mcp: bool,
     },
 
     /// Promote project-scope skills to user scope; optionally remove from project
@@ -489,7 +493,12 @@ impl Cli {
                 force,
             } => crate::commands::sync::run(file, dry_run, prune, adopt, force),
             Command::Doctor { fix } => crate::commands::doctor::run(fix),
-            Command::Scan { path, depth, json } => crate::commands::scan::run(path, depth, json),
+            Command::Scan {
+                path,
+                depth,
+                json,
+                mcp,
+            } => crate::commands::scan::run(path, depth, json, mcp),
             Command::Migrate {
                 path,
                 remove_from_project,

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -1,5 +1,5 @@
 //! `migrate <project>` — promote a project's enabledPlugins + extraKnownMarketplaces
-//! to user scope (~/.claude/settings.json), optionally removing them from the project.
+//! + MCP servers to user scope, optionally removing them from the project.
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
@@ -33,9 +33,12 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
         Vec::new()
     };
 
-    if project_settings_path.is_none() && project_agent_skills.is_empty() {
+    let project_mcps = crate::mcp::load_project_dir(&project);
+    let has_mcp_source = crate::mcp::project_has_mcp_sources(&project);
+
+    if project_settings_path.is_none() && project_agent_skills.is_empty() && !has_mcp_source {
         anyhow::bail!(
-            "no .claude/settings*.json or .claude/skills/ found in {}",
+            "no .claude/settings*.json, .claude/skills/, or MCP config found in {}",
             project.display()
         );
     }
@@ -103,7 +106,29 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
         }
     }
 
-    if promote_skills.is_empty() && promote_markets.is_empty() && promote_agent_skills.is_empty() {
+    // Plan: MCP servers. Promote the raw JSON entry verbatim (env/header
+    // values included). Skip plugin-provided names and names already at user
+    // scope — never overwrite the user's config with the project's.
+    let user_mcp_names = crate::mcp::user_server_names();
+    let mut promote_mcps: Vec<(String, Value, PathBuf)> = Vec::new();
+    for s in &project_mcps {
+        if matches!(s.source, crate::mcp::Source::FromPlugin { .. }) {
+            continue;
+        }
+        if user_mcp_names.contains(&s.name) {
+            continue;
+        }
+        let Some(raw) = crate::mcp::read_raw_from_file(&s.source_file, &s.name) else {
+            continue;
+        };
+        promote_mcps.push((s.name.clone(), raw, s.source_file.clone()));
+    }
+
+    if promote_skills.is_empty()
+        && promote_markets.is_empty()
+        && promote_agent_skills.is_empty()
+        && promote_mcps.is_empty()
+    {
         println!("  (everything in the project is already present at user scope — nothing to do)");
         if !remove_from_project {
             return Ok(());
@@ -117,6 +142,9 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
         }
         for (k, _) in &promote_agent_skills {
             println!("  {} promote agent skill {}", "+".green(), k);
+        }
+        for (k, _, _) in &promote_mcps {
+            println!("  {} promote mcp         {}", "+".green(), k);
         }
     }
 
@@ -137,6 +165,13 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
                 "  {} clear {} agent skill(s) from project .claude/skills/",
                 "-".yellow(),
                 project_agent_skills.len()
+            );
+        }
+        if !promote_mcps.is_empty() {
+            println!(
+                "  {} clear {} mcp(s) from project",
+                "-".yellow(),
+                promote_mcps.len()
             );
         }
     }
@@ -183,6 +218,12 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
         crate::agent_skill::save_inventory(&inv)?;
     }
 
+    // Apply: MCP servers via upsert so the user-scope target (and the
+    // managed-scope refusal) stay in write_target. Values are the raw JSON.
+    for (name, raw, _) in &promote_mcps {
+        crate::mcp::upsert(&crate::mcp::Scope::User, name, raw.clone())?;
+    }
+
     if remove_from_project {
         if let Some(p_settings) = project_settings {
             let mut p = p_settings.clone();
@@ -198,6 +239,11 @@ pub fn run(project: PathBuf, remove_from_project: bool, dry_run: bool) -> Result
             if dir.exists() {
                 std::fs::remove_dir_all(dir).ok();
             }
+        }
+        // After the settings save above, strip promoted MCP keys from their
+        // source files so a settings rewrite cannot put them back.
+        for (name, _, source_file) in &promote_mcps {
+            crate::mcp::delete_key_from_file(source_file, name)?;
         }
     }
 

--- a/src/commands/scan.rs
+++ b/src/commands/scan.rs
@@ -9,16 +9,60 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 #[derive(Debug)]
+pub struct ScanMcp {
+    pub name: String,
+    pub kind: String,
+}
+
+#[derive(Debug)]
 pub struct ProjectScan {
     pub path: PathBuf,
     pub enabled: Vec<String>,
     pub marketplaces: Vec<String>,
     /// Names of Agent Skills installed at `.claude/skills/<name>/`
     pub agent_skills: Vec<String>,
+    /// MCP servers from `.mcp.json` and `.claude/settings*.json`. Empty unless
+    /// the walk requested `--mcp`.
+    pub mcps: Vec<ScanMcp>,
+}
+
+impl ProjectScan {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            enabled: vec![],
+            marketplaces: vec![],
+            agent_skills: vec![],
+            mcps: vec![],
+        }
+    }
+}
+
+fn project_entry(
+    by_project: &mut BTreeMap<PathBuf, ProjectScan>,
+    project: PathBuf,
+) -> &mut ProjectScan {
+    by_project
+        .entry(project.clone())
+        .or_insert_with(|| ProjectScan::new(project))
+}
+
+fn merge_mcps(entry: &mut ProjectScan, servers: Vec<crate::mcp::McpServer>) {
+    for s in servers {
+        if !entry.mcps.iter().any(|m| m.name == s.name) {
+            entry.mcps.push(ScanMcp {
+                name: s.name,
+                kind: s.transport.kind().to_string(),
+            });
+        }
+    }
 }
 
 pub fn scan_path(root: &Path, max_depth: usize) -> Result<Vec<ProjectScan>> {
-    use std::collections::BTreeMap;
+    scan_path_inner(root, max_depth, false)
+}
+
+fn scan_path_inner(root: &Path, max_depth: usize, include_mcp: bool) -> Result<Vec<ProjectScan>> {
     let mut by_project: BTreeMap<PathBuf, ProjectScan> = BTreeMap::new();
 
     for entry in WalkDir::new(root)
@@ -60,20 +104,34 @@ pub fn scan_path(root: &Path, max_depth: usize) -> Result<Vec<ProjectScan>> {
                     }
                 }
 
-                if !enabled.is_empty() || !marketplaces.is_empty() {
-                    let project = parent.parent().unwrap_or(parent).to_path_buf();
-                    let entry = by_project.entry(project.clone()).or_insert(ProjectScan {
-                        path: project,
-                        enabled: vec![],
-                        marketplaces: vec![],
-                        agent_skills: vec![],
-                    });
+                let project = parent.parent().unwrap_or(parent).to_path_buf();
+                let servers = if include_mcp {
+                    crate::mcp::load_project_dir(&project)
+                } else {
+                    vec![]
+                };
+
+                if !enabled.is_empty() || !marketplaces.is_empty() || !servers.is_empty() {
+                    let entry = project_entry(&mut by_project, project);
                     entry.enabled.extend(enabled);
                     for mp in marketplaces {
                         if !entry.marketplaces.contains(&mp) {
                             entry.marketplaces.push(mp);
                         }
                     }
+                    merge_mcps(entry, servers);
+                }
+                continue;
+            }
+
+            // Match 1b: <project>/.mcp.json (wrapped or flat). Decoy `mcp.json`
+            // without the leading dot is ignored on purpose.
+            if include_mcp && name == ".mcp.json" {
+                let project = parent.to_path_buf();
+                let servers = crate::mcp::load_project_dir(&project);
+                if !servers.is_empty() {
+                    let entry = project_entry(&mut by_project, project);
+                    merge_mcps(entry, servers);
                 }
                 continue;
             }
@@ -104,12 +162,7 @@ pub fn scan_path(root: &Path, max_depth: usize) -> Result<Vec<ProjectScan>> {
                 .and_then(|p| p.parent())
                 .unwrap_or(Path::new(""))
                 .to_path_buf();
-            let entry = by_project.entry(project.clone()).or_insert(ProjectScan {
-                path: project,
-                enabled: vec![],
-                marketplaces: vec![],
-                agent_skills: vec![],
-            });
+            let entry = project_entry(&mut by_project, project);
             if !entry.agent_skills.contains(&skill_name) {
                 entry.agent_skills.push(skill_name);
             }
@@ -123,6 +176,7 @@ pub fn scan_path(root: &Path, max_depth: usize) -> Result<Vec<ProjectScan>> {
         p.marketplaces.sort();
         p.marketplaces.dedup();
         p.agent_skills.sort();
+        p.mcps.sort_by(|a, b| a.name.cmp(&b.name));
     }
     Ok(out)
 }
@@ -143,20 +197,28 @@ fn is_noise(name: &str) -> bool {
     )
 }
 
-pub fn run(path: Option<PathBuf>, depth: usize, json_out: bool) -> Result<()> {
+pub fn run(path: Option<PathBuf>, depth: usize, json_out: bool, include_mcp: bool) -> Result<()> {
     let root = path.unwrap_or_else(|| std::env::current_dir().expect("cwd"));
-    let projects = scan_path(&root, depth)?;
+    let projects = scan_path_inner(&root, depth, include_mcp)?;
 
     if json_out {
         let arr: Vec<_> = projects
             .iter()
             .map(|p| {
-                json!({
+                let mut obj = json!({
                     "path": p.path,
                     "enabled": p.enabled,
                     "marketplaces": p.marketplaces,
                     "agent_skills": p.agent_skills,
-                })
+                });
+                if include_mcp {
+                    obj["mcps"] = json!(p
+                        .mcps
+                        .iter()
+                        .map(|m| json!({ "name": m.name, "kind": m.kind }))
+                        .collect::<Vec<_>>());
+                }
+                obj
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&arr)?);
@@ -202,6 +264,9 @@ pub fn run(path: Option<PathBuf>, depth: usize, json_out: bool) -> Result<()> {
         }
         for s in &p.agent_skills {
             println!("  ◦ {}  {}", s, "(agent skill)".dimmed());
+        }
+        for m in &p.mcps {
+            println!("  mcp {} ({})", m.name, m.kind);
         }
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -10,7 +10,7 @@
 use anyhow::Result;
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -186,6 +186,105 @@ pub fn load_all() -> Result<Vec<McpServer>> {
     }
 
     Ok(out)
+}
+
+/// Load MCP servers declared in a project directory (not cwd).
+///
+/// Sources, first name wins:
+/// 1. `<project>/.claude.local/settings.json`
+/// 2. `<project>/.mcp.json` (wrapped `mcpServers` or flat map)
+/// 3. `<project>/.claude/settings.json`
+/// 4. `<project>/.claude/settings.local.json`
+///
+/// Attribution uses the same plugin index as `load_all`. Malformed entries
+/// (no `command`, no `url`) are dropped by `parse_transport`.
+pub fn load_project_dir(project: &Path) -> Vec<McpServer> {
+    let plugin_index = build_plugin_mcp_index().unwrap_or_default();
+    let attribute = |name: &str| -> Source {
+        plugin_index
+            .get(name)
+            .cloned()
+            .map(|plugin| Source::FromPlugin { plugin })
+            .unwrap_or(Source::Manual)
+    };
+
+    let mut out: Vec<McpServer> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut extend = |servers: Vec<McpServer>| {
+        for s in servers {
+            if seen.insert(s.name.clone()) {
+                out.push(s);
+            }
+        }
+    };
+
+    extend(load_settings_file(
+        &project.join(".claude.local").join("settings.json"),
+        Scope::Local,
+        &attribute,
+    ));
+    extend(load_mcp_json(
+        &project.join(".mcp.json"),
+        Scope::Project,
+        &attribute,
+    ));
+    extend(load_settings_file(
+        &project.join(".claude").join("settings.json"),
+        Scope::Project,
+        &attribute,
+    ));
+    extend(load_settings_file(
+        &project.join(".claude").join("settings.local.json"),
+        Scope::Project,
+        &attribute,
+    ));
+    out
+}
+
+/// True when the project directory has an MCP config file `migrate` should
+/// treat as a source, even if every entry later fails to parse.
+pub fn project_has_mcp_sources(project: &Path) -> bool {
+    project.join(".mcp.json").is_file()
+        || project
+            .join(".claude.local")
+            .join("settings.json")
+            .is_file()
+        || project.join(".claude").join("settings.json").is_file()
+        || project
+            .join(".claude")
+            .join("settings.local.json")
+            .is_file()
+}
+
+/// Names already declared at user scope (`~/.claude.json` and
+/// `~/.claude/settings.json`). Used by `migrate` so a project copy cannot
+/// overwrite the user's config.
+pub fn user_server_names() -> BTreeSet<String> {
+    let attribute = |_: &str| Source::Manual;
+    let mut names = BTreeSet::new();
+    for path in [
+        crate::paths::claude_json().ok(),
+        crate::paths::settings_json().ok(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        for s in load_settings_file(&path, Scope::User, &attribute) {
+            names.insert(s.name);
+        }
+    }
+    names
+}
+
+/// Read the raw JSON object for `name` from a specific file, preserving env
+/// and header values. Accepts wrapped `mcpServers` and a flat top-level map.
+pub fn read_raw_from_file(path: &Path, name: &str) -> Option<Value> {
+    let val = read_json(path)?;
+    let map = val
+        .get("mcpServers")
+        .and_then(|v| v.as_object())
+        .or_else(|| val.as_object())?;
+    map.get(name).cloned()
 }
 
 /// Load servers from a file whose top-level shape is `{"mcpServers": {...}}`.
@@ -540,7 +639,7 @@ pub fn remove(scope: &Scope, name: &str) -> Result<bool> {
     Ok(deleted)
 }
 
-fn delete_key_from_file(path: &Path, name: &str) -> Result<()> {
+pub(crate) fn delete_key_from_file(path: &Path, name: &str) -> Result<()> {
     if !path.exists() {
         return Ok(());
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -309,6 +309,135 @@ fn migrate_promotes_agent_skill_to_user_scope() {
 }
 
 #[test]
+fn scan_mcp_reports_project_mcps_without_secret_values() {
+    let (parent, claude_home) = fake_home_nested();
+    let tree = parent.path().join("tree");
+    let proj = tree.join("proj");
+    fs::create_dir_all(&proj).unwrap();
+    fs::write(
+        proj.join(".mcp.json"),
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "envsrv": {
+                    "command": "docker",
+                    "env": { "TOKEN": "sk-ENVLEAK-9911" }
+                },
+                "hdrsrv": {
+                    "type": "http",
+                    "url": "https://mcp.example.test/x",
+                    "headers": { "Authorization": "Bearer sk-HDRLEAK-9922" }
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let json_out = zskills_nested(&parent, &claude_home)
+        .args(["scan", tree.to_str().unwrap(), "--mcp", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json_text = String::from_utf8_lossy(&json_out);
+    assert!(
+        !json_text.contains("sk-ENVLEAK-9911"),
+        "JSON must not print env values: {json_text}"
+    );
+    assert!(
+        !json_text.contains("sk-HDRLEAK-9922"),
+        "JSON must not print header values: {json_text}"
+    );
+
+    let v: serde_json::Value = serde_json::from_slice(&json_out).unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let mcps = arr[0]["mcps"].as_array().unwrap();
+    let by_name: std::collections::BTreeMap<&str, &str> = mcps
+        .iter()
+        .map(|m| (m["name"].as_str().unwrap(), m["kind"].as_str().unwrap()))
+        .collect();
+    assert_eq!(by_name.get("envsrv"), Some(&"stdio"));
+    assert_eq!(by_name.get("hdrsrv"), Some(&"http"));
+
+    let human = zskills_nested(&parent, &claude_home)
+        .args(["scan", tree.to_str().unwrap(), "--mcp"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let human_text = String::from_utf8_lossy(&human);
+    assert!(human_text.contains("envsrv"));
+    assert!(human_text.contains("hdrsrv"));
+    assert!(!human_text.contains("sk-ENVLEAK-9911"));
+    assert!(!human_text.contains("sk-HDRLEAK-9922"));
+
+    // Without --mcp an MCP-only project stays invisible and the shape has no mcps key.
+    let default_out = zskills_nested(&parent, &claude_home)
+        .args(["scan", tree.to_str().unwrap(), "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let default_v: serde_json::Value = serde_json::from_slice(&default_out).unwrap();
+    assert!(default_v.as_array().unwrap().is_empty());
+}
+
+#[test]
+fn migrate_promotes_project_mcp_to_user_scope() {
+    let (parent, claude_home) = fake_home_nested();
+    let proj = parent.path().join("tree").join("proj");
+    fs::create_dir_all(proj.join(".claude.local")).unwrap();
+    fs::write(
+        proj.join(".mcp.json"),
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "pg1": {
+                    "command": "docker",
+                    "args": ["run", "pg"],
+                    "env": { "PGPASSWORD": "sk-PROMOTE-4711" }
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        proj.join(".claude.local").join("settings.json"),
+        serde_json::to_string(&json!({
+            "mcpServers": {
+                "loc1": {
+                    "type": "http",
+                    "url": "https://mcp.example.test/loc"
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    zskills_nested(&parent, &claude_home)
+        .args(["migrate", proj.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let claude_json = parent.path().join(".claude.json");
+    let v: serde_json::Value = serde_json::from_slice(&fs::read(&claude_json).unwrap()).unwrap();
+    assert_eq!(
+        v["mcpServers"]["pg1"]["env"]["PGPASSWORD"],
+        "sk-PROMOTE-4711"
+    );
+    assert_eq!(
+        v["mcpServers"]["loc1"]["url"],
+        "https://mcp.example.test/loc"
+    );
+    assert_eq!(v["mcpServers"]["pg1"]["command"], "docker");
+}
+
+#[test]
 fn list_reports_agent_skills_section() {
     let home = fake_home();
     let user_skills = home.path().join("skills");


### PR DESCRIPTION
Closes #14

`scan` and `migrate` ignored MCP servers. `scan` read `.claude/settings*.json` only for `enabledPlugins` and `extraKnownMarketplaces`; `migrate` had no MCP handling at all. A project's MCP configuration was invisible to both.

## One gap was already closed, so it is not rebuilt

The issue lists a `dump-mcps` helper as the highest-value item. `sync --adopt` already does that job: it appends `[[mcps]]` rows and preserves env and header values verbatim. Building `dump-mcps` would be a second way to do the same thing, and the two would drift on secret handling.

What this changes instead is the documentation. `docs/use-cases.md` no longer tells people to transcribe MCP entries by hand or describes `dump-mcps` as pending.

## Secrets

`src/mcp.rs` is built so display paths never hold env or header values: `keys_and_refs` drops the values and keeps only keys and `${VAR}` names. Surfacing MCPs across a whole tree of repos is exactly where that could be broken without anyone noticing, so a test plants a literal secret in a fixture and asserts it never reaches stdout.

## Checked

Against a throwaway `HOME`:

- both `.mcp.json` shapes are read, the wrapped `{"mcpServers": …}` and the flat map
- `.claude/settings.local.json` servers are picked up
- a planted secret value never appears in output
- an `.mcp.json` under `node_modules` or `target` is not reported
- migrate never writes managed scope and never promotes a plugin-supplied server
- `--dry-run` writes nothing
- `sync --adopt` behaves exactly as before
- existing scan tests still pass unchanged
- `cargo test`: all passing