### PR TITLE
chore: ignore .worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ Cargo.lock.bak
 .DS_Store
 *.swp
 /book
+
+# Worktrees for parallel work live here (cockpit d-0096).
+.worktrees/


### PR DESCRIPTION
Parallel work on separate issues uses git worktrees, one per issue, at `.worktrees/<slug>` inside this repo. Without this line every one of those checkouts shows up as untracked noise in `git status`.

Landing it once, separately, so the six concurrent issue branches do not each carry the same line and collide on it.