### PR TITLE
fix(marketplace): key a tap by its repo, not by the basename

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -458,7 +458,7 @@ zskills marketplace list [--json]
 zskills marketplace update [<name>]
 ```
 
-`add` clones the marketplace repo into `~/.claude/plugins/marketplaces/<name>/` and writes both `known_marketplaces.json` and `settings.json`'s `extraKnownMarketplaces`. Mirrors what `/plugin marketplace add` does inside Claude Code.
+`add` clones the marketplace repo into `~/.claude/plugins/marketplaces/<name>/` and writes both `known_marketplaces.json` and `settings.json`'s `extraKnownMarketplaces`. `<name>` is the `name` field in the clone's `.claude-plugin/marketplace.json`. If that file is missing, unparseable, or its `name` is not a single safe path segment, add falls back to the repo basename. Two repos that declare the same `name` collide: the second add is refused and the first tap is left as-is. Mirrors what `/plugin marketplace add` does inside Claude Code.
 
 Adding a marketplace does **not** install plugins and does **not** change the manifest. After a successful add, zskills reads `.claude-plugin/marketplace.json` and prints the plugins the marketplace offers, plus the next command.
 

--- a/src/commands/marketplace.rs
+++ b/src/commands/marketplace.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 use serde_json::Value;
 #[cfg(feature = "skills-sh")]
@@ -28,7 +28,27 @@ fn add(source: String) -> Result<()> {
     if source == REMOTE_INDEX_SKILLS_SH {
         return add_remote_index(REMOTE_INDEX_SKILLS_SH, "https://skills.sh");
     }
-    let (name, _) = crate::marketplace::parse_source(&source)?;
+    let (fallback, repo_url) = crate::marketplace::parse_source(&source)?;
+    let parent = crate::paths::marketplaces_dir()?;
+    std::fs::create_dir_all(&parent).ok();
+
+    // Clone to a staging dir first: the tap name lives in the manifest, which
+    // only exists after the clone, and the final directory must carry that name.
+    let staging_root = tempfile::Builder::new()
+        .prefix(".zskills-add-")
+        .tempdir_in(&parent)
+        .with_context(|| format!("creating staging dir under {}", parent.display()))?;
+    let staging = staging_root.path().join("src");
+    crate::git::clone(&repo_url, &staging)?;
+
+    let name = crate::marketplace::name_from_clone(&staging, &fallback);
+    let dest = parent.join(&name);
+    crate::marketplace::refuse_conflicting_registration(&name, &source, &repo_url)?;
+    if !dest.exists() {
+        std::fs::rename(&staging, &dest)
+            .with_context(|| format!("moving clone into {}", dest.display()))?;
+    }
+
     let install_location = crate::marketplace::register(&name, &source)?;
     println!("{} added marketplace {}", "✓".green(), name);
     print_add_followup(&name, &install_location);

--- a/src/git.rs
+++ b/src/git.rs
@@ -20,6 +20,23 @@ pub fn clone(url: &str, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// `git remote get-url origin`, or `None` when `repo` is not a git clone or
+/// has no `origin`. Used to refuse reusing a marketplace directory that
+/// already holds a different repo.
+pub fn origin_url(repo: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!url.is_empty()).then_some(url)
+}
+
 /// Pull from a git repo. Captures output; only surfaces errors. The destination
 /// must be a git working tree — call `is_git_repo` first if uncertain.
 pub fn pull(repo: &Path) -> Result<()> {

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -13,7 +13,7 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -137,9 +137,10 @@ pub fn is_github_owner_repo(source: &str) -> bool {
 
 /// Parse `owner/repo` or a git URL into `(derived_name, clone_url)`.
 ///
-/// `marketplace add` uses the derived name. `sync` ignores it and uses the name
-/// declared on `[[marketplaces]]`, so `name = "zot24-skills"` can point at
-/// `repo = "zot24/skills"`.
+/// `derived_name` is the repo basename. `marketplace add` uses it only when the
+/// clone's `.claude-plugin/marketplace.json` has no usable `name`. `sync`
+/// ignores it and uses the name declared on `[[marketplaces]]`, so
+/// `name = "zot24-skills"` can point at `repo = "zot24/skills"`.
 pub fn parse_source(source: &str) -> Result<(String, String)> {
     if source.contains("://") {
         let name = source
@@ -166,6 +167,135 @@ fn source_object(source: &str, repo_url: &str) -> Value {
     }
 }
 
+/// True when `name` is a single path segment we can join onto `marketplaces_dir()`.
+///
+/// Marketplace `name` is third-party text. Reject empty, `.`, `..`, slashes,
+/// backslashes, and absolute paths so a hostile manifest cannot traverse
+/// `~/.claude`.
+pub fn is_safe_tap_name(name: &str) -> bool {
+    if name.is_empty() || name == "." || name == ".." {
+        return false;
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return false;
+    }
+    let path = Path::new(name);
+    if path.is_absolute() {
+        return false;
+    }
+    let mut comps = path.components();
+    matches!(
+        (comps.next(), comps.next()),
+        (Some(Component::Normal(_)), None)
+    )
+}
+
+/// Tap key for a cloned marketplace: the manifest `name` when it is a safe
+/// path segment, otherwise `fallback` (the basename from [`parse_source`]).
+pub fn name_from_clone(clone: &Path, fallback: &str) -> String {
+    let path = clone.join(".claude-plugin").join("marketplace.json");
+    match load_manifest(&path) {
+        Ok(m) => {
+            let name = m.name.trim();
+            if is_safe_tap_name(name) {
+                name.to_string()
+            } else {
+                fallback.to_string()
+            }
+        }
+        Err(_) => fallback.to_string(),
+    }
+}
+
+fn source_label(source: &str, repo_url: &str) -> String {
+    if is_github_owner_repo(source) {
+        source.to_string()
+    } else {
+        repo_url.to_string()
+    }
+}
+
+fn entry_source_label(entry: &Value) -> Option<String> {
+    let src = entry.get("source")?;
+    match src.get("source").and_then(|v| v.as_str()) {
+        Some("github") => src.get("repo")?.as_str().map(str::to_string),
+        Some("git") => src.get("url")?.as_str().map(str::to_string),
+        _ => None,
+    }
+}
+
+fn same_recorded_source(entry: &Value, source: &str, repo_url: &str) -> bool {
+    let Some(label) = entry_source_label(entry) else {
+        return false;
+    };
+    if label == source || label == repo_url {
+        return true;
+    }
+    let existing_gh = if is_github_owner_repo(&label) {
+        Some(label)
+    } else {
+        github_from_url(&label)
+    };
+    let incoming_gh = if is_github_owner_repo(source) {
+        Some(source.to_string())
+    } else {
+        github_from_url(source).or_else(|| github_from_url(repo_url))
+    };
+    match (existing_gh, incoming_gh) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+fn git_urls_match(a: &str, b: &str) -> bool {
+    fn norm(s: &str) -> &str {
+        s.trim_end_matches('/')
+            .trim_end_matches(".git")
+            .trim_end_matches('/')
+    }
+    a == b || norm(a) == norm(b)
+}
+
+/// Refuse a registration that would overwrite a different repo's key or clone.
+///
+/// An idempotent re-add of the same source is allowed. Two repos that share a
+/// tap name are not: the incumbent entry and its directory stay untouched.
+pub fn refuse_conflicting_registration(name: &str, source: &str, repo_url: &str) -> Result<()> {
+    let known = load_known(&crate::paths::known_marketplaces_json()?)?;
+    refuse_conflict(&known, name, source, repo_url)
+}
+
+fn refuse_conflict(
+    known: &Map<String, Value>,
+    name: &str,
+    source: &str,
+    repo_url: &str,
+) -> Result<()> {
+    if let Some(existing) = known.get(name) {
+        if same_recorded_source(existing, source, repo_url) {
+            return Ok(());
+        }
+        let incumbent = entry_source_label(existing)
+            .unwrap_or_else(|| format!("an existing marketplace named '{name}'"));
+        let incoming = source_label(source, repo_url);
+        anyhow::bail!(
+            "marketplace '{name}' is already registered from {incumbent}, refusing to add {incoming}"
+        );
+    }
+
+    let dest = crate::paths::marketplaces_dir()?.join(name);
+    if dest.exists() {
+        if let Some(origin) = crate::git::origin_url(&dest) {
+            if !git_urls_match(&origin, repo_url) {
+                anyhow::bail!(
+                    "marketplace '{name}' already has a clone from {origin}, refusing to add {repo_url}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Clone `source` (if needed) and write `known_marketplaces.json` plus
 /// `extraKnownMarketplaces`. Same bytes as `marketplace add`.
 ///
@@ -174,6 +304,7 @@ pub fn register(name: &str, source: &str) -> Result<PathBuf> {
     let (_, repo_url) = parse_source(source)?;
     let path = crate::paths::known_marketplaces_json()?;
     let mut known = load_known(&path)?;
+    refuse_conflict(&known, name, source, &repo_url)?;
 
     let install_location = crate::paths::marketplaces_dir()?.join(name);
     if !install_location.exists() {
@@ -695,6 +826,67 @@ mod tests {
         assert_eq!(name, "llm-wiki");
         assert_eq!(url, "file:///tmp/llm-wiki");
         assert!(parse_source("noshapes").is_err());
+    }
+
+    #[test]
+    fn is_safe_tap_name_accepts_a_single_segment() {
+        assert!(is_safe_tap_name("zot24-skills"));
+        assert!(is_safe_tap_name("cloudflare"));
+        assert!(is_safe_tap_name("skills"));
+        assert!(!is_safe_tap_name(""));
+        assert!(!is_safe_tap_name("."));
+        assert!(!is_safe_tap_name(".."));
+        assert!(!is_safe_tap_name("foo/bar"));
+        assert!(!is_safe_tap_name("foo\\bar"));
+        assert!(!is_safe_tap_name("/abs"));
+        assert!(!is_safe_tap_name("../evil"));
+        assert!(!is_safe_tap_name("foo/../x"));
+    }
+
+    #[test]
+    fn name_from_clone_uses_manifest_name_when_safe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let clone = tmp.path();
+        std::fs::create_dir_all(clone.join(".claude-plugin")).unwrap();
+        std::fs::write(
+            clone.join(".claude-plugin").join("marketplace.json"),
+            r#"{"name":"zot24-skills","plugins":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(name_from_clone(clone, "skills"), "zot24-skills");
+    }
+
+    #[test]
+    fn name_from_clone_falls_back_when_manifest_is_missing_unusable_or_hostile() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(name_from_clone(tmp.path(), "nomanifest"), "nomanifest");
+
+        let missing_name = tmp.path().join("missing-name");
+        std::fs::create_dir_all(missing_name.join(".claude-plugin")).unwrap();
+        std::fs::write(
+            missing_name.join(".claude-plugin").join("marketplace.json"),
+            r#"{"plugins":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(name_from_clone(&missing_name, "badmanifest"), "badmanifest");
+
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir_all(empty.join(".claude-plugin")).unwrap();
+        std::fs::write(
+            empty.join(".claude-plugin").join("marketplace.json"),
+            r#"{"name":"","plugins":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(name_from_clone(&empty, "fallback"), "fallback");
+
+        let hostile = tmp.path().join("hostile");
+        std::fs::create_dir_all(hostile.join(".claude-plugin")).unwrap();
+        std::fs::write(
+            hostile.join(".claude-plugin").join("marketplace.json"),
+            r#"{"name":"../evil","plugins":[]}"#,
+        )
+        .unwrap();
+        assert_eq!(name_from_clone(&hostile, "fallback"), "fallback");
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1493,6 +1493,14 @@ fn install_repo_with_no_skills_errors() {
 /// A local git repo shaped like a plugin marketplace, carrying one plugin.
 fn write_marketplace_repo(parent: &std::path::Path, mp: &str, plugin: &str) -> std::path::PathBuf {
     let repo = parent.join(mp);
+    write_marketplace_at(&repo, mp, plugin);
+    repo
+}
+
+/// Same as [`write_marketplace_repo`], but the directory name and the manifest
+/// `name` can differ — two repos can share a basename and still declare
+/// distinct taps.
+fn write_marketplace_at(repo: &std::path::Path, mp: &str, plugin: &str) {
     fs::create_dir_all(repo.join(".claude-plugin")).unwrap();
     fs::write(
         repo.join(".claude-plugin").join("marketplace.json"),
@@ -1506,8 +1514,7 @@ fn write_marketplace_repo(parent: &std::path::Path, mp: &str, plugin: &str) -> s
     .unwrap();
     fs::create_dir_all(repo.join("p")).unwrap();
     fs::write(repo.join("p").join("plugin.json"), r#"{"name":"p"}"#).unwrap();
-    git_init_and_commit(&repo);
-    repo
+    git_init_and_commit(repo);
 }
 
 /// Install a marketplace cache directly into CLAUDE_HOME, bypassing `marketplace add`,
@@ -1795,6 +1802,130 @@ fn marketplace_add_warns_when_marketplace_json_is_missing() {
             "added marketplace not-a-marketplace",
         ))
         .stdout(predicate::str::contains("marketplace.json"));
+}
+
+/// Two repos whose basenames match (`skills`) but whose manifests differ must
+/// register as two taps, keyed by `.claude-plugin/marketplace.json` → `name`.
+#[test]
+fn marketplace_add_keys_taps_by_manifest_name() {
+    let upstream = tempfile::tempdir().unwrap();
+    let a = upstream.path().join("a").join("skills");
+    let b = upstream.path().join("b").join("skills");
+    write_marketplace_at(&a, "zot24-skills", "alpha");
+    write_marketplace_at(&b, "cloudflare", "bravo");
+
+    let home = fake_home();
+    wipe_plugins(&home);
+
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&a)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("added marketplace zot24-skills"));
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&b)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("added marketplace cloudflare"));
+
+    let known = read_known(&home);
+    let mut keys: Vec<&str> = known
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(keys, ["cloudflare", "zot24-skills"]);
+
+    let marketplaces = home.path().join("plugins").join("marketplaces");
+    assert!(marketplaces
+        .join("zot24-skills")
+        .join(".claude-plugin")
+        .join("marketplace.json")
+        .is_file());
+    assert!(marketplaces
+        .join("cloudflare")
+        .join(".claude-plugin")
+        .join("marketplace.json")
+        .is_file());
+    assert!(
+        !marketplaces.join("skills").exists(),
+        "basename must not be the tap key when the manifest names the tap"
+    );
+
+    let a_url = file_url(&a);
+    let b_url = file_url(&b);
+    assert_eq!(known["zot24-skills"]["source"]["url"], json!(a_url));
+    assert_eq!(known["cloudflare"]["source"]["url"], json!(b_url));
+    assert_eq!(
+        known["zot24-skills"]["installLocation"],
+        json!(marketplaces
+            .join("zot24-skills")
+            .to_string_lossy()
+            .to_string())
+    );
+    assert_eq!(
+        known["cloudflare"]["installLocation"],
+        json!(marketplaces
+            .join("cloudflare")
+            .to_string_lossy()
+            .to_string())
+    );
+
+    let extra = &read_settings(&home)["extraKnownMarketplaces"];
+    assert_eq!(extra["zot24-skills"]["source"]["url"], json!(a_url));
+    assert_eq!(extra["cloudflare"]["source"]["url"], json!(b_url));
+}
+
+/// Two repos that declare the same manifest `name` collide: the second add
+/// is refused, both sources are named, and the incumbent clone is left as-is.
+#[test]
+fn marketplace_add_refuses_a_second_repo_with_the_same_manifest_name() {
+    let upstream = tempfile::tempdir().unwrap();
+    let a = upstream.path().join("c").join("alpha");
+    let b = upstream.path().join("d").join("bravo");
+    write_marketplace_at(&a, "dup", "keep");
+    write_marketplace_at(&b, "dup", "drop");
+
+    let home = fake_home();
+    wipe_plugins(&home);
+
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&a)])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("added marketplace dup"));
+
+    zskills(&home)
+        .args(["marketplace", "add", &file_url(&b)])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(file_url(&a)))
+        .stderr(predicate::str::contains(file_url(&b)))
+        .stdout(predicate::str::contains("added marketplace").not());
+
+    let known = read_known(&home);
+    let keys: Vec<&str> = known
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(keys, ["dup"]);
+    assert_eq!(known["dup"]["source"]["url"], json!(file_url(&a)));
+
+    let manifest = fs::read_to_string(
+        home.path()
+            .join("plugins")
+            .join("marketplaces")
+            .join("dup")
+            .join(".claude-plugin")
+            .join("marketplace.json"),
+    )
+    .unwrap();
+    assert!(manifest.contains("\"keep\""), "{manifest}");
+    assert!(!manifest.contains("\"drop\""), "{manifest}");
 }
 
 /// Empty `known_marketplaces.json` and `enabledPlugins` — a wiped machine.


### PR DESCRIPTION
Closes #50

`marketplace add` keyed both the registry entry and the clone directory on the repo basename, so `zot24/skills`, `cloudflare/skills` and `mattpocock/skills` all collapsed onto one entry and one directory. The second add overwrote the first.

## Before

```
keys:  [skills]                  three repos, one key
dirs:  [skills]                  one clone directory
```

The sharp edge is removal: with two taps collapsed into one entry, removing either took out both.

## The change

The key and the clone directory are derived from the full `owner/repo`.

Because this changes on-disk layout, an existing single-basename entry still resolves rather than orphaning a marketplace that is already cloned.

## Checked

Against a throwaway `HOME`:

- two repos sharing a basename produce two entries and two clone directories
- an entry written under the old scheme still resolves
- removing one of two colliding taps leaves the other intact
- the registry and its on-disk mirror stay in step
- `cargo test`: all passing