### PR TITLE
feat: one [[agent_skills]] stanza can name many skills from one source

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ source = "jakubkrehel/make-interfaces-feel-better"
 source = "owner/multi-skill-repo"
 name = "specific-skill"
 
+# Many skills from one repo: `skills` is the plural of `name`, so one stanza
+# carries one `source`. An entry declares `name` or `skills`, not both.
+[[agent_skills]]
+source = "mattpocock/skills"
+skills = ["prototype", "research", "tdd", "wayfinder"]
+
 # npm-distributed agent skills (npm install -g <pkg> + post-install)
 [[agent_skills]]
 npm = "get-shit-done-cc"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -279,6 +279,11 @@ install_cmd = "npx some-tool setup"
 # Local-only (just tracked, never refreshed from a remote)
 [[agent_skills]]
 name = "my-internal-tool"
+
+# Many skills from one source, one stanza
+[[agent_skills]]
+source = "mattpocock/skills"
+skills = ["prototype", "research", "tdd", "wayfinder"]
 ```
 
 | Field | Purpose |
@@ -289,6 +294,7 @@ name = "my-internal-tool"
 | `npm` | npm package name. `sync`/`upgrade` runs `npm install -g <pkg>`. |
 | `install_cmd` | Custom installer command — overrides the default `npm install -g`. Used for packages with their own setup CLI. |
 | `name` | Optional. For source entries, pick a single skill out of a multi-skill repo. For local-only entries, required — names the on-disk skill to track. |
+| `skills` | Optional list. The plural form of `name`: one stanza picks many skills out of the same source, marketplace or npm package, and writes `source` once instead of once per name. Every other key on the stanza (`path`, `harnesses`, `claims`, `install_cmd`) applies to every name in the list. An entry declares `name` **or** `skills`, never both — a stanza carrying both is refused when the manifest loads. An empty `skills = []` means what an absent key means: the row keeps whatever it meant before. |
 | `harnesses` | Optional list. Names which harnesses can see this Agent Skill. Empty inherits `[defaults].harnesses`, then every harness whose home exists. Set it on marketplace+path rows. The llm-wiki recipe uses `["pi", "grok"]` so Claude does not also get the OpenCode tree. |
 | `claims` | Glob patterns (e.g., `["gsd-*"]`) matched against `~/.agents/skills/`. After install, every match is tagged with this entry's source. Used for npm packages whose installer touches pre-existing directories — so the diff-after-install discovers nothing, but `claims` retroactively claims ownership. |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,12 @@ marketplace = "cloudflare"
 [[agent_skills]]
 source = "jakubkrehel/make-interfaces-feel-better"
 
+# Many skills from one repo: `skills` is the plural of `name`, so one stanza
+# carries one `source`. An entry declares `name` or `skills`, not both.
+[[agent_skills]]
+source = "mattpocock/skills"
+skills = ["prototype", "research", "tdd", "wayfinder"]
+
 # Agent Skills from an npm package (with glob ownership)
 [[agent_skills]]
 npm = "get-shit-done-cc"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -302,6 +302,9 @@ impl McpEntry {
 ///   `"npx some-tool install"`).
 /// - `name` (optional): pick a single skill out of a multi-skill repo. For
 ///   local-only entries (no `source`/`npm`/`marketplace`), `name` is required.
+/// - `skills` (optional): the plural form of `name`. One stanza names many
+///   skills out of the same origin. An entry declares `name` or `skills`,
+///   never both.
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct AgentSkillEntry {
     #[serde(default)]
@@ -315,6 +318,12 @@ pub struct AgentSkillEntry {
     pub install_cmd: Option<String>,
     #[serde(default)]
     pub name: Option<String>,
+    /// Plural form of `name`. Each entry expands to its own `AgentSkillEntry`
+    /// at load time, so all downstream code is unchanged. Empty (or absent)
+    /// means the row keeps whatever it meant before — for `source` alone,
+    /// every skill in the repo.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
     /// Relative path inside the clone. Stored with a leading `./` stripped.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
@@ -344,6 +353,15 @@ impl AgentSkillEntry {
         if origins > 1 {
             anyhow::bail!("agent skill: pick one of source, npm, marketplace");
         }
+        // `skills` is the plural of `name`. Carrying both leaves the row's
+        // meaning undefined, so refuse it — and say which stanza is wrong,
+        // because a manifest can hold 45 of them.
+        if self.name.is_some() && !self.skills.is_empty() {
+            anyhow::bail!(
+                "agent skill {}: declare `name` or `skills`, not both",
+                self.origin_label()
+            );
+        }
         if let Some(raw) = self.path.take() {
             let normalized = normalize_skill_path(&raw)?;
             if self.npm.is_some() {
@@ -355,6 +373,22 @@ impl AgentSkillEntry {
             self.path = Some(normalized);
         }
         Ok(())
+    }
+
+    /// How this stanza names its origin, for diagnostics. Whichever of
+    /// `source`, `marketplace` or `npm` the entry actually declared; a
+    /// local-only row has none of them.
+    pub fn origin_label(&self) -> String {
+        if let Some(src) = &self.source {
+            return src.clone();
+        }
+        if let Some(mp) = &self.marketplace {
+            return format!("marketplace:{mp}");
+        }
+        if let Some(pkg) = &self.npm {
+            return format!("npm:{pkg}");
+        }
+        "local".to_string()
     }
 
     /// Inventory `source` tag this row owns. `source` + `path` uses
@@ -498,7 +532,37 @@ pub fn load(path: &Path) -> Result<Manifest> {
     for entry in &mut m.agent_skills {
         entry.validate()?;
     }
+    expand_plural_agent_skills(&mut m.agent_skills);
     Ok(m)
+}
+
+/// Replace every entry carrying a non-empty `skills` array with one clone per
+/// name, so every consumer of `Manifest.agent_skills` sees the singular rows it
+/// has always seen. The clone carries `source`, `npm`, `marketplace`, `path`,
+/// `claims`, `harnesses` and `install_cmd` through unchanged — a plural stanza
+/// that lost its `harnesses` would silently lose its harness routing.
+///
+/// `skills = []` is not an expansion: the row keeps whatever it meant before,
+/// which for `source` alone is repo-wide. It must never expand to zero rows.
+/// This runs on the in-memory manifest only; `load` never writes.
+fn expand_plural_agent_skills(entries: &mut Vec<AgentSkillEntry>) {
+    if entries.iter().all(|e| e.skills.is_empty()) {
+        return;
+    }
+    let mut out: Vec<AgentSkillEntry> = Vec::with_capacity(entries.len());
+    for entry in entries.drain(..) {
+        if entry.skills.is_empty() {
+            out.push(entry);
+            continue;
+        }
+        for name in &entry.skills {
+            let mut one = entry.clone();
+            one.skills = Vec::new();
+            one.name = Some(name.clone());
+            out.push(one);
+        }
+    }
+    *entries = out;
 }
 
 /// Append an [[agent_skills]] entry to a manifest file, preserving existing
@@ -521,9 +585,12 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
         .parse()
         .with_context(|| format!("parsing manifest {} as TOML", path.display()))?;
 
-    // Check for duplicates: (source, marketplace, path, name)
+    // Check for duplicates: (source, marketplace, path, name). While walking,
+    // remember the first stanza for the same origin that already carries a
+    // `skills` array — the new name belongs inside it, not in a new table.
+    let mut widen: Option<usize> = None;
     if let Some(Item::ArrayOfTables(existing)) = doc.get("agent_skills") {
-        for t in existing.iter() {
+        for (i, t) in existing.iter().enumerate() {
             let src = t.get("source").and_then(|v| v.as_str()).map(str::to_string);
             let mp = t
                 .get("marketplace")
@@ -531,12 +598,39 @@ pub fn append_agent_skill(path: &Path, entry: &AgentSkillEntry) -> Result<bool> 
                 .map(str::to_string);
             let path = t.get("path").and_then(|v| v.as_str()).map(str::to_string);
             let name = t.get("name").and_then(|v| v.as_str()).map(str::to_string);
-            if src == entry.source
-                && mp == entry.marketplace
-                && path == entry.path
-                && name == entry.name
-            {
+            if src != entry.source || mp != entry.marketplace || path != entry.path {
+                continue;
+            }
+            if name == entry.name {
                 return Ok(false);
+            }
+            let Some(new_name) = entry.name.as_deref() else {
+                continue;
+            };
+            if let Some(arr) = t.get("skills").and_then(|v| v.as_array()) {
+                if arr.iter().any(|v| v.as_str() == Some(new_name)) {
+                    return Ok(false);
+                }
+                if widen.is_none() {
+                    widen = Some(i);
+                }
+            }
+        }
+    }
+
+    // Widen the array in place. toml_edit keeps the surrounding comments and
+    // the array's own formatting; nothing is reflowed.
+    if let (Some(i), Some(new_name)) = (widen, entry.name.as_deref()) {
+        if let Some(Item::ArrayOfTables(aot)) = doc.get_mut("agent_skills") {
+            if let Some(arr) = aot
+                .get_mut(i)
+                .and_then(|t| t.get_mut("skills"))
+                .and_then(|v| v.as_array_mut())
+            {
+                arr.push(new_name);
+                std::fs::write(path, doc.to_string())
+                    .with_context(|| format!("writing manifest {}", path.display()))?;
+                return Ok(true);
             }
         }
     }
@@ -1008,7 +1102,15 @@ pub fn drop_mcp(path: &Path, name: &str, scope: &str) -> Result<bool> {
     Ok(true)
 }
 
-/// Drop a named `[[agent_skills]]` row. Source-only rows (no `name`) are left alone.
+/// Drop a named `[[agent_skills]]` row, or take one name out of a stanza's
+/// `skills` array. Source-only rows (no `name`, no `skills`) are left alone.
+///
+/// A plural stanza keeps its plural form: the name is removed from the array
+/// and nothing else changes. A one-name array is not collapsed back onto
+/// `name = "..."` — the user chose the plural form, and a stanza carrying both
+/// keys is the shape `AgentSkillEntry::validate` refuses to load. The whole
+/// stanza goes only when its array becomes empty, because `skills = []` reads
+/// as repo-wide.
 pub fn drop_named_agent_skill(path: &Path, name: &str) -> Result<bool> {
     use toml_edit::{DocumentMut, Item};
 
@@ -1031,10 +1133,54 @@ pub fn drop_named_agent_skill(path: &Path, name: &str) -> Result<bool> {
             break;
         }
     }
-    let Some(i) = idx else {
+    if let Some(i) = idx {
+        aot.remove(i);
+        std::fs::write(path, doc.to_string())
+            .with_context(|| format!("writing manifest {}", path.display()))?;
+        return Ok(true);
+    }
+
+    let mut hit = None;
+    for (i, t) in aot.iter().enumerate() {
+        let Some(arr) = t.get("skills").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        if let Some(j) = arr.iter().position(|v| v.as_str() == Some(name)) {
+            hit = Some((i, j));
+            break;
+        }
+    }
+    let Some((i, j)) = hit else {
         return Ok(false);
     };
-    aot.remove(i);
+    let emptied = {
+        let Some(arr) = aot
+            .get_mut(i)
+            .and_then(|t| t.get_mut("skills"))
+            .and_then(|v| v.as_array_mut())
+        else {
+            return Ok(false);
+        };
+        let dropped = arr.remove(j);
+        // Removing the head leaves the next element wearing the separator that
+        // used to sit between them (`[ "bravo"]`). Hand it the head's decor so
+        // the array reads as it did before, without reflowing the rest.
+        if j == 0 {
+            if let Some(first) = arr.get_mut(0) {
+                let prefix = dropped
+                    .decor()
+                    .prefix()
+                    .and_then(|r| r.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                first.decor_mut().set_prefix(prefix);
+            }
+        }
+        arr.is_empty()
+    };
+    if emptied {
+        aot.remove(i);
+    }
     std::fs::write(path, doc.to_string())
         .with_context(|| format!("writing manifest {}", path.display()))?;
     Ok(true)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5602,3 +5602,183 @@ fn skill_install_path_large_collection_next_steps_repeat_path() {
         "a large --path collection must install nothing"
     );
 }
+
+// ---------------------------------------------------------------------------
+// `[[agent_skills]]` plural form (#54): one stanza, one `source`, many names.
+//
+// Each of these reads what the tool *wrote or planned*, never the exit status
+// alone: the plan rows for the expansion, the origin inside the refusal, and
+// for the two writers the `skills =` line of the stanza that came back.
+// ---------------------------------------------------------------------------
+
+/// The `[[agent_skills]]` stanza of a written manifest, as raw text.
+///
+/// `fake_home` grows `[[skills]]` and `[[marketplaces]]` rows that legitimately
+/// carry `name =`, so a "no `name =`" assertion has to be scoped to this block.
+fn agent_skills_stanza(raw: &str) -> String {
+    let start = raw
+        .find("[[agent_skills]]")
+        .unwrap_or_else(|| panic!("manifest has no [[agent_skills]] stanza: {raw}"));
+    let rest = &raw[start + "[[agent_skills]]".len()..];
+    let end = rest.find("\n[").map(|i| i + 1).unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+#[test]
+fn agent_skills_plural_skills_array_expands_to_one_row_per_name() {
+    let home = fake_home();
+    write_manifest(
+        &home,
+        "[[agent_skills]]\nsource = \"acme/skills\"\nskills = [\"alpha\", \"bravo\", \"charlie\"]\n",
+    );
+
+    let out = zskills(&home)
+        .args(["sync", "--dry-run"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let plan = String::from_utf8(out).unwrap();
+
+    for name in ["alpha", "bravo", "charlie"] {
+        assert!(
+            plan.contains(&format!("install agent   {name}")),
+            "every name in the array must plan its own install; {name} is missing: {plan}"
+        );
+    }
+    assert!(
+        !plan.contains("all skills in repo"),
+        "a stanza that names skills is a selection, not a repo-wide install: {plan}"
+    );
+}
+
+#[test]
+fn agent_skills_name_and_skills_in_one_stanza_is_rejected() {
+    let home = fake_home();
+    write_manifest(
+        &home,
+        "[[agent_skills]]\nsource = \"acme/skills\"\nname = \"alpha\"\nskills = [\"bravo\"]\n",
+    );
+
+    let assert = zskills(&home)
+        .args(["sync", "--dry-run"])
+        .assert()
+        .failure();
+    let out = assert.get_output();
+    let err = String::from_utf8(out.stderr.clone()).unwrap();
+    let plan = String::from_utf8(out.stdout.clone()).unwrap();
+
+    assert!(
+        err.contains("acme/skills"),
+        "the refusal must name the origin of the stanza it read, so the user can \
+         find it among 45 of them: {err}"
+    );
+    assert!(
+        !plan.contains("Plan"),
+        "a manifest that will not load must print no plan: {plan}"
+    );
+
+    // The same defect from a second origin must name *that* origin, so the
+    // message is computed from the entry rather than spelled in as a constant.
+    let other = fake_home();
+    write_manifest(
+        &other,
+        "[[agent_skills]]\nsource = \"beta/tools\"\nname = \"gamma\"\nskills = [\"delta\"]\n",
+    );
+    let assert = zskills(&other)
+        .args(["sync", "--dry-run"])
+        .assert()
+        .failure();
+    let err = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        err.contains("beta/tools") && !err.contains("acme/skills"),
+        "the refusal must name the origin it read, not another one: {err}"
+    );
+}
+
+#[test]
+fn adopt_pushes_a_new_name_into_an_existing_skills_array() {
+    let home = fake_home();
+    write_disk_skill(&home, "bravo");
+    write_disk_skill(&home, "delta");
+    fs::write(
+        home.path().join("skills/.zskills.json"),
+        json!({
+            "version": 1,
+            "agent_skills": {
+                "bravo": { "source": "acme/skills", "installed_at": "@0", "head_sha": "abc" },
+                "delta": { "source": "acme/skills", "installed_at": "@0", "head_sha": "abc" }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_manifest(
+        &home,
+        "[[agent_skills]]\nsource = \"acme/skills\"\nskills = [\"bravo\"]\n",
+    );
+
+    zskills(&home).args(["sync", "--adopt"]).assert().success();
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    assert_eq!(
+        raw.matches("[[agent_skills]]").count(),
+        1,
+        "adopt must widen the array that is already there, not grow a second \
+         stanza for the same source: {raw}"
+    );
+    let stanza = agent_skills_stanza(&raw);
+    assert!(
+        stanza.contains("skills = [\"bravo\", \"delta\"]"),
+        "the orphan belongs inside the existing array: {raw}"
+    );
+    assert!(
+        !stanza.contains("name ="),
+        "adopt must not set `name` beside `skills` — that stanza will not load: {raw}"
+    );
+}
+
+#[test]
+fn removing_one_name_keeps_the_rest_of_the_skills_array() {
+    let home = fake_home();
+    write_disk_skill(&home, "alpha");
+    write_disk_skill(&home, "bravo");
+    fs::write(
+        home.path().join("skills/.zskills.json"),
+        json!({
+            "version": 1,
+            "agent_skills": {
+                "alpha": { "source": "acme/skills", "installed_at": "@0", "head_sha": "abc" },
+                "bravo": { "source": "acme/skills", "installed_at": "@0", "head_sha": "abc" }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    write_manifest(
+        &home,
+        "[[agent_skills]]\nsource = \"acme/skills\"\nskills = [\"alpha\", \"bravo\"]\n",
+    );
+
+    zskills(&home)
+        .args(["skill", "remove", "alpha"])
+        .assert()
+        .success();
+
+    let raw = fs::read_to_string(home.path().join("config/zskills/skills.toml")).unwrap();
+    let stanza = agent_skills_stanza(&raw);
+    assert!(
+        stanza.contains("skills = [\"bravo\"]"),
+        "remove takes one name out of the array and leaves the rest: {raw}"
+    );
+    assert!(
+        !stanza.contains("alpha"),
+        "the removed name must be gone from the array: {raw}"
+    );
+    assert!(
+        !stanza.contains("name ="),
+        "a one-name array must not collapse onto `name` — the user chose the \
+         plural form, and `name` beside `skills` will not load: {raw}"
+    );
+}


### PR DESCRIPTION
Closes #54.

A source that ships several Agent Skills costs one `[[agent_skills]]` stanza per name, and every
stanza repeats the same `source`. A repo with three skills means three stanzas and the source
written three times.

Before, in `skills.toml`:

```toml
[[agent_skills]]
source = "acme/skills"
name = "alpha"

[[agent_skills]]
source = "acme/skills"
name = "bravo"

[[agent_skills]]
source = "acme/skills"
name = "charlie"
```

After:

```toml
[[agent_skills]]
source = "acme/skills"
skills = ["alpha", "bravo", "charlie"]
```

## What changed

`src/manifest.rs` accepts a `skills` array alongside the existing `name`, and expands it to one
planned row per name at load. A stanza carrying both keys is rejected, and the error names the
source it came from so you can find it in a long manifest.

Both writers keep the array intact. `skill remove` takes one name out and leaves the rest;
removing the last name deletes that stanza and leaves an unrelated stanza beside it untouched.
`sync --adopt` pushes a new name into the existing array rather than appending a second stanza
for the same source.

`skills = []` means what an absent key means: the row stays repo-wide. It is not silently dropped.

## Checked

160 tests pass. Four new ones pin the behaviour and each passes on its own:

```
agent_skills_plural_skills_array_expands_to_one_row_per_name
agent_skills_name_and_skills_in_one_stanza_is_rejected
adopt_pushes_a_new_name_into_an_existing_skills_array
removing_one_name_keeps_the_rest_of_the_skills_array
```

Exercised beyond the tests, each in a throwaway `HOME` and `XDG_CONFIG_HOME` so no real
configuration was touched:

- a plural stanza plans one install per name, and a stanza declaring only `source` still plans
  exactly one repo-wide install
- `skill remove bravo` then `sync --adopt` on the same manifest, re-read after each step, so the
  array is observed changing rather than only its final state
- a dry run over a plural manifest leaves `skills.toml` byte-identical to the seed

Docs updated in `README.md`, `docs/commands.md` and `docs/index.md`.

Not addressed here: which harnesses receive a plural stanza's skills is unchanged by this PR.